### PR TITLE
Use svg version of build status. Only show master build status.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Shiny
 
-[![Build Status](https://travis-ci.org/rstudio/shiny.png)](https://travis-ci.org/rstudio/shiny)
+[![Build Status](https://travis-ci.org/rstudio/shiny.svg?branch=master)](https://travis-ci.org/rstudio/shiny)
 
 Shiny is a new package from RStudio that makes it incredibly easy to build interactive web applications with R.
 


### PR DESCRIPTION
Hey there, and thanks for this project and for making it available.

This here is a minor pull request that does 2 small things:
- Change the icon used for showing the build status to the svg version, so that it looks crisp and clear on retina displays (or generally I would say).
- Change the build status icon to only show status for master branch. For example when I looked at the source code now, it might seem that the build is failing for this project (never a good sign), but in fact it is only failing on the latest built branch, and not master. This commit changes that to only show how master is doing (which I assume is where the most stable code lives).

So if that is interesting, a pull request is provided. If that is not so interesting (or too minor to bother), then no biggie :)

Have a good day!