### PR TITLE
small bug: checkboxInputGroup sets html attribute "selected" in stead of "checked"

### DIFF
--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -365,7 +365,7 @@ checkboxGroupInput <- function(inputId, label, choices, selected = NULL) {
                            value = choices[[choiceName]])
     
     if (choiceName %in% selected)
-      checkbox$attribs$selected <- 'selected'
+      checkbox$attribs$checked <- 'checked'
     
     checkboxes[[length(checkboxes)+1]] <- checkbox
     checkboxes[[length(checkboxes)+1]] <- choiceName


### PR DESCRIPTION
Hi Joe,

Thanks for your great work and code,

checkboxInputGroup sets incorrectly the html attribute "selected" in stead of "checked".

Best,

Edwin de Jonge