### PR TITLE
use UTF-8 for showcase mode, and assume DESCRIPTION is also UTF-8

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -634,7 +634,9 @@ runApp <- function(appDir=getwd(),
   if (is.character(appDir)) {
     desc <- file.path.ci(appDir, "DESCRIPTION")
     if (file.exists(desc)) {
-      settings <- read.dcf(desc)
+      con <- file(desc, encoding = 'UTF-8')
+      on.exit(close(con), add = TRUE)
+      settings <- read.dcf(con)
       if ("DisplayMode" %in% colnames(settings)) {
         mode <- settings[1,"DisplayMode"]
         if (mode == "Showcase") {

--- a/R/showcase.R
+++ b/R/showcase.R
@@ -50,7 +50,7 @@ showcaseHead <- function() {
          href="shared/shiny-showcase.css"),
     if (file.exists(mdfile))
       script(type="text/markdown", id="showcase-markdown-content",
-        paste(readLines(mdfile, warn = FALSE), collapse="\n"))
+        paste(readLines(mdfile, warn = FALSE, encoding='UTF-8'), collapse="\n"))
     else ""
   ))
 
@@ -106,7 +106,8 @@ showcaseCodeTabs <- function(codeLicense) {
                   # we need to prevent the indentation of <code> ... </code>
                   HTML(format(tags$code(
                     class="language-r",
-                    paste(readLines(file.path.ci(getwd(), rFile), warn=FALSE),
+                    paste(readLines(file.path.ci(getwd(), rFile), warn=FALSE,
+                                    encoding='UTF-8'),
                           collapse="\n")
                   ), indent = FALSE))))
         })),


### PR DESCRIPTION
this time we should completely fix #136 now; I did not find other files that have to be read with UTF-8