### PR TITLE
encode the JSON response for DataTables/selectize with UTF-8

### DIFF
--- a/R/update-input.R
+++ b/R/update-input.R
@@ -476,5 +476,6 @@ selectizeJSON <- function(data, req) {
   idx <- head(which(idx), mop)
   data <- data[idx, ]
 
-  httpResponse(200, 'application/json', toJSON(columnToRowData(data)))
+  res <- toJSON(columnToRowData(data))
+  httpResponse(200, 'application/json', enc2utf8(res))
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -690,7 +690,7 @@ dataTablesJSON <- function(data, req) {
     recordsFiltered = nrow(data),
     data = fdata
   ))
-  httpResponse(200, 'application/json', res)
+  httpResponse(200, 'application/json', enc2utf8(res))
 }
 
 # when both ignore.case and fixed are TRUE, we use grep(ignore.case = FALSE,


### PR DESCRIPTION
to make sure multibyte characters in DataTables/selectize work