### PR TITLE
Fix highlighting of reactives in showcase mode

### DIFF
--- a/R/graph.R
+++ b/R/graph.R
@@ -74,7 +74,7 @@ renderReactLog <- function() {
 .graphCreateContext <- function(id, label, type, prevId, domain) {
   .graphAppend(list(
     action='ctx', id=id, label=paste(label, collapse='\n'),
-    srcref=attr(label, "srcref"), srcfile=attr(label, "srcfile"),
+    srcref=as.vector(attr(label, "srcref")), srcfile=attr(label, "srcfile"),
     type=type, prevId=prevId
   ), domain = domain)
 }


### PR DESCRIPTION
This has been broken since we switched to jsonlite. Reactives
don't highlight because their srcref is in an S3(?) class that
jsonlite doesn't recognize, whereas RJSONIO would treat it as
a numeric vector.