### PR TITLE
alias sidebarLayout to columnLayout

### DIFF
--- a/R/bootstrap-layout.R
+++ b/R/bootstrap-layout.R
@@ -276,6 +276,8 @@ sidebarLayout <- function(sidebarPanel,
     fixedRow(firstPanel, secondPanel)
 }
 
+columnLayout = sidebarLayout
+
 #' Lay out UI elements vertically
 #'
 #' Create a container that includes one or more rows of content (each element


### PR DESCRIPTION
Since sidebarPanel is its own concept, it's a bit confusing (especially in the tutorial) to have sidebarSomething contain both (mainThing, sidebarThing).