### PR TITLE
Use standardized widths for selectize/jslider

### DIFF
--- a/inst/www/shared/shiny.css
+++ b/inst/www/shared/shiny.css
@@ -28,6 +28,11 @@ table.data td[align=right] {
   background-color: transparent !important;
 }
 
+span.jslider, .selectize-control {
+  width: 220px;
+  max-width: 95%;
+}
+
 .recalculating {
   opacity: 0.3;
   transition: opacity 250ms ease 500ms;


### PR DESCRIPTION
The 100% width worked well inside of a sidebar, but in other situations
like full-width columns or zero-min-width tables a fixed width is better.
If there's demand we can add parameters for setting the width to custom
values including 100%.