### PR TITLE
fixes #605: send DT requests via POST instead of the default GET

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -613,7 +613,9 @@ Callbacks <- R6Class(
 # convert a data frame to JSON as required by DataTables request
 dataTablesJSON <- function(data, req) {
   n <- nrow(data)
-  q <- parseQueryString(req$QUERY_STRING, nested = TRUE)
+  # DataTables requests were sent via POST
+  params <- URLdecode(rawToChar(req$rook.input$read()))
+  q <- parseQueryString(params, nested = TRUE)
   ci <- q$search[['caseInsensitive']] == 'true'
 
   # global searching

--- a/inst/www/shared/shiny.js
+++ b/inst/www/shared/shiny.js
@@ -1605,6 +1605,7 @@
         "pageLength": 25,
         "ajax": {
           "url": data.action,
+          "type": "POST",
           "data": function(d) {
             d.search.caseInsensitive = searchCI;
           }


### PR DESCRIPTION
I have tested it with a few examples, and I did not see problems.

BTW, URLencode() and URLdecode() are pretty slow in base R, and I'm wondering if anyone is interested in rewriting them in C or C++. It should be very simple to rewrite them, but I have little experience in C/C++. The slowness should rarely matter, though, since the URL's to be processed are normally relatively short. I tested a character string of 200K, and URLdecode() can take 40 seconds to decode it. Below is a version of URLdecode() that I rewrote in R, which is 4-5x faster than the version in base R:

``` r
URLdecode2 = function(URL) {
  i = grep('%', URL)
  if (length(i) == 0) return(URL)
  r = paste(c('(%[', 0:9, letters[1:6], LETTERS[1:6], ']{2})+'), collapse = '')
  m = gregexpr(r, URL[i])
  d = regmatches(URL[i], m)
  regmatches(URL[i], m) = lapply(d, function(x) {
    x = sub('^%', '', x)
    unlist(lapply(strsplit(x, '%'), function(y) {
      paste(rawToChar(as.raw(strtoi(y, base = 16L))), collapse = '')
    }), recursive = FALSE, use.names = FALSE)
  })
  URL
}

library(microbenchmark)
random_str = function(n = 1e4) {
  paste(sample(intToUtf8(32:126, TRUE), n, TRUE), collapse = '')
}
x1 = random_str()
x2 = URLencode(x1)
URLdecode(x2) == URLdecode2(x2)
microbenchmark(URLdecode(x2), URLdecode2(x2))
# Unit: milliseconds
#            expr       min       lq      mean    median        uq       max neval cld
#   URLdecode(x2) 122.51090 124.0641 127.65125 124.77060 125.93105 165.38639   100   b
#  URLdecode2(x2)  33.15977  33.6150  34.22284  33.99325  34.32527  42.38638   100  a 

x1 = random_str(1e5)
x2 = URLencode(x1)
URLdecode(x2) == URLdecode2(x2)
microbenchmark(URLdecode(x2), URLdecode2(x2), times = 5)
# Unit: seconds
#            expr       min        lq     mean    median        uq       max neval cld
#   URLdecode(x2) 10.820688 10.851309 11.00779 11.013830 11.060390 11.292717     5   b
#  URLdecode2(x2)  2.448762  2.509012  2.50850  2.510879  2.525043  2.548805     5  a 
```