### PR TITLE
Better handling of dynamically generated singletons

### DIFF
--- a/R/shinywrappers.R
+++ b/R/shinywrappers.R
@@ -414,16 +414,13 @@ renderUI <- function(expr, env=parent.frame(), quoted=FALSE, func=NULL) {
     if (is.null(result) || length(result) == 0)
       return(NULL)
 
-    # renderTags returns a list with head, singletons, and html
-    output <- renderTags(result, shinysession$singletons)
-    shinysession$singletons <- output$singletons
-    output$singletons <- NULL
+    result <- takeSingletons(result, shinysession$singletons, desingleton=FALSE)$ui
+    result <- surroundSingletons(result)
     
-    # If there's stuff in head, then return a list; otherwise, just a string.
-    if (isTRUE(nchar(output$head) > 0))
-      return(output)
-    else
-      return(output$html)
+    # renderTags returns a list with head, singletons, and html
+    output <- doRenderTags(result)
+    
+    return(output)
   }
 }
 

--- a/inst/tests/test-bootstrap.r
+++ b/inst/tests/test-bootstrap.r
@@ -42,15 +42,15 @@ test_that("Repeated names for selectInput and radioButtons choices", {
   x <- radioButtons('id','label', choices = c(a='x1', a='x2', b='x3'))
   choices <- x$children
 
-  expect_equal(choices[[2]]$children[[2]]$children[[1]], 'a')
-  expect_equal(choices[[2]]$children[[1]]$attribs$value, 'x1')
-  expect_equal(choices[[2]]$children[[1]]$attribs$checked, 'checked')
+  expect_equal(choices[[2]][[1]]$children[[2]]$children[[1]], 'a')
+  expect_equal(choices[[2]][[1]]$children[[1]]$attribs$value, 'x1')
+  expect_equal(choices[[2]][[1]]$children[[1]]$attribs$checked, 'checked')
 
-  expect_equal(choices[[3]]$children[[2]]$children[[1]], 'a')
-  expect_equal(choices[[3]]$children[[1]]$attribs$value, 'x2')
-  expect_equal(choices[[3]]$children[[1]]$attribs$checked, NULL)
+  expect_equal(choices[[2]][[2]]$children[[2]]$children[[1]], 'a')
+  expect_equal(choices[[2]][[2]]$children[[1]]$attribs$value, 'x2')
+  expect_equal(choices[[2]][[2]]$children[[1]]$attribs$checked, NULL)
 
-  expect_equal(choices[[4]]$children[[2]]$children[[1]], 'b')
-  expect_equal(choices[[4]]$children[[1]]$attribs$value, 'x3')
-  expect_equal(choices[[4]]$children[[1]]$attribs$checked, NULL)
+  expect_equal(choices[[2]][[3]]$children[[2]]$children[[1]], 'b')
+  expect_equal(choices[[2]][[3]]$children[[1]]$attribs$value, 'x3')
+  expect_equal(choices[[2]][[3]]$children[[1]]$attribs$checked, NULL)
 })

