### PR TITLE
Add reactive timing logging, if the necessary variables are available.

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -1173,13 +1173,17 @@ startApp <- function(httpHandlers, serverFuncSource, port, workerId) {
         shinysession$manageHiddenOutputs()
         if (exists(".shiny__stdout") && exists("HTTP_GUID", env=ws$request)){
           # safe to assume we're in shiny-server, eNter a flushReact
-          writeLines(paste("_n_flushReact ", get("HTTP_GUID", env=ws$request), sep=""), con=.shiny__stdout)
+          writeLines(paste("_n_flushReact ", get("HTTP_GUID", env=ws$request), 
+                           " @ ", sprintf("%.3f", as.numeric(Sys.time())), 
+                           sep=""), con=.shiny__stdout)
           flush(.shiny__stdout)
         }
         flushReact()
         if (exists(".shiny__stdout") && exists("HTTP_GUID", env=ws$request)){
           # safe to assume we're in shiny-server, eXit a flushReact
-          writeLines(paste("_x_flushReact ", get("HTTP_GUID", env=ws$request), sep=""), con=.shiny__stdout)
+          writeLines(paste("_x_flushReact ", get("HTTP_GUID", env=ws$request), 
+                           " @ ", sprintf("%.3f", as.numeric(Sys.time())),
+                           sep=""), con=.shiny__stdout)
           flush(.shiny__stdout)
         }
         lapply(appsByToken$values(), function(shinysession) {


### PR DESCRIPTION
Prints a statement to a named connection upon entering and exiting every flushReact() step, if that connection exists.