### PR TITLE
Add quiet option to runApp

### DIFF
--- a/man/runApp.Rd
+++ b/man/runApp.Rd
@@ -4,7 +4,7 @@
 \usage{
   runApp(appDir = getwd(), port = NULL,
     launch.browser = getOption("shiny.launch.browser", interactive()),
-    workerId = "")
+    workerId = "", quiet = FALSE)
 }
 \arguments{
   \item{appDir}{The directory of the application. Should
@@ -24,6 +24,9 @@
   \item{workerId}{Can generally be ignored. Exists to help
   some editions of Shiny Server Pro route requests to the
   correct process.}
+
+  \item{quiet}{Should Shiny status messages be shown?
+  Defaults to FALSE.}
 }
 \description{
   Runs a Shiny application. This function normally does not


### PR DESCRIPTION
When run with `runApp(quiet = TRUE)`, this quiets the "listening on port xxxx" message. This is useful when Shiny apps are run by other processes (like ggvis), where the details of running the Shiny app aren't important to the user. The alternative, using `suppressMessages(runApp())`, is a too heavy-handed since it blocks all messages generated by the app.

It would also be nice to be able to quiet the output from `addResourcePath()`, but doing so is less straightforward. Any input on how best to do that?