### PR TITLE
htmlOutput: allow custom container function

### DIFF
--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -1877,6 +1877,9 @@ dataTableOutput <- function(outputId) {
 htmlOutput <- function(outputId, inline = FALSE,
   container = if (inline) span else div, ...)
 {
+  if (anyUnnamed(list(...))) {
+    warning("Unnamed elements in ... will be replaced with dynamic UI.")
+  }
   container(id = outputId, class="shiny-html-output", ...)
 }
 

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -1858,18 +1858,26 @@ dataTableOutput <- function(outputId) {
 #' text will be included within an HTML \code{div} tag, and is presumed to
 #' contain HTML content which should not be escaped.
 #'
-#' \code{uiOutput} is intended to be used with \code{renderUI} on the
-#' server side. It is currently just an alias for \code{htmlOutput}.
+#' \code{uiOutput} is intended to be used with \code{renderUI} on the server
+#' side. It is currently just an alias for \code{htmlOutput}.
 #'
 #' @param outputId output variable to read the value from
+#' @param ... Other arguments to pass to the container tag function. This is
+#'   useful for providing additional classes for the tag.
 #' @inheritParams textOutput
 #' @return An HTML output element that can be included in a panel
 #' @examples
 #' htmlOutput("summary")
+#'
+#' # Using a custom container and class
+#' tags$ul(
+#'   htmlOutput("summary", container = tags$li, class = "custom-li-output")
+#' )
 #' @export
-htmlOutput <- function(outputId, inline = FALSE) {
-  container <- if (inline) span else div
-  container(id = outputId, class="shiny-html-output")
+htmlOutput <- function(outputId, inline = FALSE,
+  container = if (inline) span else div, ...)
+{
+  container(id = outputId, class="shiny-html-output", ...)
 }
 
 #' @rdname htmlOutput

--- a/R/utils.R
+++ b/R/utils.R
@@ -155,6 +155,20 @@ dropNullsOrEmpty <- function(x) {
   x[!vapply(x, nullOrEmpty, FUN.VALUE=logical(1))]
 }
 
+# Given a vector/list, return TRUE if any elements are unnamed, FALSE otherwise.
+anyUnnamed <- function(x) {
+  # Zero-length vector
+  if (length(x) == 0) return(FALSE)
+
+  nms <- names(x)
+
+  # List with no name attribute
+  if (is.null(nms)) return(TRUE)
+
+  # List with name attribute; check for any ""
+  any(!nzchar(nms))
+}
+
 # Combine dir and (file)name into a file path. If a file already exists with a
 # name differing only by case, then use it instead.
 file.path.ci <- function(...) {

--- a/inst/tests/test-utils.R
+++ b/inst/tests/test-utils.R
@@ -88,3 +88,15 @@ test_that("need() works as expected", {
   expect_null(need(c(NA, NA, TRUE), FALSE))
   expect_null(need(c(FALSE, FALSE, TRUE), FALSE))
 })
+
+test_that("anyUnnamed works as expected", {
+  expect_false(anyUnnamed(list()))
+  expect_true(anyUnnamed(list(1,2,3)))
+  expect_true(anyUnnamed(list(A = 1,2,3)))
+  expect_false(anyUnnamed(list(A = 1,B = 2,C = 3)))
+
+  # List with named elements removed
+  x <- list(A = 1, B = 2, 3, 4)
+  x <- x[3:4]
+  expect_true(anyUnnamed(x))
+})

--- a/man/htmlOutput.Rd
+++ b/man/htmlOutput.Rd
@@ -5,15 +5,22 @@
 \alias{uiOutput}
 \title{Create an HTML output element}
 \usage{
-htmlOutput(outputId, inline = FALSE)
+htmlOutput(outputId, inline = FALSE, container = if (inline) span else div,
+  ...)
 
-uiOutput(outputId, inline = FALSE)
+uiOutput(outputId, inline = FALSE, container = if (inline) span else div,
+  ...)
 }
 \arguments{
 \item{outputId}{output variable to read the value from}
 
 \item{inline}{use an inline (\code{span()}) or block container (\code{div()})
 for the output}
+
+\item{container}{a function to generate an HTML element to contain the text}
+
+\item{...}{Other arguments to pass to the container tag function. This is
+useful for providing additional classes for the tag.}
 }
 \value{
 An HTML output element that can be included in a panel
@@ -24,10 +31,15 @@ text will be included within an HTML \code{div} tag, and is presumed to
 contain HTML content which should not be escaped.
 }
 \details{
-\code{uiOutput} is intended to be used with \code{renderUI} on the
-server side. It is currently just an alias for \code{htmlOutput}.
+\code{uiOutput} is intended to be used with \code{renderUI} on the server
+side. It is currently just an alias for \code{htmlOutput}.
 }
 \examples{
 htmlOutput("summary")
+
+# Using a custom container and class
+tags$ul(
+  htmlOutput("summary", container = tags$li, class = "custom-li-output")
+)
 }
 


### PR DESCRIPTION
This PR allows using a custom container for `uiOutput`, instead of just `div` or `span`. It also allows adding custom classes to the container.

This is for rstudio/shinydashboard#1.