### PR TITLE
A more fundamental fix to the Unicode issue

### DIFF
--- a/R/app.R
+++ b/R/app.R
@@ -124,7 +124,7 @@ shinyAppDir_serverR <- function(appDir, options=list()) {
         # If not, then take the last expression that's returned from ui.R.
         .globals$ui <- NULL
         on.exit(.globals$ui <- NULL, add = FALSE)
-        ui <- sourceUTF8(uiR, local = new.env(parent = globalenv()))$value
+        ui <- sourceUTF8(uiR, envir = new.env(parent = globalenv()))
         if (!is.null(.globals$ui)) {
           ui <- .globals$ui[[1]]
         }
@@ -147,7 +147,7 @@ shinyAppDir_serverR <- function(appDir, options=list()) {
       # server.R.
       .globals$server <- NULL
       on.exit(.globals$server <- NULL, add = TRUE)
-      result <- sourceUTF8(serverR, local = new.env(parent = globalenv()))$value
+      result <- sourceUTF8(serverR, envir = new.env(parent = globalenv()))
       if (!is.null(.globals$server)) {
         result <- .globals$server[[1]]
       }
@@ -202,7 +202,7 @@ shinyAppDir_appR <- function(appDir, options=list()) {
   # app.R has changed, it'll re-source the file and return the result.
   appObj <- cachedFuncWithFile(appDir, "app.R", case.sensitive = FALSE,
     function(appR) {
-      result <- sourceUTF8(fullpath, local = new.env(parent = globalenv()))$value
+      result <- sourceUTF8(fullpath, envir = new.env(parent = globalenv()))
 
       if (!is.shiny.appobj(result))
         stop("app.R did not return a shiny.appobj object.")

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -284,10 +284,6 @@ ShinySession <- R6Class(
       if (isTRUE(getOption('shiny.trace')))
         message('SEND ',
            gsub('(?m)base64,[a-zA-Z0-9+/=]+','[base64 data]',json,perl=TRUE))
-      # first convert to native encoding, then to UTF8, otherwise we may get the
-      # error in Chrome "WebSocket connection failed: Could not decode a text
-      # frame as UTF-8"
-      json <- enc2utf8(enc2native(json))
       private$websocket$send(json)
     },
     getOutputOption = function(outputName, propertyName, defaultValue) {

--- a/R/shinyui.R
+++ b/R/shinyui.R
@@ -106,7 +106,7 @@ uiHttpHandler <- function(ui, uiPattern = "^/$") {
     if (!isTRUE(grepl(uiPattern, req$PATH_INFO)))
       return(NULL)
 
-    textConn <- file(open = "w+", encoding = 'UTF-8')
+    textConn <- file(open = "w+")
     on.exit(close(textConn))
 
     showcaseMode <- .globals$showcaseDefault

--- a/R/shinyui.R
+++ b/R/shinyui.R
@@ -106,7 +106,7 @@ uiHttpHandler <- function(ui, uiPattern = "^/$") {
     if (!isTRUE(grepl(uiPattern, req$PATH_INFO)))
       return(NULL)
 
-    textConn <- textConnection(NULL, "w", encoding = 'UTF-8')
+    textConn <- file(open = "w+", encoding = 'UTF-8')
     on.exit(close(textConn))
 
     showcaseMode <- .globals$showcaseDefault
@@ -127,7 +127,7 @@ uiHttpHandler <- function(ui, uiPattern = "^/$") {
       return(NULL)
 
     renderPage(uiValue, textConn, showcaseMode)
-    html <- paste(textConnectionValue(textConn), collapse='\n')
+    html <- paste(readLines(textConn, encoding = 'UTF-8'), collapse='\n')
     return(httpResponse(200, content=enc2utf8(html)))
   }
 }

--- a/R/shinyui.R
+++ b/R/shinyui.R
@@ -53,7 +53,7 @@ renderPage <- function(ui, connection, showcase=0) {
   depHtml <- renderDependencies(deps, "href")
 
   # write preamble
-  writeLines(c('<!DOCTYPE html>',
+  writeUTF8(c('<!DOCTYPE html>',
                '<html>',
                '<head>',
                '  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>',
@@ -66,15 +66,15 @@ renderPage <- function(ui, connection, showcase=0) {
                depHtml
               ),
               con = connection)
-  writeLines(c(result$head,
+  writeUTF8(c(result$head,
                '</head>',
                recursive=TRUE),
              con = connection)
 
-  writeLines(result$html, con = connection)
+  writeUTF8(result$html, con = connection)
 
   # write end document
-  writeLines('</html>',
+  writeUTF8('</html>',
              con = connection)
 }
 

--- a/R/shinyui.R
+++ b/R/shinyui.R
@@ -106,7 +106,7 @@ uiHttpHandler <- function(ui, uiPattern = "^/$") {
     if (!isTRUE(grepl(uiPattern, req$PATH_INFO)))
       return(NULL)
 
-    textConn <- textConnection(NULL, "w")
+    textConn <- textConnection(NULL, "w", encoding = 'UTF-8')
     on.exit(close(textConn))
 
     showcaseMode <- .globals$showcaseDefault

--- a/R/utils.R
+++ b/R/utils.R
@@ -1035,6 +1035,11 @@ sourceUTF8 <- function(file, ...) {
   source(file, ..., keep.source = TRUE, encoding = checkEncoding(file))
 }
 
+# write text as UTF-8
+writeUTF8 <- function(text, ...) {
+  text <- enc2utf8(text)
+  writeLines(text, ..., useBytes = TRUE)
+}
 
 URLdecode <- decodeURIComponent
 URLencode <- function(value, reserved = FALSE) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -1005,8 +1005,6 @@ checkEncoding <- function(file) {
     warning('You should not include the Byte Order Mark (BOM) in ', file, '. ',
             'Please re-save it in UTF-8 without BOM. See ',
             'http://shiny.rstudio.com/articles/unicode.html for more info.')
-    if (getRversion() < '3.0.0')
-      stop('R does not support UTF-8-BOM before 3.0.0. Please upgrade R.')
     return('UTF-8-BOM')
   }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1005,14 +1005,20 @@ checkEncoding <- function(file) {
   'UTF-8'
 }
 
-# try to read a file using UTF-8 (fall back to getOption('encoding') in case of
-# failure, which defaults to native.enc, i.e. native encoding)
+# read a file using UTF-8 and (on Windows) convert to native encoding if possible
 readUTF8 <- function(file) {
   enc <- checkEncoding(file)
   file <- base::file(file, encoding = enc)
   on.exit(close(file), add = TRUE)
-  x <- readLines(file, encoding = enc, warn = FALSE)
-  enc2utf8(x)
+  x <- enc2utf8(readLines(file, warn = FALSE))
+  tryNativeEncoding(x)
+}
+
+# if the UTF-8 string can be represented in the native encoding, use native encoding
+tryNativeEncoding <- function(string) {
+  if (!isWindows()) return(string)
+  string2 <- enc2native(string)
+  if (identical(enc2utf8(string2), string)) string2 else string
 }
 
 # similarly, try to source() a file with UTF-8

--- a/R/utils.R
+++ b/R/utils.R
@@ -1024,13 +1024,10 @@ checkEncoding <- function(file) {
 # failure, which defaults to native.enc, i.e. native encoding)
 readUTF8 <- function(file) {
   enc <- checkEncoding(file)
-  # readLines() does not support UTF-8-BOM directly; has to go through file()
-  if (enc == 'UTF-8-BOM') {
-    file <- base::file(file, encoding = enc)
-    on.exit(close(file), add = TRUE)
-  }
+  file <- base::file(file, encoding = enc)
+  on.exit(close(file), add = TRUE)
   x <- readLines(file, encoding = enc, warn = FALSE)
-  enc2native(x)
+  enc2utf8(x)
 }
 
 # similarly, try to source() a file with UTF-8


### PR DESCRIPTION
After Duncan fixed the `grep()` bug https://bugs.r-project.org/bugzilla3/show_bug.cgi?id=16264 and a user reported #961, I took another look at the Unicode issue on Windows. This time I realized my previous work was actually buggy: I was testing if a file is encoded in UTF8 by reading it as UTF8 and checking if `iconv(from = 'UTF-8', to = '')` is `NA`. This is actually checking if the file content can be converted to native encoding, and does not really tell us if the file is encoded in UTF8.

The other mistake I made before was to convert everything to native encoding using `enc2native()`, which can be lossy, e.g. the UTF-8 encoded character `≤` will be converted to `=`. #961 revealed this mistake.

```r
> Sys.setlocale(,'English')
[1] "LC_COLLATE=English_United States.1252;LC_CTYPE=English_United States.1252;LC_MONETARY=English_United States.1252;LC_NUMERIC=C;LC_TIME=English_United States.1252"
> "\u2264"
[1] "≤"
> iconv("\u2264", "UTF-8")
[1] "="
```

Now I use native encoding only if the conversion is not lossy; see `tryNativeEncoding ()`. Native encoding works better than UTF8 on Windows in general (e.g. assign a value to a Unicode variable name in an environment), but if native encoding is lossy, we just use UTF8 anyway. Everything will be converted to UTF-8 in the final step, e.g. when sending the JSON message, or writing out HTML.

The major challenge with UTF8 before Duncan's fix was actually source references, e.g. via `source(keep.source = TRUE)`. The reason that it fails with UTF8 was a single line `grep("\n", fixed = TRUE)` in the source code of `srcfilecopy()`:

```r
> srcfilecopy
function (filename, lines, timestamp = Sys.time(), isFile = FALSE) 
{
    stopifnot(is.character(filename), length(filename) == 1L)
    e <- new.env(parent = emptyenv())
    if (any(grepl("\n", lines, fixed = TRUE))) 
        lines <- unlist(strsplit(sub("$", "\n", as.character(lines)), 
            "\n"))
    ....
}
```

I have provided a hack for it in a custom version of `srcfilecopy()`, and I believe the hack is pretty safe. So now source references will work well with UTF8 source code for all versions of R (you don't have to use R 3.3.0).

A few known issues left (they only occur when Unicode characters cannot be converted to native encoding, e.g. when using Chinese in an English locale):

1. We cannot use multibyte characters in input/output IDs, e.g. `output[['summary这里也可以用中文']] <- renderPrint(...)`. This can be fixed by replacing the environment with a list in the `Map` object, but I found a new issue after the replacement, so I didn't include the commit in this PR (https://github.com/yihui/shiny/commit/00a7a86f85368d4142ce73299606ee50460dba99).
2. Showcase mode does not work for some reason (I have not investigated the reason yet).
3. Reading the DESCRIPTION using `read.dcf()` does not work, since `read.dcf()` does not have an `encoding` argument. Not sure if `read.dcf(file('DESCRIPTION', encoding = 'UTF-8'))` works.

Anyway, after this PR, we will no longer suffer from corruption of certain Unicode characters, and we don't need to assume all characters can be represented in the system native encoding.