### PR TITLE
Fixes to make JSHint happy

### DIFF
--- a/inst/www/shared/shiny.js
+++ b/inst/www/shared/shiny.js
@@ -91,6 +91,7 @@
   // When the function is executed, it will evaluate that expression using
   // "with" on the argument value, and return the result.
   function scopeExprToFunc(expr) {
+    /*jshint evil: true */
     var func = new Function("with (this) {return (" + expr + ");}");
     return function(scope) {
       return func.call(scope);
@@ -810,6 +811,7 @@
     });
 
     addMessageHandler('javascript', function(message) {
+      /*jshint evil: true */
       eval(message);
     });
 
@@ -2513,6 +2515,7 @@
           var effectiveId = type ? id + ":" + type : id;
           currentValues[effectiveId] = binding.getValue(el);
 
+          /*jshint loopfunc:true*/
           var thisCallback = (function() {
             var thisBinding = binding;
             var thisEl = el;


### PR DESCRIPTION
These fixes include:
- Avoiding accidental globals
- Syntax fixes (e.g., semicolons)
- Changing function definitions to function vars, when the scope they're declared in makes it unclear where the function would be hoisted to. (For example, a function that's defined within an object literal)
- Using `exports` instead of `Shiny`
- Telling jshint in a few places that yes, we want to do dangerous things like `eval()`
- Checking for `hasOwnProperty` in for-in loops.

Also, the unused `InputSender` was removed.