### PR TITLE
send disconnected message to parent frame when running on localhost

### DIFF
--- a/inst/www/shared/shiny.js
+++ b/inst/www/shared/shiny.js
@@ -492,6 +492,7 @@
       };
       socket.onclose = function() {
         $(document.body).addClass('disconnected');
+        self.$notifyDisconnected();
       };
       return socket;
     };
@@ -507,6 +508,34 @@
       $.extend(this.$inputValues, values);
       this.$updateConditionals();
     };
+
+    this.$notifyDisconnected = function() {
+
+      // function to normalize hostnames
+      normalize = function(hostname) {
+        if (hostname == "127.0.0.1")
+          return "localhost";
+        else
+          return hostname;
+      }
+
+      // Send a 'disconnected' message to parent if we are on the same domin
+      var parentUrl = (parent !== window) ? document.referrer : null;
+      if (parentUrl) {
+        // parse the parent href
+        var a = document.createElement('a');
+        a.href = parentUrl;
+                
+        // post the disconnected message if the hostnames are the same
+        if (normalize(a.hostname) == normalize(window.location.hostname)) {
+          protocol = a.protocol.replace(':',''); // browser compatability
+          origin = protocol + '://' + a.hostname;
+          if (a.port)
+            origin = origin + ':' + a.port;
+          parent.postMessage('disconnected', origin);
+        }
+      }
+    }
 
     // NB: Including blobs will cause IE to break!
     // TODO: Make blobs work with Internet Explorer


### PR DESCRIPTION
Note that this verifies that both the application and the parent frame are on localhost before sending the message. I'm not sure however what exactly that is buying us, as all the postMessage does is send the string "disconnected" to anyone who is listening. It doesn't strike me that this opens up any exploits (no actual code is exchanged or evaluated) and it might be generally useful for anyone hosting a shiny app to know if/when it is disconnected. 

So I'd propose that we remove the localhost qualification -- let me know what you think.