### PR TITLE
Make default reactive domain available in request handlers. Fixes #669

### DIFF
--- a/R/middleware-shiny.R
+++ b/R/middleware-shiny.R
@@ -35,7 +35,9 @@ sessionHandler <- function(req) {
   subreq$PATH_INFO <- subpath
   subreq$SCRIPT_NAME <- paste(subreq$SCRIPT_NAME, matches[[1]][2], sep='')
 
-  return(shinysession$handleRequest(subreq))
+  withReactiveDomain(shinysession$session, {
+    shinysession$handleRequest(subreq)
+  })
 }
 
 dynamicHandler <- function(filePath, dependencyFiles=filePath) {


### PR DESCRIPTION
Progress bar now works properly with an app like this:

``` R
shinyApp(
  ui = bootstrapPage(
    downloadLink('download')
    # textOutput('txt')
  ),
  server = function(input, output, session) {
    output$download <- downloadHandler(
      'foo.txt',
      function(file) {
        withProgress({

          for (i in 1:5) {
            incProgress()
            Sys.sleep(0.2)
          }

          writeLines("test file", con = file)
        })
      }
    )
  }
)
```