### PR TITLE
Fix PriorityQueue error message during roxygenize

### DIFF
--- a/R/react.R
+++ b/R/react.R
@@ -131,7 +131,7 @@ ReactiveEnvironment <- setRefClass(
   )
 )
 
-.reactiveEnvironment <- ReactiveEnvironment$new()
+delayedAssign(".reactiveEnvironment", ReactiveEnvironment$new())
 .getReactiveEnvironment <- function() {
   .reactiveEnvironment
 }

--- a/man/validateCssUnit.Rd
+++ b/man/validateCssUnit.Rd
@@ -6,8 +6,8 @@
 validateCssUnit(x)
 }
 \arguments{
-  \item{x}{The unit to validate. Will be treated as a
-  number of pixels if a unit is not specified.}
+\item{x}{The unit to validate. Will be treated as a number of pixels if a
+unit is not specified.}
 }
 \value{
 A properly formatted CSS unit of length, if possible. Otherwise, will


### PR DESCRIPTION
Fixes the following error during `roxygen2::roxygenize()`:

```
Error in .Object$initialize(...) : object 'PriorityQueue' not found
```