### PR TITLE
Flush all shinyapp instances

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -775,7 +775,10 @@ startApp <- function(port=8101L) {
       shinyapp$dispatch(msg)
     )
     flushReact()
-    shinyapp$flushOutput()
+    lapply(apps$values(), function(shinyapp) {
+      shinyapp$flushOutput()
+      NULL
+    })
   }, ws_env)
   
   message('\n', 'Listening on port ', port)


### PR DESCRIPTION
Allows reactivity to affect all app instances at once.
(It already does but the outputs don't currently update)