### PR TITLE
Fix #725: Tabs with icons give incorrect values

### DIFF
--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -1404,7 +1404,7 @@ dateRangeInput <- function(inputId, label, start = NULL, end = NULL,
 #'   )
 #' )
 #' @export
-tabPanel <- function(title, ..., value = NULL, icon = NULL) {
+tabPanel <- function(title, ..., value = title, icon = NULL) {
   divTag <- div(class="tab-pane",
                 title=title,
                 `data-value`=value,

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -1576,11 +1576,6 @@ buildTabset <- function(tabs,
     tabId <- tabId + 1
 
     tabValue <- divTag$attribs$`data-value`
-    if (!is.null(tabValue) && is.null(id)) {
-      stop("tabsetPanel doesn't have an id assigned, but one of its tabPanels ",
-           "has a value. The value won't be sent without an id.")
-    }
-
 
     # function to append an optional icon to an aTag
     appendIcon <- function(aTag, iconClass) {

--- a/man/tabPanel.Rd
+++ b/man/tabPanel.Rd
@@ -4,7 +4,7 @@
 \alias{tabPanel}
 \title{Create a tab panel}
 \usage{
-tabPanel(title, ..., value = NULL, icon = NULL)
+tabPanel(title, ..., value = title, icon = NULL)
 }
 \arguments{
 \item{title}{Display title for tab}


### PR DESCRIPTION
When no explicit value argument was present on tabPanel,
the inner text of the HTML anchor was used. This gave
weird results when an icon was used, since it appears in
the anchor.

The fix is to always use the value parameter, defaulting
it to the title.