### PR TITLE
Move methods package to Depends

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,12 +11,12 @@ Description: Shiny makes it incredibly easy to build interactive web
     beautiful, responsive, and powerful applications with minimal effort.
 License: GPL-3
 Depends:
-    R (>= 2.14.1)
+    R (>= 2.14.1),
+    methods
 Imports:
     stats,
     tools,
     utils,
-    methods,
     httpuv (>= 1.2.0),
     caTools,
     RJSONIO,


### PR DESCRIPTION
The 'methods' package being in Imports (and not Depends) has caused an issue for users running Rscript. For example:
  https://groups.google.com/d/msg/shiny-discuss/Gbyh1cLI1Fo/AFmZrb4NPccJ

Apparently it should go into Depends, according to John Chambers himself:
  http://r.789695.n4.nabble.com/advise-on-Depends-td4678930.html