### PR TITLE
Add support for sending arbitrary messages to client

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -54,10 +54,10 @@ ShinySession <- setRefClass(
       .outputs <<- list()
       .outputOptions <<- list()
 
-      session <<- list(clientData       = clientData,
-                       sendMessage      = .self$.sendMessage,
-                       sendInputMessage = .self$.sendInputMessage,
-                       sendJavascript   = .self$.sendJavascript)
+      session <<- list(clientData        = clientData,
+                       sendCustomMessage = .self$.sendCustomMessage,
+                       sendInputMessage  = .self$.sendInputMessage,
+                       sendJavascript    = .self$.sendJavascript)
     },
     close = function() {
       closed <<- TRUE
@@ -191,10 +191,10 @@ ShinySession <- setRefClass(
         return()
       .write(toJSON(list(response=list(tag=requestMsg$tag, error=error))))
     },
-    .sendMessage = function(type, message) {
+    .sendCustomMessage = function(type, message) {
       data <- list()
       data[[type]] <- message
-      .write(toJSON(data))
+      .write(toJSON(list(custom=data)))
     },
     .sendInputMessage = function(inputId, message) {
       data <- list(id = inputId, message = message)


### PR DESCRIPTION
This pull request replaces #146. It does two things:
- Adds support for sending arbitrary JSON messages to the client.
- Adds support for registering Javascript callbacks on the client, to handle the JSON messages.

This will make it easier for app/package authors to add their own communication channels from the server to the client.

Example app at: https://github.com/wch/testapp/tree/master/message-handler-inline

```
devtools::install_github('shiny', 'wch', 'sendmessage')
library(shiny)
runGitHub('testapp', 'wch', subdir='message-handler-inline')
```

Another example, with a separate JS file to load the message handler, instead of inline Javascript:

https://github.com/wch/testapp/tree/master/message-handler-jsfile

```
runGitHub('testapp', 'wch', subdir='message-handler-jsfile')
```

Notes:
- When app authors send messages, they are wrapped into an object named `custom`.
- The order in which callbacks are called is the same as the order that they were added.
- The order of `values` and `errors` is slightly different; the code for them was previously interleaved, but now it's not. I don't know if the old way was intentional or not.