### PR TITLE
invalidateLater: don't invalidate when session closed

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -59,7 +59,8 @@ ShinySession <- setRefClass(
                        sendCustomMessage = .self$.sendCustomMessage,
                        sendInputMessage  = .self$.sendInputMessage,
                        sendJavascript    = .self$.sendJavascript,
-                       onSessionEnded   = .self$onSessionEnded)
+                       onSessionEnded    = .self$onSessionEnded,
+                       isClosed          = .self$isClosed)
     },
     onSessionEnded = function(callback) {
       "Registers the given callback to be invoked when the session is closed
@@ -80,6 +81,9 @@ ShinySession <- setRefClass(
           e$call
         ))
       })
+    },
+    isClosed = function() {
+      return(closed)
     },
     defineOutput = function(name, func, label) {
       "Binds an output generating function to this name. The function can either

--- a/man/invalidateLater.Rd
+++ b/man/invalidateLater.Rd
@@ -2,14 +2,36 @@
 \alias{invalidateLater}
 \title{Scheduled Invalidation}
 \usage{
-  invalidateLater(millis)
+  invalidateLater(millis, session)
 }
 \arguments{
   \item{millis}{Approximate milliseconds to wait before
   invalidating the current reactive context.}
+
+  \item{session}{A session object. This is needed to cancel
+  any scheduled invalidations after a user has ended the
+  session. If \code{NULL}, then this invalidation will not
+  be tied to any session, and so it will still occur.}
 }
 \description{
   Schedules the current reactive context to be invalidated
   in the given number of milliseconds.
+}
+\examples{
+\dontrun{
+shinyServer(function(input, output, session) {
+
+  observe({
+    # Re-execute this reactive expression after 1000 milliseconds
+    invalidateLater(1000, session)
+
+    # Do something each time this is invalidated.
+    # The isolate() makes this observer _not_ get invalidated and re-executed
+    # when input$n changes.
+    print(paste("The value of input$n is", isolate(input$n)))
+  })
+
+})
+}
 }
 


### PR DESCRIPTION
I also looked at doing this by using `session$onSessionEnded()`. Because `invalidateLater()` can be called many, many times in a session, if it registered a cleanup callback with `session$onSessionEnded()` each time it's called, it would also have to clear the previous cleanup callback each time. I think this approach would need a function like `ShinySession$removeOnSessionEnded(id)`, and `TimerCallbacks$unschedule(id)`.

The approach I used here is this: when the `invalidateLater()` callback is called, it checks whether the session is closed.

Example usage:

```
shinyServer(function(input, output, session) {

  observe({
    # Re-execute this reactive expression after 1000 milliseconds
    invalidateLater(1000, session)

    # Do something each time this is invalidated.
    # The isolate() makes this observer _not_ get invalidated and re-executed
    # when input$n changes.
    print(paste("The value of input$n is", isolate(input$n)))
  })

})
```