### PR TITLE
stats may not have been loaded in the event of .onLoad()

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -90,7 +90,7 @@ reinitializeSeed <- if (getRversion() >= '3.0.0') {
 } else function() {
   if (exists('.Random.seed', globalenv()))
     rm(list = '.Random.seed', pos = globalenv())
-  runif(1)  # generate any random numbers so R can reinitialize the seed
+  stats::runif(1)  # generate any random numbers so R can reinitialize the seed
 }
 
 # Version of runif that runs with private seed


### PR DESCRIPTION
`.onLoad()` only guarantees the base package to be available; other packages have to be explicitly loaded, e.g. via `::`