### PR TITLE
Add function for handling date strings in IE8

### DIFF
--- a/inst/www/shared/shiny.js
+++ b/inst/www/shared/shiny.js
@@ -38,6 +38,15 @@
     return str;
   }
 
+  // Take a string with format "YYYY-MM-DD" and return a Date object.
+  // IE8 doesn't support YYYY-MM-DD, but all major browsers support YYYY/MM/DD.
+  function parseDate(dateString) {
+    if (dateString.match(/^(\d\d\d\d)-(\d\d)-(\d\d)$/)) {
+      dateString = dateString.replace(/-/g, "/");
+    }
+    return new Date(dateString);
+  }
+
   function slice(blob, start, end) {
     if (blob.slice)
       return blob.slice(start, end);
@@ -1769,7 +1778,7 @@
 
       // Get Date object - this will be at 12AM in UTC, but may print
       // differently at the Javascript console.
-      var d = new Date(date);
+      var d = parseDate(date);
 
       // If invalid date, return null
       if (isNaN(d))


### PR DESCRIPTION
IE8 doesn't handle `new Date("YYYY-mm-dd")` properly, so I've added a function `parseDate` which works in IE8. Screenshot of functioning dateinput test app below:
![screenshot from 2014-02-24 15 21 58](https://f.cloud.github.com/assets/86978/2251224/ed3041ca-9d99-11e3-91de-b9fc2e153f9b.png)