### PR TITLE
Add shiny.port option

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -566,8 +566,10 @@ serviceApp <- function() {
 #'   \code{app.R}. Defaults to the working directory. Instead of a directory,
 #'   this could be a list with \code{ui} and \code{server} components, or a
 #'   Shiny app object created by \code{\link{shinyApp}}.
-#' @param port The TCP port that the application should listen on. Defaults to
-#'   choosing a random port.
+#' @param port The TCP port that the application should listen on. If the
+#'   \code{port} is not specified, and the \code{shiny.port} option is set (with
+#'   \code{options(shiny.port = XX)}), then that port will be used. Otherwise,
+#'   use a random port.
 #' @param launch.browser If true, the system's default web browser will be
 #'   launched automatically after the app is started. Defaults to true in
 #'   interactive sessions only. This value of this parameter can also be a
@@ -622,7 +624,7 @@ serviceApp <- function() {
 #' }
 #' @export
 runApp <- function(appDir=getwd(),
-                   port=NULL,
+                   port=getOption('shiny.port'),
                    launch.browser=getOption('shiny.launch.browser',
                                             interactive()),
                    host=getOption('shiny.host', '127.0.0.1'),

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -29,6 +29,8 @@ NULL
 #' \describe{
 #'   \item{shiny.launch.browser}{A boolean which controls the default behavior
 #'     when an app is run. See \code{\link{runApp}} for more information.}
+#'   \item{shiny.port}{A port number that Shiny will listen on. See
+#'     \code{\link{runApp}} for more information.}
 #'   \item{shiny.trace}{If \code{TRUE}, all of the messages sent between the R
 #'     server and the web browser client will be printed on the console. This
 #'     is useful for debugging.}

--- a/man/runApp.Rd
+++ b/man/runApp.Rd
@@ -4,7 +4,7 @@
 \alias{runApp}
 \title{Run Shiny Application}
 \usage{
-runApp(appDir = getwd(), port = NULL,
+runApp(appDir = getwd(), port = getOption("shiny.port"),
   launch.browser = getOption("shiny.launch.browser", interactive()),
   host = getOption("shiny.host", "127.0.0.1"), workerId = "",
   quiet = FALSE, display.mode = c("auto", "normal", "showcase"))
@@ -18,8 +18,10 @@ contains the file \code{index.html}. Alternately, instead of
 this could be a list with \code{ui} and \code{server} components, or a
 Shiny app object created by \code{\link{shinyApp}}.}
 
-\item{port}{The TCP port that the application should listen on. Defaults to
-choosing a random port.}
+\item{port}{The TCP port that the application should listen on. If the
+\code{port} is not specified, and the \code{shiny.port} option is set (with
+\code{options(shiny.port = XX)}), then that port will be used. Otherwise,
+use a random port.}
 
 \item{launch.browser}{If true, the system's default web browser will be
 launched automatically after the app is started. Defaults to true in

--- a/man/shiny-options.Rd
+++ b/man/shiny-options.Rd
@@ -11,6 +11,8 @@ be set with (for example) \code{options(shiny.trace=TRUE)}.
 \describe{
   \item{shiny.launch.browser}{A boolean which controls the default behavior
     when an app is run. See \code{\link{runApp}} for more information.}
+  \item{shiny.port}{A port number that Shiny will listen on. See
+    \code{\link{runApp}} for more information.}
   \item{shiny.trace}{If \code{TRUE}, all of the messages sent between the R
     server and the web browser client will be printed on the console. This
     is useful for debugging.}


### PR DESCRIPTION
This adds an option, `shiny.port`, so that the user can set the default port to use. This makes it easier to run apps and examples on a predetermined port, especially when a `shiny.appobj` object is used.