### PR TITLE
Fix 'Error in Context$new : could not find function "loadMethod"'

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: shiny
 Type: Package
 Title: Web Application Framework for R
-Version: 0.9.0
-Date: 2014-03-18
+Version: 0.9.1
+Date: 2014-03-19
 Author: RStudio, Inc.
 Maintainer: Winston Chang <winston@rstudio.com>
 Description: Shiny makes it incredibly easy to build interactive web

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+shiny 0.9.1
+--------------------------------------------------------------------------------
+
+* Fixed warning 'Error in Context$new : could not find function "loadMethod"'
+  that was happening to dependent packages on "R CMD check".
+
 shiny 0.9.0
 --------------------------------------------------------------------------------
 

--- a/R/react.R
+++ b/R/react.R
@@ -92,7 +92,7 @@ ReactiveEnvironment <- setRefClass(
     currentContext = function() {
       if (is.null(.currentContext)) {
         if (isTRUE(getOption('shiny.suppressMissingContextError', FALSE))) {
-          return(dummyContext)
+          return(getDummyContext())
         } else {
           stop('Operation not allowed without an active reactive context. ',
                '(You tried to do something that can only be done from inside a ',
@@ -140,4 +140,12 @@ getCurrentContext <- function() {
   .getReactiveEnvironment()$currentContext()
 }
 
-delayedAssign("dummyContext", Context$new('[none]', type='isolate'))
+getDummyContext <- function() {}
+local({
+  dummyContext <- NULL
+  getDummyContext <<- function() {
+    if (is.null(dummyContext))
+      dummyContext <<- Context$new('[none]', type='isolate')
+    return(dummyContext)
+  }
+})

--- a/inst/tests/test-reactivity.r
+++ b/inst/tests/test-reactivity.r
@@ -700,3 +700,10 @@ test_that("{} and NULL also work in reactive()", {
   reactive({})
   reactive(NULL)
 })
+
+test_that("shiny.suppressMissingContextError option works", {
+  options(shiny.suppressMissingContextError=TRUE)
+  on.exit(options(shiny.suppressMissingContextError=FALSE), add = TRUE)
+
+  expect_true(reactive(TRUE)())
+})


### PR DESCRIPTION
This warning was happening to dependent packages on R CMD check.

The problem is due to delayedAssign; it appears this can't be used safely, at least not to define package-level symbols that contain S4 or reference class objects.

If you call this in a package's .R file:

`delayedAssign("hello", stop("boom"))`

but don't refer to "hello" anywhere, when you run R CMD check on a dependent package you'll see the error.

If the expression needs the methods package (like Context$new()), you'll get an error unless the dependent package itself depends on methods.