### PR TITLE
Use correct default label for contexts. Fixes #91

### DIFF
--- a/R/react.R
+++ b/R/react.R
@@ -8,7 +8,7 @@ Context <- setRefClass(
     .flushCallbacks = 'list'
   ),
   methods = list(
-    initialize = function(label=NULL) {
+    initialize = function(label='') {
       id <<- .getReactiveEnvironment()$nextId()
       .invalidated <<- FALSE
       .invalidateCallbacks <<- list()

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -229,7 +229,7 @@ ShinyApp <- setRefClass(
           return(httpResponse(404, 'text/html', '<h1>Not Found</h1>'))
         
         filename <- ifelse(is.function(download$filename),
-                           Context$new()$run(download$filename),
+                           Context$new('[download]')$run(download$filename),
                            download$filename)
 
         # If the URL does not contain the filename, and the desired filename
@@ -246,7 +246,7 @@ ShinyApp <- setRefClass(
         
         tmpdata <- tempfile()
         on.exit(unlink(tmpdata))
-        result <- try(Context$new()$run(function() { download$func(tmpdata) }))
+        result <- try(Context$new('[download]')$run(function() { download$func(tmpdata) }))
         if (is(result, 'try-error')) {
           return(httpResponse(500, 'text/plain', 
                               attr(result, 'condition')$message))


### PR DESCRIPTION
NULL apparently is not a valid value for a field in a reference class. I set the default to `''`, although `NA_character_` would also solve the problem.

This also sets the label for downloads to `[download]`. @jcheng5, do you think these labels are appropriate?