### PR TITLE
Allow control over selectize width

### DIFF
--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -800,13 +800,14 @@ selectInput <- function(inputId, label, choices, selected = NULL,
   # return label and select tag
   res <- div(
     class = "form-group shiny-input-container",
+    style = if (!is.null(width)) paste0("width: ", validateCssUnit(width)),
     controlLabel(inputId, label),
     div(selectTag)
   )
 
   if (!selectize) return(res)
 
-  selectizeIt(inputId, res, NULL, width, nonempty = !multiple && !("" %in% choices))
+  selectizeIt(inputId, res, NULL, nonempty = !multiple && !("" %in% choices))
 }
 
 firstChoice <- function(choices) {
@@ -865,11 +866,15 @@ needOptgroup <- function(choices) {
 #'   \code{selectInput(..., selectize = FALSE)}.
 #' @export
 selectizeInput <- function(inputId, ..., options = NULL, width = NULL) {
-  selectizeIt(inputId, selectInput(inputId, ..., selectize = FALSE), options, width)
+  selectizeIt(
+    inputId,
+    selectInput(inputId, ..., selectize = FALSE, width = width),
+    options
+  )
 }
 
 # given a select input and its id, selectize it
-selectizeIt <- function(inputId, select, options, width = NULL, nonempty = FALSE) {
+selectizeIt <- function(inputId, select, options, nonempty = FALSE) {
   res <- checkAsIs(options)
 
   selectizeDep <- htmlDependency(
@@ -890,7 +895,6 @@ selectizeIt <- function(inputId, select, options, width = NULL, nonempty = FALSE
       type = 'application/json',
       `data-for` = inputId, `data-nonempty` = if (nonempty) '',
       `data-eval` = if (length(res$eval)) HTML(toJSON(res$eval)),
-      `data-width` = validateCssUnit(width),
       if (length(res$options)) HTML(toJSON(res$options)) else '{}'
     )
   )

--- a/inst/www/shared/shiny.css
+++ b/inst/www/shared/shiny.css
@@ -181,3 +181,8 @@ table.data td[align=right] {
 .well .shiny-input-container {
   width: auto;
 }
+
+/* Width of non-selectize select inputs */
+.shiny-input-container > div > select:not(.selectized) {
+  width: 100%;
+}

--- a/inst/www/shared/shiny.js
+++ b/inst/www/shared/shiny.js
@@ -2378,7 +2378,6 @@
         control.destroy();
         control = $el.selectize(settings)[0].selectize;
       }
-      $el.next('div.selectize-control').css('width', config.data('width'));
       return control;
     }
   });


### PR DESCRIPTION
Fixes one of the issues raised in the comments of #675.

Previously, you could set the width of a selectInput with a pixel value like `"500px"`, but it wouldn't respect percent widths like `"100%"`. This commit makes `width` control the wrapper container's width, instead of setting the `data-width`, so it will respect percent values.

This commit also allows control over non-selectize select inputs.

All of these work now:

```R
library(shiny)
shinyApp(
  ui = fluidPage(
    selectInput("n", "default", c(5, 10, 100), selectize = FALSE),
    selectInput("n2", "100%", c(5, 10, 100), selectize = FALSE, width="100%"),
    selectInput("n3", "500px", c(5, 10, 100), selectize = FALSE, width="500px"),

    selectInput("n4", "default", c(5, 10, 100)),
    selectInput("n5", "100%", c(5, 10, 100), width="100%"),
    selectInput("n6", "500px", c(5, 10, 100), width="500px"),

    selectizeInput("n7", "default", c(5, 10, 100)),
    selectizeInput("n8", "100%", c(5, 10, 100), width="100%"),
    selectizeInput("n9", "500px", c(5, 10, 100), width="500px"),
    plotOutput("plot")
  ),
  server = function(input, output) {
    output$plot <- renderPlot( plot(head(cars, as.numeric(input$n))) )
  }
)
```

@yihui Do you see potential pitfalls with doing it this way? It seems to me that the reason the previous version used `data-width` was because it didn't have a wrapper div around the select.
