### PR TITLE
Fix downloading of files with no extension. Fixes #575

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -290,8 +290,7 @@ download <- function(url, ...) {
   }
 }
 
-knownContentTypes <- Map$new()
-knownContentTypes$mset(
+knownContentTypes <- list(
   html='text/html; charset=UTF-8',
   htm='text/html; charset=UTF-8',
   js='text/javascript',
@@ -332,10 +331,11 @@ knownContentTypes$mset(
   docx='application/vnd.openxmlformats-officedocument.wordprocessingml.document',
   dotx='application/vnd.openxmlformats-officedocument.wordprocessingml.template',
   xlam='application/vnd.ms-excel.addin.macroEnabled.12',
-  xlsb='application/vnd.ms-excel.sheet.binary.macroEnabled.12')
+  xlsb='application/vnd.ms-excel.sheet.binary.macroEnabled.12'
+)
 
 getContentType <- function(ext, defaultType='application/octet-stream') {
-  knownContentTypes$get(tolower(ext)) %OR% defaultType
+  knownContentTypes[[tolower(ext)]] %OR% defaultType
 }
 
 # Create a zero-arg function from a quoted expression and environment


### PR DESCRIPTION
Previously, attempting to download a file with this example resulted in an error.

```R
x = 1:10
library(shiny)
runApp(list(
  ui = fluidPage(
    downloadButton('try', 'Save')
  ),
  server = function(input, output) {
    output$try <- downloadHandler(
      filename = 'foo',
      content = function(file) {
        save(x, file = file)
      }
    )
  }
))
```

The error was:

```
Error in knownContentTypes$get(tolower(ext)) : 
  attempt to use zero-length variable name
```

The cause was that the file had no extension, and `knownContentTypes` was a `Map` object, where it wasn't valid to access a member with the name `""`.

In this PR, I just changed it from a `Map` to a `list`, which simplifies the object and makes this problem go away because it's valid to access `""` in a list.

@jcheng5 if there's a reason to keep it as a `Map`, please let me know.