### PR TITLE
use ISO8601 and UTC for POSIX[c|l]t time by default

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -90,7 +90,7 @@ toJSON <- function(x, ..., digits = getOption("shiny.json.digits", 16)) {
 
   jsonlite::toJSON(x, dataframe = "columns", null = "null", na = "null",
                    auto_unbox = unbox, digits = digits, use_signif = TRUE,
-                   force = TRUE, ...)
+                   force = TRUE, POSIXt = "ISO8601", UTC = TRUE, ...)
 }
 
 # Call the workerId func with no args to get the worker id, and with an arg to


### PR DESCRIPTION
I want to change two default arguments related to date/time in jsonlite::toJSON(): basically I want to make sure the default conversion is to a predictable standard representation, instead of a timezone-specific one, otherwise users will not be able to faithfully parse the original date/time back, e.g. the conversion in R might be using the server's timezone, and JS might parse the time using the browser's timezone info when a shiny app is published to a server.