### PR TITLE
Specifying destination file for runURL, runGist, and runGitHub

### DIFF
--- a/R/run-url.R
+++ b/R/run-url.R
@@ -25,7 +25,7 @@
 #' runUrl("https://github.com/rstudio/shiny_example/archive/master.zip",
 #'  subdir = "inst/shinyapp/")
 #' }
-runUrl <- function(url, filetype = NULL, subdir = NULL, ...) {
+runUrl <- function(url, filetype = NULL, subdir = NULL, destFile = NULL, ...) {
 
   if (!is.null(subdir) && ".." %in% strsplit(subdir, '/')[[1]])
     stop("'..' not allowed in subdir")
@@ -43,8 +43,14 @@ runUrl <- function(url, filetype = NULL, subdir = NULL, ...) {
     stop("Unknown file extension.")
 
   message("Downloading ", url)
-  filePath <- tempfile('shinyapp', fileext=fileext)
-  fileDir  <- tempfile('shinyapp')
+  if (is.null(destFile)) {
+    filePath <- tempfile('shinyapp', fileext = fileext)
+    fileDir  <- tempfile('shinyapp')
+  } else {
+    fileDir <- destFile
+    filePath <- paste(destFile, fileext)
+  }
+  message("App data files in ", fileDir)
   dir.create(fileDir, showWarnings = FALSE)
   if (download(url, filePath, mode = "wb", quiet = TRUE) != 0)
     stop("Failed to download URL ", url)
@@ -88,7 +94,7 @@ runUrl <- function(url, filetype = NULL, subdir = NULL, ...) {
 #' runGist("https://gist.github.com/3239667")
 #' }
 #'
-runGist <- function(gist, ...) {
+runGist <- function(gist, destFile = NULL, ...) {
 
   gistUrl <- if (is.numeric(gist) || grepl('^[0-9a-f]+$', gist)) {
     sprintf('https://gist.github.com/%s/download', gist)
@@ -98,7 +104,7 @@ runGist <- function(gist, ...) {
     stop('Unrecognized gist identifier format')
   }
 
-  runUrl(gistUrl, filetype=".tar.gz", ...)
+  runUrl(gistUrl, filetype = ".tar.gz", destFile = destFile, ...)
 }
 
 
@@ -118,7 +124,7 @@ runGist <- function(gist, ...) {
 #' runGitHub("shiny_example", "rstudio", subdir = "inst/shinyapp/")
 #' }
 runGitHub <- function(repo, username = getOption("github.user"),
-                      ref = "master", subdir = NULL, ...) {
+                      ref = "master", subdir = NULL, destFile = NULL, ...) {
 
   if (grepl('/', repo)) {
     res <- strsplit(repo, '/')[[1]]
@@ -130,5 +136,5 @@ runGitHub <- function(repo, username = getOption("github.user"),
   url <- paste("https://github.com/", username, "/", repo, "/archive/",
                ref, ".tar.gz", sep = "")
 
-  runUrl(url, subdir=subdir, ...)
+  runUrl(url, subdir = subdir, destFile = destFile, ...)
 }

--- a/R/run-url.R
+++ b/R/run-url.R
@@ -14,7 +14,9 @@
 #' @param subdir A subdirectory in the repository that contains the app. By
 #'   default, this function will run an app from the top level of the repo, but
 #'   you can use a path such as `\code{"inst/shinyapp"}.
-#' @param destDir Directory to store the downloaded application files
+#' @param destdir Directory to store the downloaded application files. If \code{NULL}
+#'   (the default), the application files will be stored in a temporary directory
+#'   and removed when the app exits
 #' @param ... Other arguments to be passed to \code{\link{runApp}()}, such as
 #'   \code{port} and \code{launch.browser}.
 #' @export
@@ -26,7 +28,7 @@
 #' runUrl("https://github.com/rstudio/shiny_example/archive/master.zip",
 #'  subdir = "inst/shinyapp/")
 #' }
-runUrl <- function(url, filetype = NULL, subdir = NULL, destDir = NULL, ...) {
+runUrl <- function(url, filetype = NULL, subdir = NULL, destdir = NULL, ...) {
 
   if (!is.null(subdir) && ".." %in% strsplit(subdir, '/')[[1]])
     stop("'..' not allowed in subdir")
@@ -44,14 +46,14 @@ runUrl <- function(url, filetype = NULL, subdir = NULL, destDir = NULL, ...) {
     stop("Unknown file extension.")
 
   message("Downloading ", url)
-  if (is.null(destDir)) {
+  if (is.null(destdir)) {
     filePath <- tempfile('shinyapp', fileext = fileext)
     fileDir  <- tempfile('shinyapp')
   } else {
-    fileDir <- destDir
-    filePath <- paste(destDir, fileext)
+    fileDir <- destdir
+    filePath <- paste(destdir, fileext)
   }
-  message("App data files in ", fileDir)
+
   dir.create(fileDir, showWarnings = FALSE)
   if (download(url, filePath, mode = "wb", quiet = TRUE) != 0)
     stop("Failed to download URL ", url)
@@ -72,7 +74,7 @@ runUrl <- function(url, filetype = NULL, subdir = NULL, destDir = NULL, ...) {
     unzip(filePath, exdir = fileDir)
   }
 
-  if(is.null(destDir)){
+  if(is.null(destdir)){
     on.exit(unlink(fileDir, recursive = TRUE), add = TRUE)
   }
   
@@ -88,7 +90,9 @@ runUrl <- function(url, filetype = NULL, subdir = NULL, destDir = NULL, ...) {
 #'   https://gist.github.com/jcheng5/3239667, then \code{3239667},
 #'   \code{'3239667'}, and \code{'https://gist.github.com/jcheng5/3239667'} are
 #'   all valid values.
-#' @param destDir Directory to store the downloaded gist.
+#' @param destdir Directory to store the downloaded gist. If \code{NULL}
+#'   (the default), the application files will be stored in a temporary directory
+#'   and removed when the app exits
 #' @export
 #' @examples
 #' \donttest{
@@ -99,7 +103,7 @@ runUrl <- function(url, filetype = NULL, subdir = NULL, destDir = NULL, ...) {
 #' runGist("https://gist.github.com/3239667")
 #' }
 #'
-runGist <- function(gist, destDir = NULL, ...) {
+runGist <- function(gist, destdir = NULL, ...) {
 
   gistUrl <- if (is.numeric(gist) || grepl('^[0-9a-f]+$', gist)) {
     sprintf('https://gist.github.com/%s/download', gist)
@@ -109,7 +113,7 @@ runGist <- function(gist, destDir = NULL, ...) {
     stop('Unrecognized gist identifier format')
   }
 
-  runUrl(gistUrl, filetype = ".tar.gz", destDir = destDir, ...)
+  runUrl(gistUrl, filetype = ".tar.gz", destdir = destdir, ...)
 }
 
 
@@ -119,7 +123,9 @@ runGist <- function(gist, destDir = NULL, ...) {
 #'   \code{"username/repo"}, \code{username} will be taken from \code{repo}.
 #' @param ref Desired git reference. Could be a commit, tag, or branch name.
 #'   Defaults to \code{"master"}.
-#' @param destDir Directory to store the downloaded repository.
+#' @param destdir Directory to store the downloaded repository. If \code{NULL}
+#'   (the default), the application files will be stored in a temporary directory
+#'   and removed when the app exits
 #' @export
 #' @examples
 #' \donttest{
@@ -130,7 +136,7 @@ runGist <- function(gist, destDir = NULL, ...) {
 #' runGitHub("shiny_example", "rstudio", subdir = "inst/shinyapp/")
 #' }
 runGitHub <- function(repo, username = getOption("github.user"),
-                      ref = "master", subdir = NULL, destDir = NULL, ...) {
+                      ref = "master", subdir = NULL, destdir = NULL, ...) {
 
   if (grepl('/', repo)) {
     res <- strsplit(repo, '/')[[1]]
@@ -142,5 +148,5 @@ runGitHub <- function(repo, username = getOption("github.user"),
   url <- paste("https://github.com/", username, "/", repo, "/archive/",
                ref, ".tar.gz", sep = "")
 
-  runUrl(url, subdir = subdir, destDir = destDir, ...)
+  runUrl(url, subdir = subdir, destdir = destdir, ...)
 }

--- a/R/run-url.R
+++ b/R/run-url.R
@@ -14,6 +14,7 @@
 #' @param subdir A subdirectory in the repository that contains the app. By
 #'   default, this function will run an app from the top level of the repo, but
 #'   you can use a path such as `\code{"inst/shinyapp"}.
+#' @param destDir Directory to store the downloaded application files
 #' @param ... Other arguments to be passed to \code{\link{runApp}()}, such as
 #'   \code{port} and \code{launch.browser}.
 #' @export
@@ -25,7 +26,7 @@
 #' runUrl("https://github.com/rstudio/shiny_example/archive/master.zip",
 #'  subdir = "inst/shinyapp/")
 #' }
-runUrl <- function(url, filetype = NULL, subdir = NULL, destFile = NULL, ...) {
+runUrl <- function(url, filetype = NULL, subdir = NULL, destDir = NULL, ...) {
 
   if (!is.null(subdir) && ".." %in% strsplit(subdir, '/')[[1]])
     stop("'..' not allowed in subdir")
@@ -43,12 +44,12 @@ runUrl <- function(url, filetype = NULL, subdir = NULL, destFile = NULL, ...) {
     stop("Unknown file extension.")
 
   message("Downloading ", url)
-  if (is.null(destFile)) {
+  if (is.null(destDir)) {
     filePath <- tempfile('shinyapp', fileext = fileext)
     fileDir  <- tempfile('shinyapp')
   } else {
-    fileDir <- destFile
-    filePath <- paste(destFile, fileext)
+    fileDir <- destDir
+    filePath <- paste(destDir, fileext)
   }
   message("App data files in ", fileDir)
   dir.create(fileDir, showWarnings = FALSE)
@@ -84,6 +85,7 @@ runUrl <- function(url, filetype = NULL, subdir = NULL, destFile = NULL, ...) {
 #'   https://gist.github.com/jcheng5/3239667, then \code{3239667},
 #'   \code{'3239667'}, and \code{'https://gist.github.com/jcheng5/3239667'} are
 #'   all valid values.
+#' @param destDir Directory to store the downloaded gist.
 #' @export
 #' @examples
 #' \donttest{
@@ -94,7 +96,7 @@ runUrl <- function(url, filetype = NULL, subdir = NULL, destFile = NULL, ...) {
 #' runGist("https://gist.github.com/3239667")
 #' }
 #'
-runGist <- function(gist, destFile = NULL, ...) {
+runGist <- function(gist, destDir = NULL, ...) {
 
   gistUrl <- if (is.numeric(gist) || grepl('^[0-9a-f]+$', gist)) {
     sprintf('https://gist.github.com/%s/download', gist)
@@ -104,7 +106,7 @@ runGist <- function(gist, destFile = NULL, ...) {
     stop('Unrecognized gist identifier format')
   }
 
-  runUrl(gistUrl, filetype = ".tar.gz", destFile = destFile, ...)
+  runUrl(gistUrl, filetype = ".tar.gz", destDir = destDir, ...)
 }
 
 
@@ -114,6 +116,7 @@ runGist <- function(gist, destFile = NULL, ...) {
 #'   \code{"username/repo"}, \code{username} will be taken from \code{repo}.
 #' @param ref Desired git reference. Could be a commit, tag, or branch name.
 #'   Defaults to \code{"master"}.
+#' @param destDir Directory to store the downloaded repository.
 #' @export
 #' @examples
 #' \donttest{
@@ -124,7 +127,7 @@ runGist <- function(gist, destFile = NULL, ...) {
 #' runGitHub("shiny_example", "rstudio", subdir = "inst/shinyapp/")
 #' }
 runGitHub <- function(repo, username = getOption("github.user"),
-                      ref = "master", subdir = NULL, destFile = NULL, ...) {
+                      ref = "master", subdir = NULL, destDir = NULL, ...) {
 
   if (grepl('/', repo)) {
     res <- strsplit(repo, '/')[[1]]
@@ -136,5 +139,5 @@ runGitHub <- function(repo, username = getOption("github.user"),
   url <- paste("https://github.com/", username, "/", repo, "/archive/",
                ref, ".tar.gz", sep = "")
 
-  runUrl(url, subdir = subdir, destFile = destFile, ...)
+  runUrl(url, subdir = subdir, destDir = destDir, ...)
 }

--- a/R/run-url.R
+++ b/R/run-url.R
@@ -71,7 +71,7 @@ runUrl <- function(url, filetype = NULL, subdir = NULL, destDir = NULL, ...) {
     first <- as.character(unzip(filePath, list=TRUE)$Name)[1]
     unzip(filePath, exdir = fileDir)
   }
-  on.exit(unlink(fileDir, recursive = TRUE), add = TRUE)
+  on.exit(unlink(fileDir, recursive = is.null(destDir)), add = TRUE)
 
   appdir <- file.path(fileDir, first)
   if (!file_test('-d', appdir)) appdir <- dirname(appdir)

--- a/R/run-url.R
+++ b/R/run-url.R
@@ -71,8 +71,11 @@ runUrl <- function(url, filetype = NULL, subdir = NULL, destDir = NULL, ...) {
     first <- as.character(unzip(filePath, list=TRUE)$Name)[1]
     unzip(filePath, exdir = fileDir)
   }
-  on.exit(unlink(fileDir, recursive = is.null(destDir)), add = TRUE)
 
+  if(is.null(destDir)){
+    on.exit(unlink(fileDir, recursive = TRUE), add = TRUE)
+  }
+  
   appdir <- file.path(fileDir, first)
   if (!file_test('-d', appdir)) appdir <- dirname(appdir)
 


### PR DESCRIPTION
Currently, when users run an application from a URL, gist, or GitHub repository, the source files are downloaded to a temporary file and immediately removed when the application is exited. It'd be useful to change this behavior and download the source files to a destination directory so that users can make modifications locally.

This pull request adds options to runUrl, runGist, and runGitHub so that users can save the downloaded application source files to a specific destination directory. This is done through the additional option destDir = ... in runUrl, runGist, and runGitHub. Default is NULL and gives the original behavior.