### PR TITLE
Bugfix/456

### DIFF
--- a/R/globals.R
+++ b/R/globals.R
@@ -5,5 +5,5 @@
   # R's lazy-loading package scheme causes the private seed to be cached in the
   # package itself, making our PRNG completely deterministic. This line resets
   # the private seed during load.
-  withPrivateSeed(set.seed(NULL))
+  withPrivateSeed(reinitializeSeed())
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -84,6 +84,15 @@ withPrivateSeed <- function(expr) {
   )
 }
 
+# a homemade version of set.seed(NULL) for backward compatibility with R 2.15.x
+reinitializeSeed <- if (getRversion() >= '3.0.0') {
+  function() set.seed(NULL)
+} else function() {
+  if (exists('.Random.seed', globalenv()))
+    rm(list = '.Random.seed', pos = globalenv())
+  runif(1)  # generate any random numbers so R can reinitialize the seed
+}
+
 # Version of runif that runs with private seed
 p_runif <- function(...) {
   withPrivateSeed(runif(...))


### PR DESCRIPTION
I wrote a version of `set.seed(NULL)` for R 2.15.x, `reinitializeSeed()`, which should achieve the same goal. The random seed is temporarily removed before generating a random number. Since this is called in `withPrivateSeed()`, the global random seed should not be affected after the call even it was removed internally.