### PR TITLE
remove addResourcePath warning for overriding an existing prefix

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -169,13 +169,6 @@ addResourcePath <- function(prefix, directoryPath) {
 
   existing <- .globals$resources[[prefix]]
 
-  if (!is.null(existing)) {
-    if (!identical(existing$directoryPath, directoryPath)) {
-      warning("Overriding existing prefix ", prefix, " => ",
-              existing$directoryPath)
-    }
-  }
-
   .globals$resources[[prefix]] <- list(directoryPath=directoryPath,
                                        func=staticHandler(directoryPath))
 }


### PR DESCRIPTION
As per comment from @jcheng5 "I think maybe we should just remove the addResourcePath warning, it seems to only have caused confusion and problems."