### PR TITLE
Restrict the number of observations to a valid, positive number.

### DIFF
--- a/inst/examples/01_hello/ui.R
+++ b/inst/examples/01_hello/ui.R
@@ -10,7 +10,7 @@ shinyUI(pageWithSidebar(
   sidebarPanel(
     sliderInput("obs", 
                 "Number of observations:", 
-                min = 0, 
+                min = 1, 
                 max = 1000, 
                 value = 500)
   ),


### PR DESCRIPTION
Was throwing an `invalid  number of breaks` error when the slider went all the way left, leading to an attempt to create a histogram off `rnorm(0)`.