### PR TITLE
Allow updateSelectInput(choices=character(0)) to clear select choices

### DIFF
--- a/R/update-input.R
+++ b/R/update-input.R
@@ -403,10 +403,10 @@ updateRadioButtons <- function(session, inputId, label = NULL, choices = NULL,
 #' @export
 updateSelectInput <- function(session, inputId, label = NULL, choices = NULL,
                               selected = NULL) {
-  choices <- choicesWithNames(choices)
+  choices <- if (!is.null(choices)) choicesWithNames(choices)
   if (!is.null(selected))
     selected <- validateSelected(selected, choices, inputId)
-  options <- if (length(choices)) selectOptions(choices, selected)
+  options <- if (!is.null(choices)) selectOptions(choices, selected)
   message <- dropNulls(list(label = label, options = options, value = selected))
   session$sendInputMessage(inputId, message)
 }


### PR DESCRIPTION
This is just a strawman proposal. I feel like we have a general problem with ambiguous `NULL` values in update*Input functions.