### PR TITLE
Separate private and public fields for input and clientData

### DIFF
--- a/R/reactives.R
+++ b/R/reactives.R
@@ -166,6 +166,9 @@ reactiveValues <- function(...) {
   values
 }
 
+# Register the S3 class so that it can be used for a field in a Reference Class
+setOldClass("reactivevalues")
+
 # Create a reactivevalues object
 #
 # @param values A ReactiveValues object

--- a/R/shinywrappers.R
+++ b/R/shinywrappers.R
@@ -66,15 +66,15 @@ renderPlot <- function(expr, width='auto', height='auto', res=72, ...,
     # height were explicitly specified).
     prefix <- 'output_'
     if (width == 'auto')
-      width <- shinysession$clientData$get(paste(prefix, name, '_width', sep=''));
+      width <- shinysession$clientData[[paste(prefix, name, '_width', sep='')]];
     if (height == 'auto')
-      height <- shinysession$clientData$get(paste(prefix, name, '_height', sep=''));
+      height <- shinysession$clientData[[paste(prefix, name, '_height', sep='')]];
     
     if (width <= 0 || height <= 0)
       return(NULL)
 
     # Resolution multiplier
-    pixelratio <- shinysession$clientData$get("pixelratio")
+    pixelratio <- shinysession$clientData$pixelratio
     if (is.null(pixelratio))
       pixelratio <- 1
 


### PR DESCRIPTION
This makes it a bit clearer what's the ReactiveValues ref class, and what's the S3 wrapper class. App developers should use the S3 wrapper object.