### PR TITLE
Handle zero-argument outputs gracefully

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -608,7 +608,9 @@ ShinySession <- setRefClass(
     # arguments), which generally corresponds to the reactive expression--
     # e.g. in renderTable({ x }), { x } is the expression to trace.
     attr(label, "srcref") <- srcrefFromShinyCall(substitute(value)[[2]])
-    attr(label, "srcfile") <- srcFileOfRef(attr(substitute(value)[[2]], "srcref")[[1]])
+    srcref <- attr(substitute(value)[[2]], "srcref")
+    if (length(srcref) > 0)
+      attr(label, "srcfile") <- srcFileOfRef(srcref[[1]])
   }
   .subset2(x, 'impl')$defineOutput(name, value, label)
   return(invisible(x))

--- a/R/utils.R
+++ b/R/utils.R
@@ -488,6 +488,8 @@ checkAsIs <- function(options) {
 srcrefFromShinyCall <- function(expr) {
   srcrefs <- attr(expr, "srcref")
   num_exprs <- length(srcrefs)
+  if (num_exprs < 1)
+    return(NULL)
   c(srcrefs[[1]][1], srcrefs[[1]][2],
     srcrefs[[num_exprs]][3], srcrefs[[num_exprs]][4],
     srcrefs[[1]][5], srcrefs[[num_exprs]][6])


### PR DESCRIPTION
The Shiny output assignment currently assumes that the assignment will have the form 

```
output$foo <- bar({ expr })
```

and attempts to read source references from `{ expr }` for appropriate labeling in the reactive graph/Showcase mode. However, there's no guarantee that the right-hand side of the assignment has these characteristics, and when it doesn't a runtime error occurs.

This change does the minimum required to deal gracefully with the situation wherein outputs are assigned to zero-argument functions, or where the expressions don't have source references. 

(If more esoteric assignments are possible we might want to check more specifically to ensure that the RHS is a call with arguments.)