### PR TITLE
Revert "tweak after #492: capture.output() does withVisible() and print(...

### DIFF
--- a/R/shinywrappers.R
+++ b/R/shinywrappers.R
@@ -124,9 +124,13 @@ renderPlot <- function(expr, width='auto', height='auto', res=72, ...,
 
     coordmap <- NULL
     plotFunc <- function() {
-      # Actually perform the plotting: use capture.output() to suppress output
-      # to console, and print func() if it returns a visible value
-      capture.output(func())
+      # Actually perform the plotting
+      result <- withVisible(func())
+      if (result$visible) {
+        # Use capture.output to squelch printing to the actual console; we
+        # are only interested in plot output
+        capture.output(print(result$value))
+      }
 
       # Now capture some graphics device info before we close it
       usrCoords <- par('usr')


### PR DESCRIPTION
...) if necessary"

This reverts commit 451f950d0dd54ad57ec5b9b5ab465a2ac6d29a9b.

Too-aggressive capture.output was causing browser() not to work in
renderPlot().