### PR TITLE
Add support for HTTP HEAD requests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -63,7 +63,7 @@ Depends:
     methods
 Imports:
     utils,
-    httpuv (>= 1.3.2),
+    httpuv (>= 1.3.2.9001),
     mime (>= 0.3),
     jsonlite (>= 0.9.16),
     xtable,

--- a/NEWS
+++ b/NEWS
@@ -16,6 +16,8 @@ shiny 0.12.1.9xxx
 
 * Added `width` option to Shiny's input functions. (#589, #834)
 
+* Shiny now correctly handles HTTP HEAD requests. (#876)
+
 shiny 0.12.1
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
This fixes an issue where Shiny would not respect HTTP HEAD requests. The change was requested by CRAN because they now test package URLs with `getCurlHeaders()`, which is equivalent to `curl --head --location`.

This fix can be tested by running a simple test app, and then accessing it with `curl --head`.

```R
library(shiny)
runApp(
  shinyApp(bootstrapPage(), function(input, output) {}),
  port = 9000, launch.browser = FALSE
)
```

After the fix, `curl --head` gives these responses:

```
$ curl --head http://localhost:9000/
HTTP/1.1 200 OK
X-UA-Compatible: IE=edge,chrome=1
Content-Type: text/html; charset=UTF-8
Content-Length: 0

$ curl --head http://localhost:9000/foo
HTTP/1.1 404 Not Found
X-UA-Compatible: IE=edge,chrome=1
Content-Type: text/html; charset=UTF-8
Content-Length: 0
```