### PR TITLE
added .csv for Windows users

### DIFF
--- a/_includes/tutorial/uploads.md
+++ b/_includes/tutorial/uploads.md
@@ -22,7 +22,7 @@ shinyUI(pageWithSidebar(
   headerPanel("CSV Viewer"),
   sidebarPanel(
     fileInput('file1', 'Choose CSV File',
-              accept=c('text/csv', 'text/comma-separated-values,text/plain')),
+              accept=c('text/csv', 'text/comma-separated-values,text/plain', '.csv')),
     tags$hr(),
     checkboxInput('header', 'Header', TRUE),
     radioButtons('sep', 'Separator',


### PR DESCRIPTION
Without the ".csv" on Windows file selector does not filter for csv
files. This may be due to Excel. But the install base for Excel is
humongous so I propose to incorporate it.