### PR TITLE
add application run and stop hooks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,3 +50,4 @@ Collate:
     'imageutils.R'
     'update-input.R'
     'bootstrap-layout.R'
+    'hooks.R'

--- a/R/hooks.R
+++ b/R/hooks.R
@@ -1,0 +1,24 @@
+
+
+# Call an application hook. Application hooks are provided so that front ends
+# can know when a Shiny application is running:
+#
+# shiny.onRunApp -- called when an application begins running 
+# shiny.onAppStop -- called when an appliation stops
+#
+# Both hooks are passed the url where the application is accessible (appUrl). 
+# Note that the appUrl can be NULL if the application was run on a UNIX domain
+# socket rather than a TCP/IP port/
+callAppHook <- function(name, appUrl) {
+  for (hook in getHooksList(paste0("shiny.", name)))
+    hook(appUrl)
+}
+
+# The value for getHook can be a single function or a list of functions,
+# This function ensures that the result can always be processed as a list
+getHooksList <- function(name) {
+  hooks <- getHook(name)
+  if (!is.list(hooks))
+    hooks <- list(hooks)
+  hooks
+}

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -1470,7 +1470,15 @@ runApp <- function(appDir=getwd(),
       launch.browser(appUrl)
     else if (launch.browser)
       utils::browseURL(appUrl)
+  } else {
+    appUrl <- NULL
   }
+  
+  # call application hooks
+  callAppHook("onRunApp", appUrl)
+  on.exit({
+    callAppHook("onAppStop", appUrl)
+  }, add = TRUE)
   
   .globals$retval <- NULL
   .globals$stopped <- FALSE


### PR DESCRIPTION
Add R hooks for notification when applications run and stop. These hooks are principally useful to front-end environments. Two use-cases are:
1. Awareness that a busy console represents a long running sub-task (rather than an R command that happens to be taking a few seconds). Front ends might in this case want to treat their busy/stop UI a bit differently.
2. Implementing more sophisticated browser management. For example, a front-end could set shiny.launch.browser to FALSE and then launch and manage application browser using DDE, AppleScript, or DBus. A front-end could also implement their own shiny application browser container (with features like auto-reactivation, close-on-stop, and auto-refresh).