### PR TITLE
selectInput: add control for size (height)

### DIFF
--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -745,22 +745,27 @@ choicesWithNames <- function(choices) {
 
 #' Create a select list input control
 #'
-#' Create a select list that can be used to choose a single or
-#' multiple items from a list of values.
+#' Create a select list that can be used to choose a single or multiple items
+#' from a list of values.
 #'
 #' By default, \code{selectInput()} and \code{selectizeInput()} use the
-#' JavaScript library \pkg{selectize.js} (\url{https://github.com/brianreavis/selectize.js})
-#' to instead of the basic select input element. To use the standard HTML select
-#' input element, use \code{selectInput()} with \code{selectize=FALSE}.
+#' JavaScript library \pkg{selectize.js}
+#' (\url{https://github.com/brianreavis/selectize.js}) to instead of the basic
+#' select input element. To use the standard HTML select input element, use
+#' \code{selectInput()} with \code{selectize=FALSE}.
 #'
 #' @inheritParams textInput
 #' @param choices List of values to select from. If elements of the list are
-#' named then that name rather than the value is displayed to the user.
+#'   named then that name rather than the value is displayed to the user.
 #' @param selected The initially selected value (or multiple values if
-#' \code{multiple = TRUE}). If not specified then defaults to the first value
-#' for single-select lists and no values for multiple select lists.
+#'   \code{multiple = TRUE}). If not specified then defaults to the first value
+#'   for single-select lists and no values for multiple select lists.
 #' @param multiple Is selection of multiple items allowed?
 #' @param selectize Whether to use \pkg{selectize.js} or not.
+#' @param size Number of items to show in the selection box; a larger number
+#'   will result in a taller box. Not compatible with \code{selectize=TRUE}.
+#'   Normally, when \code{multiple=FALSE}, a select input will be a drop-down
+#'   list, but when \code{size} is set, it will be a box instead.
 #' @return A select list control that can be added to a UI definition.
 #'
 #' @family input elements
@@ -773,7 +778,8 @@ choicesWithNames <- function(choices) {
 #'               "Gears" = "gear"))
 #' @export
 selectInput <- function(inputId, label, choices, selected = NULL,
-                        multiple = FALSE, selectize = TRUE, width = NULL) {
+                        multiple = FALSE, selectize = TRUE, width = NULL,
+                        size = NULL) {
   # resolve names
   choices <- choicesWithNames(choices)
 
@@ -782,10 +788,15 @@ selectInput <- function(inputId, label, choices, selected = NULL,
     if (!multiple) selected <- firstChoice(choices)
   } else selected <- validateSelected(selected, choices, inputId)
 
+  if (!is.null(size) && selectize) {
+    stop("'size' argument is incompatible with 'selectize=TRUE'.")
+  }
+
   # create select tag and add options
   selectTag <- tags$select(
     id = inputId,
     class = if (!selectize) "form-control",
+    size = size,
     selectOptions(choices, selected)
   )
   if (multiple)

--- a/man/selectInput.Rd
+++ b/man/selectInput.Rd
@@ -6,7 +6,7 @@
 \title{Create a select list input control}
 \usage{
 selectInput(inputId, label, choices, selected = NULL, multiple = FALSE,
-  selectize = TRUE, width = NULL)
+  selectize = TRUE, width = NULL, size = NULL)
 
 selectizeInput(inputId, ..., options = NULL, width = NULL)
 }
@@ -29,6 +29,11 @@ for single-select lists and no values for multiple select lists.}
 \item{width}{The width of the input, e.g. \code{'400px'}, or \code{'100\%'};
 see \code{\link{validateCssUnit}}.}
 
+\item{size}{Number of items to show in the selection box; a larger number
+will result in a taller box. Not compatible with \code{selectize=TRUE}.
+Normally, when \code{multiple=FALSE}, a select input will be a drop-down
+list, but when \code{size} is set, it will be a box instead.}
+
 \item{...}{Arguments passed to \code{selectInput()}.}
 
 \item{options}{A list of options. See the documentation of \pkg{selectize.js}
@@ -40,14 +45,15 @@ for details).}
 A select list control that can be added to a UI definition.
 }
 \description{
-Create a select list that can be used to choose a single or
-multiple items from a list of values.
+Create a select list that can be used to choose a single or multiple items
+from a list of values.
 }
 \details{
 By default, \code{selectInput()} and \code{selectizeInput()} use the
-JavaScript library \pkg{selectize.js} (\url{https://github.com/brianreavis/selectize.js})
-to instead of the basic select input element. To use the standard HTML select
-input element, use \code{selectInput()} with \code{selectize=FALSE}.
+JavaScript library \pkg{selectize.js}
+(\url{https://github.com/brianreavis/selectize.js}) to instead of the basic
+select input element. To use the standard HTML select input element, use
+\code{selectInput()} with \code{selectize=FALSE}.
 }
 \note{
 The selectize input created from \code{selectizeInput()} allows


### PR DESCRIPTION
This addresses https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/shiny-discuss/-gFgWdMLkvg/MM1UdM6R9kkJ

This adds control over the height of select inputs -- for both multiple and single inputs. It's not surprising that we haven't supported control over the height of single-select inputs, but I'm surprised we've never had the ability to control the height of multiple select boxes before.