### PR TITLE
bump the required version of httpuv to v1.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Imports:
     tools,
     utils,
     methods,
-    httpuv (>= 1.1.0),
+    httpuv (>= 1.2.0),
     caTools,
     RJSONIO,
     xtable,


### PR DESCRIPTION
this is to pull the changes to httpuv that enable shiny applications to run inside the rstudio viewer pane