### PR TITLE
Fix issue #359: Factors in HTML attributes are being converted to their numeric, not character, equivalent

### DIFF
--- a/R/tags.R
+++ b/R/tags.R
@@ -161,8 +161,9 @@ tagWrite <- function(tag, textWriter, indent=0, context = NULL, eol = "\n") {
   # write tag name
   textWriter(paste(indentText, "<", tag$name, sep=""))
   
+  # Convert all attribs to chars explicitly; prevents us from messing up factors
+  attribs <- lapply(tag$attribs, as.character)
   # concatenate attributes
-  attribs <- tag$attribs
   attribs <- lapply(split(attribs, names(attribs)), paste, collapse = " ")
 
   # write attributes

--- a/inst/tests/test-tags.r
+++ b/inst/tests/test-tags.r
@@ -323,3 +323,16 @@ test_that("Head and singleton behavior", {
   expect_identical(result2$head, HTML(""))
   expect_identical(result2$html, HTML(""))
 })
+
+test_that("Factors are treated as characters, not numbers", {
+  myfactors <- factor(LETTERS[1:3])
+  expect_identical(
+    as.character(tags$option(value=myfactors[[1]], myfactors[[1]])),
+    HTML('<option value="A">A</option>')
+  )
+
+  expect_identical(
+    as.character(tags$option(value=myfactors[[1]], value='B', value=3, myfactors[[1]])),
+    HTML('<option value="A B 3">A</option>')
+  )
+})


### PR DESCRIPTION
This bug was introduced in 3fc1410. Essentially it boils down to the difference between stringifying a factor, and stringifying a list containing a factor:

> as.character(factor('a'))
> [1] "a"
> as.character(list(factor('a')))
> [1] "1"
> The call to split that was introduced in this commit ends up generating lists of factors, not vectors of them.

The best fix I could find was to convert all the attribute values to character before doing the split.