### PR TITLE
Don't show broken image when plot is empty

### DIFF
--- a/inst/www/shared/shiny.js
+++ b/inst/www/shared/shiny.js
@@ -1062,7 +1062,8 @@
         img = document.createElement('img');
         // Copy items from data to img. This should include 'src'
         $.each(data, function(key, value) {
-          img[key] = value;
+          if (value !== null)
+            img[key] = value;
         });
 
         // Firefox doesn't have offsetX/Y, so we need to use an alternate


### PR DESCRIPTION
Repro case:

``` s
shiny::runApp(list(
  ui=basicPage(plotOutput('foo')),
  server=function(input, output, session) {
    output$foo <- renderPlot({})
  }
))
```