### PR TITLE
Refactor ShinySession object

### DIFF
--- a/R/middleware-shiny.R
+++ b/R/middleware-shiny.R
@@ -35,7 +35,7 @@ sessionHandler <- function(req) {
   subreq$PATH_INFO <- subpath
   subreq$SCRIPT_NAME <- paste(subreq$SCRIPT_NAME, matches[[1]][2], sep='')
 
-  withReactiveDomain(shinysession$session, {
+  withReactiveDomain(shinysession, {
     shinysession$handleRequest(subreq)
   })
 }

--- a/R/progress.R
+++ b/R/progress.R
@@ -83,8 +83,8 @@ Progress <- R6Class(
   public = list(
 
     initialize = function(session = getDefaultReactiveDomain(), min = 0, max = 1) {
-      # A hacky check to make sure the session object is indeed a session object.
-      if (is.null(session$onFlush)) stop("'session' is not a session object.")
+      if (!inherits(session, "ShinySession"))
+        stop("'session' is not a ShinySession object.")
 
       private$session <- session
       private$id <- paste(as.character(as.raw(runif(8, min=0, max=255))), collapse='')
@@ -231,8 +231,8 @@ withProgress <- function(expr, min = 0, max = 1,
   if (!quoted)
     expr <- substitute(expr)
 
-  # A hacky check to make sure the session object is indeed a session object.
-  if (is.null(session$onFlush)) stop("'session' is not a session object.")
+  if (!inherits(session, "ShinySession"))
+    stop("'session' is not a ShinySession object.")
 
   p <- Progress$new(session, min = min, max = max)
 
@@ -252,8 +252,8 @@ withProgress <- function(expr, min = 0, max = 1,
 setProgress <- function(value = NULL, message = NULL, detail = NULL,
                         session = getDefaultReactiveDomain()) {
 
-  # A hacky check to make sure the session object is indeed a session object.
-  if (is.null(session$onFlush)) stop("'session' is not a session object.")
+  if (!inherits(session, "ShinySession"))
+    stop("'session' is not a ShinySession object.")
 
   if (session$progressStack$size() == 0) {
     warning('setProgress was called outside of withProgress; ignoring')
@@ -269,8 +269,8 @@ setProgress <- function(value = NULL, message = NULL, detail = NULL,
 incProgress <- function(amount = 0.1, message = NULL, detail = NULL,
                         session = getDefaultReactiveDomain()) {
 
-  # A hacky check to make sure the session object is indeed a session object.
-  if (is.null(session$onFlush)) stop("'session' is not a session object.")
+  if (!inherits(session, "ShinySession"))
+    stop("'session' is not a ShinySession object.")
 
   if (session$progressStack$size() == 0) {
     warning('incProgress was called outside of withProgress; ignoring')

--- a/R/server.R
+++ b/R/server.R
@@ -406,9 +406,9 @@ createAppHandlers <- function(httpHandlers, serverFuncSource) {
                 args$clientData <- shinysession$clientData
 
               if ('session' %in% names(formals(serverFunc)))
-                args$session <- shinysession$session
+                args$session <- shinysession
 
-              withReactiveDomain(shinysession$session, {
+              withReactiveDomain(shinysession, {
                 do.call(appvars$server, args)
               })
             })

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -226,34 +226,36 @@ NULL
 ShinySession <- R6Class(
   'ShinySession',
   private = list(
-    .websocket = 'ANY',
-    .invalidatedOutputValues = 'Map',
-    .invalidatedOutputErrors = 'Map',
-    .inputMessageQueue = list(),    # A list of inputMessages to send when flushed
-    .outputs = list(),       # Keeps track of all the output observer objects
-    .outputOptions = list(), # Options for each of the output observer objects
-    .progressKeys = 'character',
-    .showcase   = 'ANY',
-    .fileUploadContext = 'FileUploadContext',
+    # There are some private items with a leading "."; except for the dot, these
+    # items share a name with a public item.
+    websocket = 'ANY',
+    invalidatedOutputValues = 'Map',
+    invalidatedOutputErrors = 'Map',
+    inputMessageQueue = list(), # A list of inputMessages to send when flushed
+    .outputs = list(),          # Keeps track of all the output observer objects
+    .outputOptions = list(),     # Options for each of the output observer objects
+    progressKeys = 'character',
+    showcase   = 'ANY',
+    fileUploadContext = 'FileUploadContext',
     .input      = 'ANY', # Internal ReactiveValues object for normal input sent from client
     .clientData = 'ANY', # Internal ReactiveValues object for other data sent from the client
-    .closedCallbacks = 'Callbacks',
-    .flushCallbacks = 'Callbacks',
-    .flushedCallbacks = 'Callbacks',
-    .sendResponse = function(requestMsg, value) {
+    closedCallbacks = 'Callbacks',
+    flushCallbacks = 'Callbacks',
+    flushedCallbacks = 'Callbacks',
+    sendResponse = function(requestMsg, value) {
       if (is.null(requestMsg$tag)) {
         warning("Tried to send response for untagged message; method: ",
                 requestMsg$method)
         return()
       }
-      private$.write(toJSON(list(response=list(tag=requestMsg$tag, value=value))))
+      private$write(toJSON(list(response=list(tag=requestMsg$tag, value=value))))
     },
-    .sendErrorResponse = function(requestMsg, error) {
+    sendErrorResponse = function(requestMsg, error) {
       if (is.null(requestMsg$tag))
         return()
-      private$.write(toJSON(list(response=list(tag=requestMsg$tag, error=error))))
+      private$write(toJSON(list(response=list(tag=requestMsg$tag, error=error))))
     },
-    .write = function(json) {
+    write = function(json) {
       if (self$closed){
         return()
       }
@@ -264,9 +266,9 @@ ShinySession <- R6Class(
       # error in Chrome "WebSocket connection failed: Could not decode a text
       # frame as UTF-8"
       json <- enc2utf8(enc2native(json))
-      private$.websocket$send(json)
+      private$websocket$send(json)
     },
-    .getOutputOption = function(outputName, propertyName, defaultValue) {
+    getOutputOption = function(outputName, propertyName, defaultValue) {
       opts <- private$.outputOptions[[outputName]]
       if (is.null(opts))
         return(defaultValue)
@@ -275,7 +277,7 @@ ShinySession <- R6Class(
         return(defaultValue)
       return(result)
     },
-    .shouldSuspend = function(name) {
+    shouldSuspend = function(name) {
       # Find corresponding hidden state clientData variable, with the format
       # "output_foo_hidden". (It comes from .clientdata_output_foo_hidden
       # on the JS side)
@@ -289,7 +291,7 @@ ShinySession <- R6Class(
                                            sep="")]]
       if (is.null(hidden)) hidden <- TRUE
 
-      return(hidden && private$.getOutputOption(name, 'suspendWhenHidden', TRUE))
+      return(hidden && private$getOutputOption(name, 'suspendWhenHidden', TRUE))
     }
   ),
   public = list(
@@ -306,16 +308,16 @@ ShinySession <- R6Class(
     groups = character(0),
 
     initialize = function(websocket) {
-      private$.websocket <- websocket
+      private$websocket <- websocket
       self$closed <- FALSE
       # TODO: Put file upload context in user/app-specific dir if possible
 
-      private$.invalidatedOutputValues <- Map$new()
-      private$.invalidatedOutputErrors <- Map$new()
-      private$.fileUploadContext <- FileUploadContext$new()
-      private$.closedCallbacks <- Callbacks$new()
-      private$.flushCallbacks <- Callbacks$new()
-      private$.flushedCallbacks <- Callbacks$new()
+      private$invalidatedOutputValues <- Map$new()
+      private$invalidatedOutputErrors <- Map$new()
+      private$fileUploadContext <- FileUploadContext$new()
+      private$closedCallbacks <- Callbacks$new()
+      private$flushCallbacks <- Callbacks$new()
+      private$flushedCallbacks <- Callbacks$new()
       private$.input      <- ReactiveValues$new()
       private$.clientData <- ReactiveValues$new()
       self$progressStack <- Stack$new()
@@ -346,7 +348,7 @@ ShinySession <- R6Class(
       # tries to access session$request
       delayedAssign('request', websocket$request, assign.env = session)
 
-      private$.write(toJSON(list(config = list(
+      private$write(toJSON(list(config = list(
         workerId = workerId(),
         sessionId = self$token
       ))))
@@ -356,7 +358,7 @@ ShinySession <- R6Class(
       (i.e. the connection to the client has been severed). The return value
       is a function which unregisters the callback. If multiple callbacks are
       registered, the order in which they are invoked is not guaranteed."
-      return(private$.closedCallbacks$register(callback))
+      return(private$closedCallbacks$register(callback))
     },
     onEnded = function(callback) {
       "Synonym for onSessionEnded"
@@ -367,7 +369,7 @@ ShinySession <- R6Class(
     },
     close = function() {
       if (!self$closed) {
-        private$.websocket$close()
+        private$websocket$close()
       }
     },
     wsClosed = function() {
@@ -375,7 +377,7 @@ ShinySession <- R6Class(
       for (output in private$.outputs) {
         output$suspend()
       }
-      private$.closedCallbacks$invoke(onError=function(e) {
+      private$closedCallbacks$invoke(onError=function(e) {
         warning(simpleWarning(
           paste("An error occurred in an onSessionEnded handler:",
                 e$message),
@@ -395,7 +397,7 @@ ShinySession <- R6Class(
       return(self$isClosed())
     },
     setShowcase = function(value) {
-      private$.showcase <- !is.null(value) && as.logical(value)
+      private$showcase <- !is.null(value) && as.logical(value)
     },
     defineOutput = function(name, func, label) {
       "Binds an output generating function to this name. The function can either
@@ -450,21 +452,21 @@ ShinySession <- R6Class(
             silent=FALSE
           )
 
-          private$.invalidatedOutputErrors$remove(name)
-          private$.invalidatedOutputValues$remove(name)
+          private$invalidatedOutputErrors$remove(name)
+          private$invalidatedOutputValues$remove(name)
 
           if (inherits(value, 'try-error')) {
             cond <- attr(value, 'condition')
             type <- setdiff(class(cond), c('simpleError', 'error', 'condition'))
-            private$.invalidatedOutputErrors$set(
+            private$invalidatedOutputErrors$set(
               name,
               list(message = cond$message,
                    call = capture.output(print(cond$call)),
                    type = if (length(type)) type))
           }
           else
-            private$.invalidatedOutputValues$set(name, value)
-        }, suspended=private$.shouldSuspend(name), label=label)
+            private$invalidatedOutputValues$set(name, value)
+        }, suspended=private$shouldSuspend(name), label=label)
 
         obs$onInvalidate(function() {
           self$showProgress(name)
@@ -480,30 +482,30 @@ ShinySession <- R6Class(
     },
     flushOutput = function() {
 
-      private$.flushCallbacks$invoke()
-      on.exit(private$.flushedCallbacks$invoke())
+      private$flushCallbacks$invoke()
+      on.exit(private$flushedCallbacks$invoke())
 
-      if (length(private$.progressKeys) == 0
-          && length(private$.invalidatedOutputValues) == 0
-          && length(private$.invalidatedOutputErrors) == 0
-          && length(private$.inputMessageQueue) == 0) {
+      if (length(private$progressKeys) == 0
+          && length(private$invalidatedOutputValues) == 0
+          && length(private$invalidatedOutputErrors) == 0
+          && length(private$inputMessageQueue) == 0) {
         return(invisible())
       }
 
-      private$.progressKeys <- character(0)
+      private$progressKeys <- character(0)
 
-      values <- private$.invalidatedOutputValues
-      private$.invalidatedOutputValues <- Map$new()
-      errors <- private$.invalidatedOutputErrors
-      private$.invalidatedOutputErrors <- Map$new()
-      inputMessages <- private$.inputMessageQueue
-      private$.inputMessageQueue <- list()
+      values <- private$invalidatedOutputValues
+      private$invalidatedOutputValues <- Map$new()
+      errors <- private$invalidatedOutputErrors
+      private$invalidatedOutputErrors <- Map$new()
+      inputMessages <- private$inputMessageQueue
+      private$inputMessageQueue <- list()
 
       json <- toJSON(list(errors=as.list(errors),
                           values=as.list(values),
                           inputMessages=inputMessages))
 
-      private$.write(json)
+      private$write(json)
     },
     showProgress = function(id) {
       'Send a message to the client that recalculation of the output identified
@@ -516,10 +518,10 @@ ShinySession <- R6Class(
       if (self$closed)
         return()
 
-      if (id %in% private$.progressKeys)
+      if (id %in% private$progressKeys)
         return()
 
-      private$.progressKeys <- c(private$.progressKeys, id)
+      private$progressKeys <- c(private$progressKeys, id)
 
       self$sendProgress('binding', list(id = id))
     },
@@ -527,7 +529,7 @@ ShinySession <- R6Class(
       json <- toJSON(list(
         progress = list(type = type, message = message)
       ))
-      private$.write(json)
+      private$write(json)
     },
     dispatch = function(msg) {
       method <- paste('@', msg$method, sep='')
@@ -535,22 +537,22 @@ ShinySession <- R6Class(
       # https://github.com/rstudio/shiny/issues/274
       func <- try(do.call(`$`, list(self, method)), silent=TRUE)
       if (inherits(func, 'try-error')) {
-        private$.sendErrorResponse(msg, paste('Unknown method', msg$method))
+        private$sendErrorResponse(msg, paste('Unknown method', msg$method))
       }
 
       value <- try(do.call(func, as.list(append(msg$args, msg$blobs))),
                    silent=TRUE)
       if (inherits(value, 'try-error')) {
-        private$.sendErrorResponse(msg, conditionMessage(attr(value, 'condition')))
+        private$sendErrorResponse(msg, conditionMessage(attr(value, 'condition')))
       }
       else {
-        private$.sendResponse(msg, value)
+        private$sendResponse(msg, value)
       }
     },
     sendCustomMessage = function(type, message) {
       data <- list()
       data[[type]] <- message
-      private$.write(toJSON(list(custom=data)))
+      private$write(toJSON(list(custom=data)))
     },
     sendInputMessage = function(inputId, message) {
       data <- list(id = inputId, message = message)
@@ -560,9 +562,9 @@ ShinySession <- R6Class(
     },
     onFlush = function(func, once = TRUE) {
       if (!isTRUE(once)) {
-        return(private$.flushCallbacks$register(func))
+        return(private$flushCallbacks$register(func))
       } else {
-        dereg <- private$.flushCallbacks$register(function() {
+        dereg <- private$flushCallbacks$register(function() {
           dereg()
           func()
         })
@@ -571,9 +573,9 @@ ShinySession <- R6Class(
     },
     onFlushed = function(func, once = TRUE) {
       if (!isTRUE(once)) {
-        return(private$.flushedCallbacks$register(func))
+        return(private$flushedCallbacks$register(func))
       } else {
-        dereg <- private$.flushedCallbacks$register(function() {
+        dereg <- private$flushedCallbacks$register(function() {
           dereg()
           func()
         })
@@ -581,7 +583,7 @@ ShinySession <- R6Class(
       }
     },
     reactlog = function(logEntry) {
-      if (private$.showcase)
+      if (private$showcase)
         self$sendCustomMessage("reactlog", logEntry)
     },
 
@@ -601,14 +603,14 @@ ShinySession <- R6Class(
         stop("Maximum upload size exceeded")
       }
 
-      jobId <- private$.fileUploadContext$createUploadOperation(fileInfos)
+      jobId <- private$fileUploadContext$createUploadOperation(fileInfos)
       return(list(jobId=jobId,
                   uploadUrl=paste('session', self$token, 'upload',
                                   paste(jobId, "?w=", workerId(), sep=""),
                                   sep='/')))
     },
     `@uploadEnd` = function(jobId, inputId) {
-      fileData <- private$.fileUploadContext$getUploadOperation(jobId)$finish()
+      fileData <- private$fileUploadContext$getUploadOperation(jobId)$finish()
       private$.input$set(inputId, fileData)
       invisible()
     },
@@ -634,7 +636,7 @@ ShinySession <- R6Class(
       }
 
       if (matches[2] == 'upload' && identical(req$REQUEST_METHOD, "POST")) {
-        job <- private$.fileUploadContext$getUploadOperation(matches[3])
+        job <- private$fileUploadContext$getUploadOperation(matches[3])
         if (!is.null(job)) {
           fileName <- req$HTTP_SHINY_FILE_NAME
           fileType <- req$HTTP_SHINY_FILE_TYPE
@@ -801,7 +803,7 @@ ShinySession <- R6Class(
     manageHiddenOutputs = function() {
       # Find hidden state for each output, and suspend/resume accordingly
       for (outputName in names(private$.outputs)) {
-        if (private$.shouldSuspend(outputName)) {
+        if (private$shouldSuspend(outputName)) {
           private$.outputs[[outputName]]$suspend()
         } else {
           private$.outputs[[outputName]]$resume()

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -283,8 +283,8 @@ ShinySession <- R6Class(
 
       session <<- new.env(parent=emptyenv())
       session$clientData        <<- clientData
-      session$sendCustomMessage <<- self$.sendCustomMessage
-      session$sendInputMessage  <<- self$.sendInputMessage
+      session$sendCustomMessage <<- self$sendCustomMessage
+      session$sendInputMessage  <<- self$sendInputMessage
       session$unhandledError    <<- self$unhandledError
       session$close             <<- self$close
       session$onSessionEnded    <<- self$onSessionEnded
@@ -527,12 +527,12 @@ ShinySession <- R6Class(
         return()
       .write(toJSON(list(response=list(tag=requestMsg$tag, error=error))))
     },
-    .sendCustomMessage = function(type, message) {
+    sendCustomMessage = function(type, message) {
       data <- list()
       data[[type]] <- message
       .write(toJSON(list(custom=data)))
     },
-    .sendInputMessage = function(inputId, message) {
+    sendInputMessage = function(inputId, message) {
       data <- list(id = inputId, message = message)
 
       # Add to input message queue
@@ -562,7 +562,7 @@ ShinySession <- R6Class(
     },
     reactlog = function(logEntry) {
       if (.showcase)
-        .sendCustomMessage("reactlog", logEntry)
+        sendCustomMessage("reactlog", logEntry)
     },
     .write = function(json) {
       if (closed){

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -225,7 +225,6 @@ NULL
 #' @include utils.R
 ShinySession <- R6Class(
   'ShinySession',
-  class = FALSE,
   private = list(
     .websocket = 'ANY',
     .invalidatedOutputValues = 'Map',

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -302,7 +302,6 @@ ShinySession <- R6Class(
     files = 'Map',        # For keeping track of files sent to client
     downloads = 'Map',
     closed = logical(0),
-    session = 'environment',      # Object for the server app to access session stuff
     singletons = character(0),  # Tracks singleton HTML fragments sent to the page
     user = character(0),
     groups = character(0),
@@ -334,25 +333,6 @@ ShinySession <- R6Class(
       self$token <- createUniqueId(16)
       private$.outputs <- list()
       private$.outputOptions <- list()
-
-      self$session <<- new.env(parent=emptyenv())
-      self$session$clientData        <<- self$clientData
-      self$session$sendCustomMessage <<- self$sendCustomMessage
-      self$session$sendInputMessage  <<- self$sendInputMessage
-      self$session$unhandledError    <<- self$unhandledError
-      self$session$close             <<- self$close
-      self$session$onSessionEnded    <<- self$onSessionEnded
-      self$session$onEnded           <<- self$onEnded
-      self$session$onFlush           <<- self$onFlush
-      self$session$onFlushed         <<- self$onFlushed
-      self$session$isClosed          <<- self$isClosed
-      self$session$input             <<- self$input
-      self$session$output            <<- self$output
-      self$session$reactlog          <<- self$reactlog
-      self$session$registerDataObj   <<- self$registerDataObj
-      self$session$progressStack     <<- self$progressStack
-      self$session$sendProgress      <<- self$sendProgress
-      self$session$.impl             <<- self
 
       if (!is.null(websocket$request$HTTP_SHINY_SERVER_CREDENTIALS)) {
         try({


### PR DESCRIPTION
This fixes #720, but also does some cleaning up that I've wanted to do for a long time. This is a refactoring of the `ShinySession` object so that a separate `session` object containing publicly-accessible functions is no longer needed.

In this PR:

* Some members of the `ShinySession` object are now private.
* `ShinySession` is changed to a portable R6 class. This means that, internally, all members must be accessed with an explicit `private$` or `self$`.
* Leading dots are removed from private members, except where the name would conflict with a public member.

The default reactive domain is no longer `shinysession$session`, but just the `shinysession` object itself.

With this change, it's possible to check whether something is a session object, with `inherits(session, 'ShinySession')`.

