### PR TITLE
Fix debounce error in IE8

### DIFF
--- a/inst/www/shared/shiny.js
+++ b/inst/www/shared/shiny.js
@@ -137,6 +137,10 @@
       this.args = arguments;
 
       this.timerId = setTimeout(function() {
+        // IE8 doesn't reliably clear timeout, so this additional
+        // check is needed
+        if (self.timerId === null)
+          return;
         self.$clearTimer();
         self.$invoke();
       }, this.delayMs);
@@ -178,6 +182,10 @@
       if (this.timerId === null) {
         this.$invoke();
         this.timerId = setTimeout(function() {
+          // IE8 doesn't reliably clear timeout, so this additional
+          // check is needed
+          if (self.timerId === null)
+            return;
           self.$clearTimer();
           if (self.args)
             self.normalCall.apply(self, self.args);
@@ -224,6 +232,10 @@
         timerId = null;
       }
       timerId = setTimeout(function() {
+        // IE8 doesn't reliably clear timeout, so this additional
+        // check is needed
+        if (timerId === null)
+          return;
         timerId = null;
         func.apply(self, args);
       }, threshold);


### PR DESCRIPTION
In the repo https://github.com/rstudio/shiny-testapp/ the test app
called "setinput" threw errors in IE8 due to the debouncer getting
triggered incorrectly. Essentially Debouncer.$invoke was being
called twice without an intervening normalCall or immediateCall,
which caused apply to be called with this.args === null. Upon
careful inspection/debugging it seems like this may be a bug in the
IE8 implementation of setTimeout/clearTimeout:
http://stackoverflow.com/questions/5853571/clarifying-cleartimeout-behavior-in-ie

In any case, the workaround is to check for a null timer id, which
means we tried to clear the timer at least.