### PR TITLE
a more reliable solution for e.offsetX/Y in Firefox

### DIFF
--- a/inst/www/shared/shiny.js
+++ b/inst/www/shared/shiny.js
@@ -1050,11 +1050,10 @@
               y: mouseEvent.offsetY
             };
           }
-
-          var origEvent = mouseEvent.originalEvent || {};
+          var offset = $el.offset();
           return {
-            x: origEvent.layerX - origEvent.target.offsetLeft,
-            y: origEvent.layerY - origEvent.target.offsetTop
+            x: mouseEvent.pageX - offset.left,
+            y: mouseEvent.pageY - offset.top
           };
         }
         


### PR DESCRIPTION
see http://stackoverflow.com/q/12704686/559676

this also fixes the bug reported by Greg D: https://groups.google.com/forum/#!topic/shiny-discuss/E6oYvyvx0oU

I have tested it in Chrome and Firefox.

@jcheng5 please check if you see any problems