### PR TITLE
Add compatibility wrapper for getComputedStyle in IE8

### DIFF
--- a/inst/www/shared/shiny.js
+++ b/inst/www/shared/shiny.js
@@ -13,6 +13,17 @@
     return Math.floor(0x100000000 + (Math.random() * 0xF00000000)).toString(16);
   }
 
+  // A wrapper for getComputedStyle that is compatible with older browsers.
+  // This is significantly faster than jQuery's .css() function.
+  function getStyle(el, styleProp) {
+    if (el.currentStyle)
+      var x = el.currentStyle[styleProp];
+    else if (window.getComputedStyle)
+      var x = document.defaultView.getComputedStyle(el, null)
+                .getPropertyValue(styleProp);
+    return x;
+  }
+
   // Convert a number to a string with leading zeros
   function padZeros(n, digits) {
     var str = n.toString();
@@ -2609,7 +2620,7 @@
       // non-zero, then we know that no ancestor has display:none.
       if (obj === null || obj.offsetWidth !== 0 || obj.offsetHeight !== 0) {
         return false;
-      } else if (getComputedStyle(obj, null).display === 'none') {
+      } else if (getStyle(obj, 'display') === 'none') {
         return true;
       } else {
         return(isHidden(obj.parentNode));


### PR DESCRIPTION
[Update: this fixes the issue for IE8, but IE9 should have been OK to begin with]

Fixes #196.

The wrapper function is still significantly faster than using jQuery's `.css()` function, which may be important since this is called on every shiny element to see whether it is hidden:
  http://jsperf.com/jquery-css-vs-getcomputedstyle/2