### PR TITLE
Suppress validation errors from printing at console

### DIFF
--- a/R/reactives.R
+++ b/R/reactives.R
@@ -373,7 +373,7 @@ Observable <- setRefClass(
       on.exit(.running <<- wasRunning)
 
       ctx$run(function() {
-        result <- withVisible(try(shinyCallingHandlers(.func()), silent=FALSE))
+        result <- withVisible(try(shinyCallingHandlers(.func()), silent=TRUE))
         .visible <<- result$visible
         .value <<- result$value
       })

--- a/R/utils.R
+++ b/R/utils.R
@@ -892,7 +892,7 @@ isTruthy <- function(x) {
 stopWithCondition <- function(class, message) {
   cond <- structure(
     list(message = message),
-    class = c(class, 'error', 'condition')
+    class = c(class, 'shiny.silent.error', 'error', 'condition')
   )
   stop(cond)
 }


### PR DESCRIPTION
We want regular errors from render functions to print at the console, but not validation errors.