### PR TITLE
Scroll page to top when prev/next clicked.

### DIFF
--- a/tutorial/index.html
+++ b/tutorial/index.html
@@ -457,11 +457,13 @@ manageNextPrev();
 $('a#next').click(function(e) {
    e.preventDefault();
    location.href = $('.nav li.active').nextAll('li:not(.nav-header)').first().find('a').attr('href');
+   $('html,body').scrollTop(0);
    manageNextPrev();
 });
 $('a#previous').click(function(e) {
    e.preventDefault();
    location.href = $('.nav li.active').prevAll('li:not(.nav-header)').first().find('a').attr('href');
+   $('html,body').scrollTop(0);
    manageNextPrev();
 });
 


### PR DESCRIPTION
Currently, clicking on the `prev` or `next` button to advance to the next chapter does not return the page to its top, which is what one would expect. This fix adds a line of javascript to make sure that the page returns to the top.