### PR TITLE
use sys.source() and keep.source=TRUE

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -764,7 +764,7 @@ dynamicHandler <- function(filePath, dependencyFiles=filePath) {
       if (file.exists(filePath)) {
         local({
           cacheContext$with(function() {
-            sys.source(filePath, envir=new.env(parent=.GlobalEnv), keep.source=TRUE)
+            sys.source(filePath, envir=new.env(parent=globalenv()), keep.source=TRUE)
           })
         })
       }
@@ -1018,11 +1018,11 @@ startAppDir <- function(port=8101L, workerId) {
     stop(paste("server.R file was not found in", getwd()))
   
   if (file.exists(globalR))
-    sys.source(globalR, envir=.GlobalEnv, keep.source=TRUE)
+    sys.source(globalR, envir=globalenv(), keep.source=TRUE)
   
   shinyServer(NULL)
   serverFileTimestamp <- file.info(serverR)$mtime
-  local(sys.source(serverR, envir=new.env(parent=.GlobalEnv), keep.source=TRUE))
+  sys.source(serverR, envir=new.env(parent=globalenv()), keep.source=TRUE)
   if (is.null(.globals$server))
     stop("No server was defined in server.R")
   
@@ -1032,7 +1032,7 @@ startAppDir <- function(port=8101L, workerId) {
     if (!identical(mtime, serverFileTimestamp)) {
       shinyServer(NULL)
       serverFileTimestamp <<- mtime
-      local(sys.source(serverR, envir=new.env(parent=.GlobalEnv), keep.source=TRUE))
+      sys.source(serverR, envir=new.env(parent=globalenv()), keep.source=TRUE)
       if (is.null(.globals$server))
         stop("No server was defined in server.R")
     }


### PR DESCRIPTION
I can do #237 as well after it is clear to me

I was also wondering why we need to put `local()` around `source()`, since we have specified the environment to evaluate ui.R and server.R

@jcheng5