### PR TITLE
Allow display.mode to be provided for examples

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -1637,6 +1637,10 @@ stopApp <- function(returnValue = NULL) {
 #'   interactive sessions only.
 #' @param host The IPv4 address that the application should listen on. Defaults
 #'   to the \code{shiny.host} option, if set, or \code{"127.0.0.1"} if not.
+#' @param display.mode The mode in which to display the example. Defaults to 
+#'   \code{showcase}, but may be set to \code{normal} to see the example without
+#'   code or commentary.
+#'
 #' @examples
 #' \dontrun{
 #' # List all available examples
@@ -1653,7 +1657,8 @@ runExample <- function(example=NA,
                        port=NULL,
                        launch.browser=getOption('shiny.launch.browser',
                                                 interactive()),
-                       host=getOption('shiny.host', '127.0.0.1')) {
+                       host=getOption('shiny.host', '127.0.0.1'), 
+                       display.mode=c("auto", "normal", "showcase")) {
   examplesDir <- system.file('examples', package='shiny')
   dir <- resolve(examplesDir, example)
   if (is.null(dir)) {
@@ -1673,7 +1678,7 @@ runExample <- function(example=NA,
   }
   else {
     runApp(dir, port = port, host = host, launch.browser = launch.browser, 
-           display.mode = "showcase")
+           display.mode = display.mode)
   }
 }
 

--- a/man/runExample.Rd
+++ b/man/runExample.Rd
@@ -4,7 +4,8 @@
 \usage{
 runExample(example = NA, port = NULL,
   launch.browser = getOption("shiny.launch.browser", interactive()),
-  host = getOption("shiny.host", "127.0.0.1"))
+  host = getOption("shiny.host", "127.0.0.1"), display.mode = c("auto",
+  "normal", "showcase"))
 }
 \arguments{
   \item{example}{The name of the example to run, or
@@ -20,10 +21,15 @@ runExample(example = NA, port = NULL,
   \item{host}{The IPv4 address that the application should
   listen on. Defaults to the \code{shiny.host} option, if
   set, or \code{"127.0.0.1"} if not.}
+
+  \item{display.mode}{The mode in which to display the
+  example. Defaults to \code{showcase}, but may be set to
+  \code{normal} to see the example without code or
+  commentary.}
 }
 \description{
-Launch Shiny example applications, and optionally, your
-system's web browser.
+  Launch Shiny example applications, and optionally, your
+  system's web browser.
 }
 \examples{
 \dontrun{


### PR DESCRIPTION
Implementing a suggestion from @garrettgman: for training purposes, it's useful to show examples in normal mode, which is currently difficult.