### PR TITLE
Enhancements to help profiling

### DIFF
--- a/R/react.R
+++ b/R/react.R
@@ -72,8 +72,8 @@ Context <- R6Class(
         }
       }, add = TRUE)
 
-      lapply(.flushCallbacks, function(func) {
-        func()
+      lapply(.flushCallbacks, function(flushCallback) {
+        flushCallback()
       })
     }
   )
@@ -112,7 +112,9 @@ ReactiveEnvironment <- R6Class(
       old.ctx <- .currentContext
       .currentContext <<- ctx
       on.exit(.currentContext <<- old.ctx)
-      shinyCallingHandlers(func())
+      # Rename to assist debugging
+      contextFunc <- func
+      shinyCallingHandlers(contextFunc())
     },
     addPendingFlush = function(ctx, priority) {
       .pendingFlush$enqueue(ctx, priority)

--- a/R/react.R
+++ b/R/react.R
@@ -108,12 +108,10 @@ ReactiveEnvironment <- R6Class(
       }
       return(.currentContext)
     },
-    runWith = function(ctx, func) {
+    runWith = function(ctx, contextFunc) {
       old.ctx <- .currentContext
       .currentContext <<- ctx
       on.exit(.currentContext <<- old.ctx)
-      # Rename to assist debugging
-      contextFunc <- func
       shinyCallingHandlers(contextFunc())
     },
     addPendingFlush = function(ctx, priority) {

--- a/R/reactives.R
+++ b/R/reactives.R
@@ -487,15 +487,12 @@ Observer <- R6Class(
     .destroyed = logical(0),
     .prevId = character(0),
 
-    initialize = function(func, label, suspended = FALSE, priority = 0,
+    initialize = function(observerFunc, label, suspended = FALSE, priority = 0,
                           domain = getDefaultReactiveDomain(),
                           autoDestroy = TRUE) {
-      if (length(formals(func)) > 0)
+      if (length(formals(observerFunc)) > 0)
         stop("Can't make an observer from a function that takes parameters; ",
              "only functions without parameters can be reactive.")
-
-      # New name to assist debugging
-      observerFunc <- func
 
       .func <<- function() {
         tryCatch(

--- a/R/reactives.R
+++ b/R/reactives.R
@@ -494,9 +494,12 @@ Observer <- R6Class(
         stop("Can't make an observer from a function that takes parameters; ",
              "only functions without parameters can be reactive.")
 
+      # New name to assist debugging
+      observerFunc <- func
+
       .func <<- function() {
         tryCatch(
-          func(),
+          observerFunc(),
           validation = function(e) {
             # It's OK for a validation error to cause an observer to stop
             # running
@@ -523,8 +526,8 @@ Observer <- R6Class(
       .prevId <<- ctx$id
 
       ctx$onInvalidate(function() {
-        lapply(.invalidateCallbacks, function(func) {
-          func()
+        lapply(.invalidateCallbacks, function(invalidateCallback) {
+          invalidateCallback()
           NULL
         })
 

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -461,6 +461,8 @@ ShinySession <- R6Class(
           }
         }
 
+        func <- wrapFunctionLabel(func, paste0("output$", name))
+
         # Preserve source reference and file information when formatting the
         # label for display in the reactive graph
         srcref <- attr(label, "srcref")

--- a/R/utils.R
+++ b/R/utils.R
@@ -1058,11 +1058,14 @@ wrapFunctionLabel <- function(func, name) {
   }
   assign(name, func, environment())
 
-  relabelWrapper <- function(...) {
-    # This `f` gets renamed to the value of `name`
-    f(...)
-  }
+  relabelWrapper <- eval(substitute(
+    function(...) {
+      # This `f` gets renamed to the value of `name`. Note that it may not
+      # print as the new name, because of source refs stored in the function.
+      f(...)
+    },
+    list(f = as.name(name))
+  ))
 
-  body(relabelWrapper)[[2]][[1]] <- as.name(name)
   relabelWrapper
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1046,3 +1046,23 @@ URLencode <- function(value, reserved = FALSE) {
   value <- enc2utf8(value)
   if (reserved) encodeURIComponent(value) else encodeURI(value)
 }
+
+
+# This function takes a name and function, and it wraps that function in a new
+# function which calls the original function using the specified name. This can
+# be helpful for profiling, because the specified name will show up on the stack
+# trace.
+wrapFunctionLabel <- function(func, name) {
+  if (name == "name" || name == "func" || name == "relabelWrapper") {
+    stop("Invalid name for wrapFunctionLabel: ", name)
+  }
+  assign(name, func, environment())
+
+  relabelWrapper <- function(...) {
+    # This `f` gets renamed to the value of `name`
+    f(...)
+  }
+
+  body(relabelWrapper)[[2]][[1]] <- as.name(name)
+  relabelWrapper
+}


### PR DESCRIPTION
There are three changes in this PR:

* There's a function `wrapFunctionLabel` which essentially renames a function so that it can have any arbitrary label to show up in the profiler. This makes it possible to make output observers show up as `output$foo` instead of as `func`, at the small cost of adding one more function on the call stack.
* A `try(tryCatch())` statement was simplified to just `tryCatch()`. This makes the call stack a little smaller, and also now prints to the console which output the error occurred in.
* Various internal functions named `func` and `.func` were renamed to more descriptive names, like `observerFunc` and `flushCallback`.