### PR TITLE
Fix reactivity for empty checkbox groups. Fixes #58

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -730,8 +730,12 @@ startApp <- function(port=8101L) {
             stop('Unknown type specified for ', name)
           )
         }
-        else if (is.list(val) && is.null(names(val)))
-          msg$data[[name]] <- unlist(val, recursive=FALSE)
+        else if (is.list(val) && is.null(names(val))) {
+          # The single-bracket indexing and use of list() on the right side is
+          # a workaround for when unlist(val) is NULL; double bracket indexing
+          # would delete the item instead of assigning it NULL.
+          msg$data[name] <- list(unlist(val, recursive=FALSE))
+        }
       }
     }
     


### PR DESCRIPTION
This fixes #58.

It was a choice between short, awkward construction plus long comment, or longer, clearer logic plus no comment. I went with short and awkward:

``` R
else if (is.list(val) && is.null(names(val))) {
  # The single-bracket indexing and use of list() on the right side is
  # a workaround for when unlist(val) is NULL; double bracket indexing
  # would delete the item instead of assigning it NULL.
  msg$data[name] <- list(unlist(val, recursive=FALSE))
}
```

This was the alternative:

``` R
else if (is.list(val) && is.null(names(val))) {
  if (length(val) == 0)
    msg$data[name] <- list(NULL)
  else
    msg$data[[name]] <- unlist(val, recursive=FALSE)
}
```