### PR TITLE
Fix fixedPanel default cursor handling

### DIFF
--- a/R/jqueryui.R
+++ b/R/jqueryui.R
@@ -97,8 +97,8 @@ fixedPanel <- function(...,
                        top = NULL, left = NULL, right = NULL, bottom = NULL,
                        width = NULL, height = NULL,
                        draggable = FALSE,
-                       cursor = c('move', 'default', 'inherit')) {
+                       cursor = c('auto', 'move', 'default', 'inherit')) {
   absolutePanel(..., top=top, left=left, right=right, bottom=bottom,
-                width=width, height=height, draggable=draggable, cursor=cursor,
+                width=width, height=height, draggable=draggable, cursor=match.arg(cursor),
                 fixed=TRUE)
 }

--- a/man/absolutePanel.Rd
+++ b/man/absolutePanel.Rd
@@ -10,8 +10,8 @@ absolutePanel(..., top = NULL, left = NULL, right = NULL, bottom = NULL,
   cursor = c("auto", "move", "default", "inherit"))
 
 fixedPanel(..., top = NULL, left = NULL, right = NULL, bottom = NULL,
-  width = NULL, height = NULL, draggable = FALSE, cursor = c("move",
-  "default", "inherit"))
+  width = NULL, height = NULL, draggable = FALSE, cursor = c("auto",
+  "move", "default", "inherit"))
 }
 \arguments{
 \item{...}{Attributes (named arguments) or children (unnamed arguments) that


### PR DESCRIPTION
Previous to this fix, calling fixedPanel without an
explicit cursor argument would cause an error due to
the vector of possible values being passed as the
actual cursor argument to absolutePanel.