### PR TITLE
Emit R Markdown warnings for render* functions as well as shinyApps

### DIFF
--- a/R/app.R
+++ b/R/app.R
@@ -309,6 +309,7 @@ knit_print.shiny.render.function <- function(x, ..., inline = FALSE) {
   x <- htmltools::as.tags(x, inline = inline)
   output <- knitr::knit_print(tagList(x))
   attr(output, "knit_cacheable") <- FALSE
-  attr(output, "knit_meta") <- shiny_rmd_warning()
+  attr(output, "knit_meta") <- append(attr(output, "knit_meta"),
+                                      shiny_rmd_warning())
   output
 }


### PR DESCRIPTION
`shinyApp` objects in R Markdown documents will trigger a warning if you attempt to render them in static documents, but render functions (e.g. `renderPlot`) don't trigger that warning. This change fixes that.