### PR TITLE
replace `condition` in `conditionalPanel()` with `disable` and `hide`

### DIFF
--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -463,11 +463,12 @@ mainPanel <- function(..., width = 8) {
 #'     selectInput('xcol', 'X Variable', names(iris)),
 #'     selectInput('ycol', 'Y Variable', names(iris),
 #'                 selected=names(iris)[[2]]),
-#'     conditionalPanel(disable='input.xcol == "Sepal.Width"',
-#'                      hide='input.ycol == "Species"',
-#'                      numericInput('clusters', 'Cluster count', 3,
-#'                                   min = 1, max = 9)
-#'                      )
+#'     conditionalPanel(
+#'         disable='input.xcol == "Sepal.Width"',
+#'         hide='input.ycol == "Species"',
+#'         numericInput('clusters', 'Cluster count', 3,
+#'                      min = 1, max = 9)
+#'         )
 #'   ),
 #'   mainPanel(
 #'       plotOutput('plot1')

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -464,8 +464,7 @@ mainPanel <- function(..., width = 8) {
 #'     selectInput('ycol', 'Y Variable', names(iris),
 #'                 selected=names(iris)[[2]]),
 #'     conditionalPanel(disable='input.xcol == "Sepal.Width"',
-#'                      hide='input.ycol == "Sepal.Width"',
-#'                      'Hello World',
+#'                      hide='input.ycol == "Species"',
 #'                      numericInput('clusters', 'Cluster count', 3,
 #'                                   min = 1, max = 9)
 #'                      )
@@ -476,15 +475,13 @@ mainPanel <- function(..., width = 8) {
 #' ))
 #' @export
 conditionalPanel <- function(..., condition, disable, hide) {
-    if (! missing(condition)) {
-        args <- list('data-display-if'=condition)
-        div('data-display-if'=condition, ...)
-    } else {
-        args <- list()
+    args <- list()
+    if (! missing(condition)) args$'data-display-if' <- condition
+    else {
         if (! missing(disable)) args$'data-disable-if' <- disable
         if (! missing(hide)) args$'data-hide-if' <- hide
     }
-    do.call(div, c(args, ...))
+    do.call(div, c(args, substitute(...)))
 }
 
 #' Create a text input control

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -372,7 +372,7 @@ mainPanel <- function(..., width = 8) {
 #'
 #' Creates a panel that is visible, visible but subdued, or hidden,
 #' depending on the arguments provided. The JS expression(s) is
-#' evaluted once at startup and whenever Shiny detects a relevant
+#' evaluated once at startup and whenever Shiny detects a relevant
 #' change in input/output.
 #'
 #' If condition is provided then it does not make sense to provide

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -370,18 +370,39 @@ mainPanel <- function(..., width = 8) {
 
 #' Conditional Panel
 #'
-#' Creates a panel that is visible or not, depending on the value of a
-#' JavaScript expression. The JS expression is evaluated once at startup and
-#' whenever Shiny detects a relevant change in input/output.
+#' Creates a panel that is visible, visible but subdued, or hidden,
+#' depending on the arguments provided. The JS expression(s) is
+#' evaluted once at startup and whenever Shiny detects a relevant
+#' change in input/output.
 #'
-#' In the JS expression, you can refer to \code{input} and \code{output}
+#' If condition is provided then it does not make sense to provide
+#' disable or hide (therefore they are ignored if provided). However,
+#' disable and hide may be provided individually or together (with
+#' distinct logic). During the JavaScript execution, the check for
+#' hide is run last so it will take precedence.
+#'
+#' In the JS expression(s), you can refer to \code{input} and \code{output}
 #' JavaScript objects that contain the current values of input and output. For
 #' example, if you have an input with an id of \code{foo}, then you can use
 #' \code{input.foo} to read its value. (Be sure not to modify the input/output
 #' objects, as this may cause unpredictable behavior.)
 #'
+#' The use of condition and hide are logically opposite but are
+#' otherwise functionally identical: they cause the element to 'hide'
+#' or 'show' via jQuery UI events.
+#'
+#' When a disable expression is true, all encapsulated elements have
+#' their text color changed to #c2c2c2, and all encapsulated input
+#' elements have the "disabled" property set to true and have the
+#' "ui-state-disabled" class added to it. These elements are all
+#' reversed when the disable expression is false.
+#'
 #' @param condition A JavaScript expression that will be evaluated repeatedly to
 #'   determine whether the panel should be displayed.
+#' @param disable A JavaScript expression that will be evaluated repeatedly to
+#'   determine whether the panel should be disabled (shown but subdued).
+#' @param hide A JavaScript expression that will be evaluated repeatedly to
+#'   determine whether the panel should be hidden (not shown at all).
 #' @param ... Elements to include in the panel.
 #'
 #' @examples
@@ -409,9 +430,61 @@ mainPanel <- function(..., width = 8) {
 #'    )
 #' )
 #'
+#' ## equivalent functionally but with different visual results
+#' sidebarPanel(
+#'   selectInput(
+#'     "plotType", "Plot Type",
+#'       c(Scatter = "scatter",
+#'         Histogram = "hist")),
+#'
+#'    # Only show this panel if the plot type is a histogram
+#'    conditionalPanel(
+#'       disable = "input.plotType !== 'hist'",
+#'       selectInput(
+#'          "breaks", "Breaks",
+#'          c("Sturges",
+#'            "Scott",
+#'            "Freedman-Diaconis",
+#'            "[Custom]" = "custom")),
+#'
+#'       # Only show this panel if Custom is selected
+#'       conditionalPanel(
+#'          hide = "input.breaks !== 'custom'",
+#'          sliderInput("breakCount", "Break Count", min=1, max=1000, value=10)
+#'       )
+#'    )
+#' )
+#'
+#' ## using both disable and hide in the same conditionalPanel,
+#' ## derived from http://shiny.rstudio.com/gallery/kmeans-example.html
+#' shinyUI(pageWithSidebar(
+#'   headerPanel('Iris k-means clustering'),
+#'   sidebarPanel(
+#'     selectInput('xcol', 'X Variable', names(iris)),
+#'     selectInput('ycol', 'Y Variable', names(iris),
+#'                 selected=names(iris)[[2]]),
+#'     conditionalPanel(disable='input.xcol == "Sepal.Width"',
+#'                      hide='input.ycol == "Sepal.Width"',
+#'                      'Hello World',
+#'                      numericInput('clusters', 'Cluster count', 3,
+#'                                   min = 1, max = 9)
+#'                      )
+#'   ),
+#'   mainPanel(
+#'       plotOutput('plot1')
+#'   )
+#' ))
 #' @export
-conditionalPanel <- function(condition, ...) {
-  div('data-display-if'=condition, ...)
+conditionalPanel <- function(..., condition, disable, hide) {
+    if (! missing(condition)) {
+        args <- list('data-display-if'=condition)
+        div('data-display-if'=condition, ...)
+    } else {
+        args <- list()
+        if (! missing(disable)) args$'data-disable-if' <- disable
+        if (! missing(hide)) args$'data-hide-if' <- hide
+    }
+    do.call(div, c(args, ...))
 }
 
 #' Create a text input control

--- a/inst/www/shared/shiny.css
+++ b/inst/www/shared/shiny.css
@@ -144,3 +144,7 @@ span.jslider {
   border: 1px solid #e3e3e3;
   border-radius: 2px;
 }
+
+.shiny-text-disabled {
+  color: #c2c2c2;
+}

--- a/inst/www/shared/shiny.js
+++ b/inst/www/shared/shiny.js
@@ -771,18 +771,18 @@
 
         var elins = el.find('input');
         if (condFunc(scope)) {
-          elins.trigger('disable');
+          el.trigger('disable');
           elins.prop('disabled', true);
           elins.addClass('ui-state-disabled');
           el.addClass('shiny-text-disabled');
-          elins.show(0, triggerDisabled);
+          el.show(0, triggerDisabled);
         }
         else {
-          elins.trigger('show');
+          el.trigger('show');
           elins.prop('disabled', false);
           elins.removeClass('ui-state-disabled');
           el.removeClass('shiny-text-disabled');
-          elins.show(0, triggerShown);
+          el.show(0, triggerShown);
         }
       }
 

--- a/inst/www/shared/shiny.js
+++ b/inst/www/shared/shiny.js
@@ -734,6 +734,7 @@
       var scope = {input: inputs, output: this.$values};
 
       var triggerShown  = function() { $(this).trigger('shown'); };
+      var triggerDisabled = function() { $(this).trigger('disabled'); };
       var triggerHidden = function() { $(this).trigger('hidden'); };
 
       var conditionals = $(document).find('[data-display-if]');
@@ -754,6 +755,55 @@
         else {
           el.trigger('hide');
           el.hide(0, triggerHidden);
+        }
+      }
+
+      var disables = $(document).find('[data-disable-if]');
+      for (var i = 0; i < disables.length; i++) {
+        var el = $(disables[i]);
+        var condFunc = el.data('data-disable-if-func');
+
+        if (!condFunc) {
+          var condExpr = el.attr('data-disable-if');
+          condFunc = scopeExprToFunc(condExpr);
+          el.data('data-disable-if-func', condFunc);
+        }
+
+        var elins = el.find('input');
+        if (condFunc(scope)) {
+          elins.trigger('disable');
+          elins.prop('disabled', true);
+          elins.addClass('ui-state-disabled');
+          el.addClass('shiny-text-disabled');
+          elins.show(0, triggerDisabled);
+        }
+        else {
+          elins.trigger('show');
+          elins.prop('disabled', false);
+          elins.removeClass('ui-state-disabled');
+          el.removeClass('shiny-text-disabled');
+          elins.show(0, triggerShown);
+        }
+      }
+
+      var hides = $(document).find('[data-hide-if]');
+      for (var i = 0; i < hides.length; i++) {
+        var el = $(hides[i]);
+        var condFunc = el.data('data-hide-if-func');
+
+        if (!condFunc) {
+          var condExpr = el.attr('data-hide-if');
+          condFunc = scopeExprToFunc(condExpr);
+          el.data('data-hide-if-func', condFunc);
+        }
+
+        if (condFunc(scope)) {
+          el.trigger('hide');
+          el.hide(0, triggerHidden);
+        }
+        else {
+          el.trigger('show');
+          el.show(0, triggerShown);
         }
       }
     };

--- a/man/conditionalPanel.Rd
+++ b/man/conditionalPanel.Rd
@@ -9,19 +9,42 @@ conditionalPanel(condition, ...)
 \item{condition}{A JavaScript expression that will be evaluated repeatedly to
 determine whether the panel should be displayed.}
 
+\item{disable}{A JavaScript expression that will be evaluated repeatedly
+to determine whether the panel should be disabled (shown but subdued).}
+
+\item{hide}{A JavaScript expression that will be evaluated repeatedly to
+determine whether the panel should be hidden (not shown at all).}
+
 \item{...}{Elements to include in the panel.}
 }
 \description{
-Creates a panel that is visible or not, depending on the value of a
-JavaScript expression. The JS expression is evaluated once at startup and
-whenever Shiny detects a relevant change in input/output.
+Creates a panel that is visible, visible but subdued, or hidden,
+depending on the arguments provided. The JS expression(s) is evaluated
+once at startup and whenever Shiny detects a relevant change in
+input/output.
 }
 \details{
+If condition is provided then it does not make sense to provide disable
+or hide (therefore they are ignored if provided). However, disable and
+hide may be provided individually or together (with distinct logic).
+During the JavaScript execution, the check for hide is run last so it
+will take precedence.
+
 In the JS expression, you can refer to \code{input} and \code{output}
 JavaScript objects that contain the current values of input and output. For
 example, if you have an input with an id of \code{foo}, then you can use
 \code{input.foo} to read its value. (Be sure not to modify the input/output
 objects, as this may cause unpredictable behavior.)
+
+The use of condition and hide are logically opposite but are otherwise
+functionally identical: they cause the element to 'hide' or 'show' via
+jQuery UI events.
+
+When a disable expression is true, all encapsulated elements have their
+text color changed to #c2c2c2, and all encapsulated input elements have
+the "disabled" property set to true and have the "ui-state-disabled"
+class added to it. These elements are all reversed when the disable
+expression is false.
 }
 \examples{
 sidebarPanel(
@@ -47,5 +70,49 @@ sidebarPanel(
       )
    )
 )
+
+## equivalent functionally but with different visual results
+sidebarPanel(
+  selectInput(
+    "plotType", "Plot Type",
+      c(Scatter = "scatter",
+        Histogram = "hist")),
+
+   # Only show this panel if the plot type is a histogram
+   conditionalPanel(
+      disable = "input.plotType !== 'hist'",
+      selectInput(
+         "breaks", "Breaks",
+         c("Sturges",
+           "Scott",
+           "Freedman-Diaconis",
+           "[Custom]" = "custom")),
+
+      # Only show this panel if Custom is selected
+      conditionalPanel(
+         hide = "input.breaks !== 'custom'",
+         sliderInput("breakCount", "Break Count", min=1, max=1000, value=10)
+      )
+   )
+)
+
+## using both disable and hide in the same conditionalPanel,
+## derived from http://shiny.rstudio.com/gallery/kmeans-example.html
+shinyUI(pageWithSidebar(
+  headerPanel('Iris k-means clustering'),
+  sidebarPanel(
+    selectInput('xcol', 'X Variable', names(iris)),
+    selectInput('ycol', 'Y Variable', names(iris),
+                selected=names(iris)[[2]]),
+    conditionalPanel(disable='input.xcol == "Sepal.Width"',
+                     hide='input.ycol == "Species"',
+                     numericInput('clusters', 'Cluster count', 3,
+                                  min = 1, max = 9)
+                     )
+  ),
+  mainPanel(
+      plotOutput('plot1')
+  )
+))
 }
 

--- a/man/conditionalPanel.Rd
+++ b/man/conditionalPanel.Rd
@@ -104,11 +104,12 @@ shinyUI(pageWithSidebar(
     selectInput('xcol', 'X Variable', names(iris)),
     selectInput('ycol', 'Y Variable', names(iris),
                 selected=names(iris)[[2]]),
-    conditionalPanel(disable='input.xcol == "Sepal.Width"',
-                     hide='input.ycol == "Species"',
-                     numericInput('clusters', 'Cluster count', 3,
-                                  min = 1, max = 9)
-                     )
+    conditionalPanel(
+        disable='input.xcol == "Sepal.Width"',
+        hide='input.ycol == "Species"',
+        numericInput('clusters', 'Cluster count', 3,
+                     min = 1, max = 9)
+        )
   ),
   mainPanel(
       plotOutput('plot1')

--- a/man/conditionalPanel.Rd
+++ b/man/conditionalPanel.Rd
@@ -3,7 +3,7 @@
 \alias{conditionalPanel}
 \title{Conditional Panel}
 \usage{
-conditionalPanel(condition, ...)
+conditionalPanel(..., condition, disable, hide)
 }
 \arguments{
 \item{condition}{A JavaScript expression that will be evaluated repeatedly to


### PR DESCRIPTION
I wanted to be able to keep an element within view (both for spacing and for the visual effect of it being immutable), so I added two optional arguments to `conditionalPanel()`: `disable` and `hide`.

`hide` is merely a reversal logically from `condition`. In fact, if you accept that having disable/hide as options is relevant, I suggest that deprecating `condition` might be appropriate.

`disable` was a little more challenging and admittedly not as "global" in its capabilities. Namely, it currently only affects text and input fields. For text, it just adds `.shiny-text-disabled` (a new class in shiny.css that lightens the font color). For input elements, it also disables the elements two ways (using `.ui-state-disabled` from jQuery ui and the `disabled` HTML5 property).

There might be a way to broaden this to other types of elements (e.g., images and plots), but I'm not certain how to do that with plots that shiny touches. My vision has an output plot graying out and not updating with input changes, but this would probably require a bit more JS <--> Shiny interaction than I'm able to tackle at the moment.

Tested using the kmeans-example on win7, R-3.1.0, chrome 35.0.1916.153 m. (Perhaps this time the travis-CI test will pass.)