### PR TITLE
Add `position` parameter to `navbarPage`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -37,6 +37,8 @@ shiny 0.10.1.9xxx
 
 * Fixes to rounding behavior of sliderInput. (#301, #502)
 
+* Added `position` parameter to `navbarPage`.
+
 shiny 0.10.1
 --------------------------------------------------------------------------------
 

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -144,6 +144,13 @@ pageWithSidebar <- function(headerPanel,
 #'   server logic to determine which of the current tabs is active. The value
 #'   will correspond to the \code{value} argument that is passed to
 #'   \code{\link{tabPanel}}.
+#' @param position Determines whether the navbar should be displayed at the top
+#'   of the page with normal scrolling behavior (\code{"static-top"}), pinned
+#'   at the top (\code{"fixed-top"}), or pinned at the bottom
+#'   (\code{"fixed-bottom"}). Note that using \code{"fixed-top"} or
+#'   \code{"fixed-bottom"} will cause the navbar to overlay your body content,
+#'   unless you add padding, e.g.:
+#'   \code{tags$style(type="text/css", "body {padding-top: 70px;}")}
 #' @param header Tag of list of tags to display as a common header above all
 #'   tabPanels.
 #' @param footer Tag or list of tags to display as a common footer below all
@@ -190,6 +197,7 @@ pageWithSidebar <- function(headerPanel,
 navbarPage <- function(title,
                        ...,
                        id = NULL,
+                       position = c("static-top", "fixed-top", "fixed-bottom"),
                        header = NULL,
                        footer = NULL,
                        inverse = FALSE,
@@ -203,7 +211,10 @@ navbarPage <- function(title,
   pageTitle <- title
 
   # navbar class based on options
-  navbarClass <- "navbar navbar-static-top"
+  navbarClass <- "navbar"
+  position <- match.arg(position)
+  if (!is.null(position))
+    navbarClass <- paste(navbarClass, " navbar-", position, sep = "")
   if (inverse)
     navbarClass <- paste(navbarClass, "navbar-inverse")
 

--- a/man/navbarPage.Rd
+++ b/man/navbarPage.Rd
@@ -4,9 +4,10 @@
 \alias{navbarPage}
 \title{Create a page with a top level navigation bar}
 \usage{
-navbarPage(title, ..., id = NULL, header = NULL, footer = NULL,
-  inverse = FALSE, collapsable = FALSE, fluid = TRUE, responsive = TRUE,
-  theme = NULL, windowTitle = title)
+navbarPage(title, ..., id = NULL, position = c("static-top", "fixed-top",
+  "fixed-bottom"), header = NULL, footer = NULL, inverse = FALSE,
+  collapsable = FALSE, fluid = TRUE, responsive = TRUE, theme = NULL,
+  windowTitle = title)
 
 navbarMenu(title, ..., icon = NULL)
 }
@@ -19,6 +20,14 @@ navbarMenu(title, ..., icon = NULL)
 server logic to determine which of the current tabs is active. The value
 will correspond to the \code{value} argument that is passed to
 \code{\link{tabPanel}}.}
+
+\item{position}{Determines whether the navbar should be displayed at the top
+of the page with normal scrolling behavior (\code{"static-top"}), pinned
+at the top (\code{"fixed-top"}), or pinned at the bottom
+(\code{"fixed-bottom"}). Note that using \code{"fixed-top"} or
+\code{"fixed-bottom"} will cause the navbar to overlay your body content,
+unless you add padding, e.g.:
+\code{tags$style(type="text/css", "body {padding-top: 70px;}")}}
 
 \item{header}{Tag of list of tags to display as a common header above all
 tabPanels.}


### PR DESCRIPTION
In response to a query by a customer via @garrettgman.

The only problem is that in the RStudio captive Shiny browser, the `fixed-top` and `fixed-bottom` options don't actually seem to work--not sure what's up with that. (Tested on Mac using v0.98.1049, the installed Safari is Version 7.0.6 (9537.78.2).)