### PR TITLE
Prevent caching conditionally

### DIFF
--- a/R/app.R
+++ b/R/app.R
@@ -261,7 +261,9 @@ knit_print.shiny.tag <- function(x, ...) {
   content <- takeHeads(output)
   head_content <- doRenderTags(tagList(content$head))
 
-  meta <- list(structure(head_content, class = "shiny_head"))
+  meta <- if (length(head_content) > 1 || head_content != "") {
+    list(structure(head_content, class = "shiny_head"))
+  }
   meta <- c(meta, deps)
 
   knitr::asis_output(html_preserve(format(content$ui, indent=FALSE)), meta = meta)
@@ -269,7 +271,8 @@ knit_print.shiny.tag <- function(x, ...) {
 
 knit_print.html <- function(x, ...) {
   deps <- getNewestDeps(findDependencies(x))
-  knitr::asis_output(html_preserve(as.character(x)), meta = list(deps))
+  knitr::asis_output(html_preserve(as.character(x)),
+                     meta = if (length(deps)) list(deps))
 }
 
 #' @rdname knitr_methods


### PR DESCRIPTION
The basic reasoning of this PR:
- shiny app objects and render functions must never be cached, so we use `knitr::asis_output(..., cacheable = FALSE)`
- shiny tags and HTML objects can be cached only when they do not have dependencies (`length(meta) == 0`)
- the `cacheable` argument of `asis_output()` was added at https://github.com/yihui/knitr/commit/0d3ab27d8f1b7ae8530742fa69e9f658009cc4ac, so that this can be a general approach in knitr to stop improper caching (client packages only need to specify `cacheable = TRUE/FALSE`, instead of checking the chunk option `cache`)

@jcheng5 @jmcphers @jjallaire