### PR TITLE
Rproj changes: don't roxygenize; use --as-cran for test

### DIFF
--- a/shiny.Rproj
+++ b/shiny.Rproj
@@ -11,7 +11,6 @@ Encoding: UTF-8
 
 RnwWeave: Sweave
 LaTeX: pdfLaTeX
-RootDocument: 
 
 BuildType: Package
-PackageRoxygenize: rd,namespace
+PackageCheckArgs: --as-cran


### PR DESCRIPTION
- Remove roxygenize during build operations since Shiny currently requires devtools::document to correctly roxygenize. 
- R CMD check --as-cran by default