### PR TITLE
Add support for sending arbitrary messages to client

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -54,10 +54,10 @@ ShinySession <- setRefClass(
       .outputs <<- list()
       .outputOptions <<- list()
 
-      session <<- list(clientData       = clientData,
-                       sendMessage      = .self$.sendMessage,
-                       sendInputMessage = .self$.sendInputMessage,
-                       sendJavascript   = .self$.sendJavascript)
+      session <<- list(clientData        = clientData,
+                       sendCustomMessage = .self$.sendCustomMessage,
+                       sendInputMessage  = .self$.sendInputMessage,
+                       sendJavascript    = .self$.sendJavascript)
     },
     close = function() {
       closed <<- TRUE
@@ -191,10 +191,10 @@ ShinySession <- setRefClass(
         return()
       .write(toJSON(list(response=list(tag=requestMsg$tag, error=error))))
     },
-    .sendMessage = function(type, message) {
+    .sendCustomMessage = function(type, message) {
       data <- list()
       data[[type]] <- message
-      .write(toJSON(data))
+      .write(toJSON(list(custom=data)))
     },
     .sendInputMessage = function(inputId, message) {
       data <- list(id = inputId, message = message)


### PR DESCRIPTION
This does two things:
- Adds support for sending arbitrary JSON messages to the client.
- Adds support for registering Javascript callbacks on the client, to handle the JSON messages.

This will make it easier for app/package authors to add their own communication channels from the server to the client.

Example app at: https://github.com/wch/testapp/tree/master/message-handler-inline

```
devtools::install_github('shiny', 'wch', 'sendmessage')
library(shiny)
runGitHub('testapp', 'wch', subdir='message-handler-inline')
```

Notes:
- I removed `custom` message since it wasn't being used, and this does the same thing.
- The order in which the messages are dispatched was previously defined by the order of the `if` statements, but now the order is not specified, and is browser-dependent: http://stackoverflow.com/a/280861/412655 . If order is important, it could be implemented with an array.
  - The order of `values` and `errors` is slightly different; the code for them was previously interleaved, but now it's not. I don't know if the old way was intentional or not.
- I _think_ that putting it in `exports.registerMessageHandler` is the right place, but I'm not 100% sure.

**This pull request is based off of the set-input branch, and so most of the commits listed here are for that branch. This branch starts from the commit titled `Add general method for message handlers`**