### PR TITLE
Fix #477: renderPlot in shinydoc with height > 400 overlaps subsequent c...

### DIFF
--- a/R/shinywrappers.R
+++ b/R/shinywrappers.R
@@ -84,7 +84,16 @@ renderPlot <- function(expr, width='auto', height='auto', res=72, ...,
   else
     heightWrapper <- NULL
 
-  return(markRenderFunction(plotOutput, function(shinysession, name, ...) {
+  # If renderPlot isn't going to adapt to the height of the div, then the
+  # div needs to adapt to the height of renderPlot. By default, plotOutput
+  # sets the height to 400px, so to make it adapt we need to override it
+  # with NULL.
+  outputFunc <- if (identical(height, 'auto'))
+    plotOutput
+  else
+    function(outputId) plotOutput(outputId, height = NULL)
+
+  return(markRenderFunction(outputFunc, function(shinysession, name, ...) {
     if (!is.null(widthWrapper))
       width <- widthWrapper()
     if (!is.null(heightWrapper))


### PR DESCRIPTION
...ontent