### PR TITLE
Don't clear timers when runApp returns

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -1383,15 +1383,10 @@ runApp <- function(appDir=getwd(),
   
   .globals$retval <- NULL
   .globals$stopped <- FALSE
-  tryCatch(
-    while (!.globals$stopped) {
-      serviceApp()
-      Sys.sleep(0.001)
-    },
-    finally = {
-      timerCallbacks$clear()
-    }
-  )
+  while (!.globals$stopped) {
+    serviceApp()
+    Sys.sleep(0.001)
+  }
   
   return(.globals$retval)
 }


### PR DESCRIPTION
The lifetimes of reactive expressions and observers can span multiple runApp calls, so timers should as well.

```
library(shiny)
now <- reactive({invalidateLater(1000, NULL); Sys.time()})
shiny::runApp(list(
  ui=basicPage(textOutput('foo')),
  server = function(input, output) {
    output$foo <- renderText({now()})
  }
))
```

Then stop the app and re-run the runApp command. Without this fix, the time doesn't change anymore for the second and subsequent times.