### PR TITLE
Add option for not using Cairo

### DIFF
--- a/R/imageutils.R
+++ b/R/imageutils.R
@@ -11,6 +11,10 @@
 #' output. Notably, plain \code{png} output on Linux and Windows may not
 #' antialias some point shapes, resulting in poor quality output.
 #'
+#' In some cases, \code{Cairo()} provides output that looks worse than
+#' \code{png()}. To disable Cairo output for an app, use
+#' \code{options(shiny.usecairo=FALSE)}.
+#'
 #' @param func A function that generates a plot.
 #' @param filename The name of the output file. Defaults to a temp file with
 #'   extension \code{.png}.
@@ -30,9 +34,8 @@ plotPNG <- function(func, filename=tempfile(fileext='.png'),
   # Finally, if neither quartz nor Cairo, use png().
   if (capabilities("aqua")) {
     pngfun <- png
-  } else if (nchar(system.file(package = "Cairo"))) {
-    require(Cairo)
-
+  } else if (getOption('shiny.usecairo', TRUE) &&
+             nchar(system.file(package = "Cairo"))) {
     # Workaround for issue #140: Cairo ignores res and dpi settings. Need to
     # use regular png function.
     if (res == 72) {

--- a/R/shinywrappers.R
+++ b/R/shinywrappers.R
@@ -11,6 +11,9 @@ suppressPackageStartupMessages({
 #' The corresponding HTML output tag should be \code{div} or \code{img} and have
 #' the CSS class name \code{shiny-plot-output}.
 #'
+#' @seealso For more details on how the plots are generated, and how to control
+#'   the output, see \code{\link{plotPNG}}.
+#'
 #' @param expr An expression that generates a plot.
 #' @param width The width of the rendered plot, in pixels; or \code{'auto'} to 
 #'   use the \code{offsetWidth} of the HTML element that is bound to this plot. 
@@ -108,6 +111,9 @@ renderPlot <- function(expr, width='auto', height='auto', res=72, ...,
 #'
 #' The corresponding HTML output tag should be \code{div} or \code{img} and have
 #' the CSS class name \code{shiny-image-output}.
+#'
+#' @seealso For more details on how the images are generated, and how to control
+#'   the output, see \code{\link{plotPNG}}.
 #'
 #' @param expr An expression that returns a list.
 #' @param env The environment in which to evaluate \code{expr}.

--- a/man/observe.Rd
+++ b/man/observe.Rd
@@ -56,16 +56,17 @@
   it is invoked.  } }
 }
 \description{
-  Creates an observer from the given expression An observer
-  is like a reactive expression in that it can read
-  reactive values and call reactive expressions, and will
-  automatically re-execute when those dependencies change.
-  But unlike reactive expression, it doesn't yield a result
-  and can't be used as an input to other reactive
-  expressions. Thus, observers are only useful for their
-  side effects (for example, performing I/O).
+  Creates an observer from the given expression.
 }
 \details{
+  An observer is like a reactive expression in that it can
+  read reactive values and call reactive expressions, and
+  will automatically re-execute when those dependencies
+  change. But unlike reactive expressions, it doesn't yield
+  a result and can't be used as an input to other reactive
+  expressions. Thus, observers are only useful for their
+  side effects (for example, performing I/O).
+
   Another contrast between reactive expressions and
   observers is their execution strategy. Reactive
   expressions use lazy evaluation; that is, when their

--- a/man/plotPNG.Rd
+++ b/man/plotPNG.Rd
@@ -39,5 +39,9 @@
   of output. Notably, plain \code{png} output on Linux and
   Windows may not antialias some point shapes, resulting in
   poor quality output.
+
+  In some cases, \code{Cairo()} provides output that looks
+  worse than \code{png()}. To disable Cairo output for an
+  app, use \code{options(shiny.usecairo=FALSE)}.
 }
 

--- a/man/renderImage.Rd
+++ b/man/renderImage.Rd
@@ -99,4 +99,8 @@ shinyServer(function(input, output, clientData) {
 
 }
 }
+\seealso{
+  For more details on how the images are generated, and how
+  to control the output, see \code{\link{plotPNG}}.
+}
 

--- a/man/renderPlot.Rd
+++ b/man/renderPlot.Rd
@@ -51,4 +51,8 @@
   \code{img} and have the CSS class name
   \code{shiny-plot-output}.
 }
+\seealso{
+  For more details on how the plots are generated, and how
+  to control the output, see \code{\link{plotPNG}}.
+}
 


### PR DESCRIPTION
This adds an option to _not_ use Cairo for generating PNGs, even when it's installed. Even though Cairo output usually looks better, it's come up on the mailing list a couple times that Cairo can result in worse-looking output.