### PR TITLE
Events shiny:connected and shiny:disconnected

### DIFF
--- a/srcjs/shinyapp.js
+++ b/srcjs/shinyapp.js
@@ -70,6 +70,10 @@ var ShinyApp = function() {
 
     var socket = createSocketFunc();
     socket.onopen = function() {
+      $(document).trigger({
+        type: 'shiny:connected',
+        socket: socket
+      });
       socket.send(JSON.stringify({
         method: 'init',
         data: self.$initialInput
@@ -84,6 +88,10 @@ var ShinyApp = function() {
       self.dispatchMessage(e.data);
     };
     socket.onclose = function() {
+      $(document).trigger({
+        type: 'shiny:disconnected',
+        socket: socket
+      });
       $(document.body).addClass('disconnected');
       self.$notifyDisconnected();
     };


### PR DESCRIPTION
Example:

```r
library(shiny)
shinyApp(
  ui = fluidPage(
    tags$head(tags$script(HTML(
      "$(document).on('shiny:connected', function(event) {
        alert('socket state: ' + event.socket.readyState);
      });
      $(document).on('shiny:disconnected', function(event, data) {
        alert('socket state: ' + event.socket.readyState);
      });"
    ))),
    actionButton('foo', 'Stop')
  ),
  server = function(input, output) {
    observeEvent(input$foo, {
      stopApp()
    })
  }
)
```

Note I didn't commit the minified js files generated by grunt. 