### PR TITLE
Cleanups to reactive logging code for R CMD check

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -1171,20 +1171,27 @@ startApp <- function(httpHandlers, serverFuncSource, port, workerId) {
           shinysession$dispatch(msg)
         )
         shinysession$manageHiddenOutputs()
-        if (exists(".shiny__stdout") && exists("HTTP_GUID", env=ws$request)){
-          # safe to assume we're in shiny-server, eNter a flushReact
-          writeLines(paste("_n_flushReact ", get("HTTP_GUID", env=ws$request), 
+
+        if (exists(".shiny__stdout", globalenv()) &&
+            exists("HTTP_GUID", ws$request)) {
+          # safe to assume we're in shiny-server
+          shiny_stdout <- get(".shiny__stdout", globalenv())
+
+          # eNter a flushReact
+          writeLines(paste("_n_flushReact ", get("HTTP_GUID", ws$request),
                            " @ ", sprintf("%.3f", as.numeric(Sys.time())), 
-                           sep=""), con=.shiny__stdout)
-          flush(.shiny__stdout)
-        }
-        flushReact()
-        if (exists(".shiny__stdout") && exists("HTTP_GUID", env=ws$request)){
-          # safe to assume we're in shiny-server, eXit a flushReact
-          writeLines(paste("_x_flushReact ", get("HTTP_GUID", env=ws$request), 
+                           sep=""), con=shiny_stdout)
+          flush(shiny_stdout)
+
+          flushReact()
+
+          # eXit a flushReact
+          writeLines(paste("_x_flushReact ", get("HTTP_GUID", ws$request),
                            " @ ", sprintf("%.3f", as.numeric(Sys.time())),
-                           sep=""), con=.shiny__stdout)
-          flush(.shiny__stdout)
+                           sep=""), con=shiny_stdout)
+          flush(shiny_stdout)
+        } else {
+          flushReact()
         }
         lapply(appsByToken$values(), function(shinysession) {
           shinysession$flushOutput()


### PR DESCRIPTION
These are some fixes to make R CMD check happy. @trestletech, could you review and test it? (I'm not sure how to test this code).

Changes: 
- Fix 'env' partial argument match for get().
- Fix access of unbound global variable `.shiny__stdout`.
- Restructure if statement so test is only done once. This wasn't necessary for R CMD check, but given the other changes (setting the `shiny_stdout` var), this reduced code duplication.