### PR TITLE
fixes #90: textOuput() can be put in any tag now

### DIFF
--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -1414,16 +1414,17 @@ buildTabset <- function(tabs,
 #' Create a text output element
 #' 
 #' Render a reactive output variable as text within an application page. The 
-#' text will be included within an HTML \code{div} tag. 
+#' text will be included within an HTML \code{div} tag by default.
 #' @param outputId output variable to read the value from
+#' @param container a function to generate an HTML element to contain the text
 #' @return A text output element that can be included in a panel
 #' @details Text is HTML-escaped prior to rendering. This element is often used 
 #' to display \link{renderText} output variables.
 #' @examples
 #' h3(textOutput("caption"))
 #' @export
-textOutput <- function(outputId) {
-  div(id = outputId, class = "shiny-text-output")
+textOutput <- function(outputId, container = div) {
+  container(id = outputId, class = "shiny-text-output")
 }
 
 #' Create a verbatim text output element
@@ -1445,7 +1446,7 @@ textOutput <- function(outputId) {
 #' )
 #' @export
 verbatimTextOutput <- function(outputId) {
-  pre(id = outputId, class =  "shiny-text-output")
+  textOutput(outputId, container = pre)
 }
 
 #' Create a image output element

--- a/inst/examples/03_reactivity/ui.R
+++ b/inst/examples/03_reactivity/ui.R
@@ -24,7 +24,7 @@ shinyUI(fluidPage(
     # Show the caption, a summary of the dataset and an HTML 
 	 # table with the requested number of observations
     mainPanel(
-      h3(textOutput("caption")), 
+      h3(textOutput("caption", container = span)),
       
       verbatimTextOutput("summary"), 
       

--- a/man/textOutput.Rd
+++ b/man/textOutput.Rd
@@ -2,10 +2,13 @@
 \alias{textOutput}
 \title{Create a text output element}
 \usage{
-  textOutput(outputId)
+  textOutput(outputId, container = div)
 }
 \arguments{
   \item{outputId}{output variable to read the value from}
+
+  \item{container}{a function to generate an HTML element
+  to contain the text}
 }
 \value{
   A text output element that can be included in a panel
@@ -13,7 +16,7 @@
 \description{
   Render a reactive output variable as text within an
   application page. The text will be included within an
-  HTML \code{div} tag.
+  HTML \code{div} tag by default.
 }
 \details{
   Text is HTML-escaped prior to rendering. This element is


### PR DESCRIPTION
for the example, we use `<span>`, which is allowed in `<h3>`