### PR TITLE
Method of getting variables without invalidating context

### DIFF
--- a/R/reactives.R
+++ b/R/reactives.R
@@ -134,6 +134,11 @@ Values <- setRefClass(
   x[['impl']]$get(name)
 }
 
+#' @S3method ^ reactvaluesreader
+`^.reactvaluesreader` <- function(x, name) {
+  x[['impl']]$get_inert(name)
+}
+
 #' @S3method names reactvaluesreader
 names.reactvaluesreader <- function(x) {
   x[['impl']]$names()


### PR DESCRIPTION
This is a first stab at a method for retrieving values without invalidating the context, and not meant to be merged. I've defined the `^` operator for retrieving values this way.

Example usage:

``` R
# Note that you need the latest github version of devtools to use load_all()
# with shiny.
library(devtools)
load_all()

# Create some values
v <- Values$new()
v$set('x', 1)
v$set('y', 10)
input <- .createValuesReader(v)

# Use Observer$new() instead of observe(), so that it can be stored and inspected
o <- Observer$new(function() {
  print(paste("x is", input$x))
  print(paste("y is", input^"y"))
})

flushReact()
# [1] "x is 1"
# [1] "y is 10"

v$set('x', 2)
flushReact()
# [1] "x is 2"
# [1] "y is 10"

v$set('y', 11)
flushReact()    # no output
```

Some notes:
- The `^` operator isn't really greata good one to use for this. I wanted to use `@`, but it seems that I'm not able to overload it. It would be nice to use an operator where the right-side token doesn't have to be quoted, but I don't know of any besides `$` and `@` -- and `$` is already taken.
- Assignment still has to be done with `$set`.

Any comments on this would be appreciated, since I'm still getting up to speed with this stuff.