--- a/inst/tests/test-tags.r
+++ b/inst/tests/test-tags.r
@@ -72,13 +72,14 @@ test_that("Adding child tags", {
 
   # Creating nested tags by calling the tag$div function and passing a list
   t1 <- tags$div(class="foo", tag_list)
-  expect_equal(length(t1$children), 3)
-  expect_equal(t1$children[[1]]$name, "p")
-  expect_equal(t1$children[[1]]$children[[1]], "tag1")
-  expect_equal(t1$children[[2]]$name, "b")
-  expect_equal(t1$children[[2]]$children[[1]], "tag2")
-  expect_equal(t1$children[[3]]$name, "i")
-  expect_equal(t1$children[[3]]$children[[1]], "tag3")
+  expect_equal(length(t1$children), 1)
+  expect_equal(length(t1$children[[1]]), 3)
+  expect_equal(t1$children[[1]][[1]]$name, "p")
+  expect_equal(t1$children[[1]][[1]]$children[[1]], "tag1")
+  expect_equal(t1$children[[1]][[2]]$name, "b")
+  expect_equal(t1$children[[1]][[2]]$children[[1]], "tag2")
+  expect_equal(t1$children[[1]][[3]]$name, "i")
+  expect_equal(t1$children[[1]][[3]]$children[[1]], "tag3")
 
 
   # div tag used as starting point for tests below
@@ -88,45 +89,46 @@ test_that("Adding child tags", {
   t2 <- tagAppendChild(div_tag, tag_list[[1]])
   t2 <- tagAppendChild(t2, tag_list[[2]])
   t2 <- tagAppendChild(t2, tag_list[[3]])
-  expect_identical(t1, t2)
+  t2a <- do.call(tags$div, c(tag_list, class="foo"))
+  expect_identical(t2a, t2)
 
 
   # tagSetChildren, using list argument
   t2 <- tagSetChildren(div_tag, list = tag_list)
-  expect_identical(t1, t2)
+  expect_identical(t2a, t2)
 
   # tagSetChildren, using ... arguments
   t2 <- tagSetChildren(div_tag, tag_list[[1]], tag_list[[2]], tag_list[[3]])
-  expect_identical(t1, t2)
+  expect_identical(t2a, t2)
 
   # tagSetChildren, using ... and list arguments
   t2 <- tagSetChildren(div_tag, tag_list[[1]], list = tag_list[2:3])
-  expect_identical(t1, t2)
+  expect_identical(t2a, t2)
 
   # tagSetChildren overwrites existing children
   t2 <- tagAppendChild(div_tag, p("should replace this tag"))
   t2 <- tagSetChildren(div_tag, list = tag_list)
-  expect_identical(t1, t2)
+  expect_identical(t2a, t2)
 
 
   # tagAppendChildren, using list argument
   t2 <- tagAppendChild(div_tag, tag_list[[1]])
   t2 <- tagAppendChildren(t2, list = tag_list[2:3])
-  expect_identical(t1, t2)
+  expect_identical(t2a, t2)
 
   # tagAppendChildren, using ... arguments
   t2 <- tagAppendChild(div_tag, tag_list[[1]])
   t2 <- tagAppendChildren(t2, tag_list[[2]], tag_list[[3]])
-  expect_identical(t1, t2)
+  expect_identical(t2a, t2)
 
   # tagAppendChildren, using ... and list arguments
   t2 <- tagAppendChild(div_tag, tag_list[[1]])
   t2 <- tagAppendChildren(t2, tag_list[[2]], list = list(tag_list[[3]]))
-  expect_identical(t1, t2)
+  expect_identical(t2a, t2)
 
   # tagAppendChildren can start with no children
   t2 <- tagAppendChildren(div_tag, list = tag_list)
-  expect_identical(t1, t2)
+  expect_identical(t2a, t2)
 
 
   # tagSetChildren preserves attributes
@@ -168,18 +170,14 @@ test_that("Creating simple tags", {
 
   # NULL children are dropped
   expect_identical(
-    div("foo", NULL, list(NULL, list(NULL, "bar"))),
-    div("foo", "bar")
+    renderTags(div("foo", NULL, list(NULL, list(NULL, "bar"))))$html,
+    renderTags(div("foo", "bar"))$html
   )
 
   # Numbers are coerced to strings
   expect_identical(
-    div(1234),
-    structure(
-      list(name = "div", attribs = list(), children = list("1234")),
-      .Names = c("name", "attribs", "children"),
-      class = "shiny.tag"
-    )
+    renderTags(div(1234))$html,
+    renderTags(div("1234"))$html
   )
 })
 
@@ -192,7 +190,7 @@ test_that("Creating nested tags", {
     structure(
       list(name = "div",
            attribs = structure(list(class = "foo"), .Names = "class"),
-           children = list("a", "b")),
+           children = list(list("a", "b"))),
       .Names = c("name", "attribs", "children"),
       class = "shiny.tag"
     )
@@ -249,7 +247,7 @@ test_that("Creating nested tags", {
     class = "shiny.tag"
   )
 
-  expect_identical(t1, t1_full)
+  expect_identical(renderTags(t1)$html, renderTags(t1_full)$html)
 })
 
 test_that("Attributes are preserved", {
@@ -322,6 +320,17 @@ test_that("Head and singleton behavior", {
   expect_identical(result$singletons, result2$singletons)
   expect_identical(result2$head, HTML(""))
   expect_identical(result2$html, HTML(""))
+  
+  result3 <- renderTags(tagList(
+    tags$head(singleton("hello"), singleton("hello"))
+  ))
+  expect_identical(result$singletons, result3$singletons)
+  expect_identical(result3$head, HTML("  hello"))
+  
+  # Ensure that singleton can be applied to lists, not just tags
+  result4 <- renderTags(list(singleton(list("hello")), singleton(list("hello"))))
+  expect_identical(result4$singletons, "d7319e3f14167c4c056dd7aa0b274c83fe2291f6")
+  expect_identical(result4$html, renderTags(HTML("hello"))$html)
 })
 
 test_that("Factors are treated as characters, not numbers", {
@@ -334,5 +343,52 @@ test_that("Factors are treated as characters, not numbers", {
   expect_identical(
     as.character(tags$option(value=myfactors[[1]], value='B', value=3, myfactors[[1]])),
     HTML('<option value="A B 3">A</option>')
+  )
+})
+
+test_that("Unusual list contents are rendered correctly", {
+  expect_identical(renderTags(list(NULL)), renderTags(HTML("")))
+  expect_identical(renderTags(list(100)), renderTags(HTML("100")))
+  expect_identical(renderTags(list(list(100))), renderTags(HTML("100")))
+  expect_identical(renderTags(list(list())), renderTags(HTML("")))
+  expect_identical(renderTags(NULL), renderTags(HTML("")))
+})
+
+test_that("Low-level singleton manipulation methods", {
+  # Default arguments drop singleton duplicates and strips the
+  # singletons it keeps of the singleton bit
+  result1 <- takeSingletons(tags$div(
+    singleton(tags$head(tags$script("foo"))),
+    singleton(tags$head(tags$script("foo")))
+  ))
+  
+  expect_identical(result1$ui$children[[2]], NULL)
+  expect_false(is(result1$ui$children[[1]], "shiny.singleton"))
+
+  # desingleton=FALSE means drop duplicates but don't strip the
+  # singleton bit
+  result2 <- takeSingletons(tags$div(
+    singleton(tags$head(tags$script("foo"))),
+    singleton(tags$head(tags$script("foo")))
+  ), desingleton=FALSE)
+
+  expect_identical(result2$ui$children[[2]], NULL)
+  expect_is(result2$ui$children[[1]], "shiny.singleton")
+  
+  result3 <- surroundSingletons(tags$div(
+    singleton(tags$script("foo")),
+    singleton(tags$script("foo"))
+  ))
+  
+  expect_identical(
+    renderTags(result3)$html,
+    HTML("<div>
+  <!--SHINY.SINGLETON[58b302d493b50acb75e4a5606687cadccdf902d8]-->
+  <script>foo</script>
+  <!--/SHINY.SINGLETON[58b302d493b50acb75e4a5606687cadccdf902d8]-->
+  <!--SHINY.SINGLETON[58b302d493b50acb75e4a5606687cadccdf902d8]-->
+  <script>foo</script>
+  <!--/SHINY.SINGLETON[58b302d493b50acb75e4a5606687cadccdf902d8]-->
+</div>")
   )
 })


### PR DESCRIPTION
Ref:
https://groups.google.com/d/msg/shiny-discuss/cgSHsM1FCjY/vgU1-jmkGjkJ

The user reported that on a page with multiple uiOutputs whose corresponding
renderUI calls all returned sliderInputs (but no sliderInput was present in
ui.R), some but not all of the sliders were initialized correctly; the ones
that were not didn't receive the jquery-slider treatment and just looked like
text boxes.

This was caused by a fundamental flaw in our handling of singletons in
renderUI. The implicit assumption in the old renderUI code was that:

1) Any HTML we generate in renderUI would be rendered in the client
2) Given multiple calls to renderUI, the HTML we return will be rendered in
   the client in the order that we generated it

Both assumptions are incorrect. #1 would be incorrect in cases where an output
is rendered twice before flushOutput is called (this is possible when using an
observer to modify a reactive input, for example), and #2 is incorrect when
output is flushed with multiple values (very common, and exactly what was
happening to the user scenario linked above).

This commit fixes the problem by deferring singleton-handling for uiOutput to
the client. We don't assume that a singleton has been rendered until right
before we render it. The implementation uses a surroundSingletons function on
the server side to surround all singletons with <!--SHINY.SINGLETON[sig]-->
and <!--/SHINY.SINGLETON[sig]-->, which will then be parsed and removed in
the htmlOutputBinding in shiny.js. (And because singletons may contain head
elements, we also need to defer head hoisting to htmlOutputBinding as well.)

The context$filter mechanism previously used in tagWrite was not flexible
enough to handle this kind of singleton processing. The new rewriteTags
function does tag walking and rewriting much more robustly and flexibly than
context$filter, so I also refactored renderTags to use it instead.

One unrelated problem I noticed was that singleton only worked reliably on
tags, possibly on characters and definitely not on list() or tagList(). This
is because list flattening was happening at tag construction time, which
can cause singleton objects to be trampled. (Among other reasons, such as
context$filter not being called on list objects.) I changed tags.R to not do
any flattening or NULL dropping at tag construction time, but instead to do
it at the last minute during tagWrite.