### PR TITLE
Fix runGist

### DIFF
--- a/R/run-url.R
+++ b/R/run-url.R
@@ -112,7 +112,7 @@ runGist <- function(gist, destdir = NULL, ...) {
     stop('Unrecognized gist identifier format')
   }
 
-  runUrl(gistUrl, filetype = ".tar.gz", destdir = destdir, ...)
+  runUrl(gistUrl, filetype = ".zip", destdir = destdir, ...)
 }
 
 


### PR DESCRIPTION
Looks like GitHub changed the format of gist downloads from .tar.gz
to .zip