### PR TITLE
updateCheckboxGroup: allow clearing all choices. Fixes #981

### DIFF
--- a/R/update-input.R
+++ b/R/update-input.R
@@ -306,15 +306,16 @@ updateSliderInput <- function(session, inputId, label = NULL, value = NULL,
 updateInputOptions <- function(session, inputId, label = NULL, choices = NULL,
                                selected = NULL, inline = FALSE,
                                type = 'checkbox') {
-
-  choices <- choicesWithNames(choices)
+  if (!is.null(choices))
+    choices <- choicesWithNames(choices)
   if (!is.null(selected))
     selected <- validateSelected(selected, choices, inputId)
 
-  options <- if (length(choices))
+  options <- if (!is.null(choices)) {
     format(tagList(
       generateOptions(inputId, choices, selected, inline, type = type)
     ))
+  }
 
   message <- dropNulls(list(label = label, options = options, value = selected))
 

--- a/man-roxygen/update-input.R
+++ b/man-roxygen/update-input.R
@@ -1,4 +1,5 @@
 #' @details
+#'
 #' The input updater functions send a message to the client, telling it to
 #' change the settings of an input object. The messages are collected and sent
 #' after all the observers (including outputs) have finished running.
@@ -9,6 +10,10 @@
 #'
 #' Any arguments with NULL values will be ignored; they will not result in any
 #' changes to the input object on the client.
+#'
+#' For \code{\link{radioButtons}()}, \code{\link{checkboxGroupInput}()} and
+#' \code{\link{selectInput}()}, the set of choices can be cleared by using
+#' \code{choices=character(0)}
 #'
 #' @param session The \code{session} object passed to function given to
 #'   \code{shinyServer}.

--- a/man/updateCheckboxGroupInput.Rd
+++ b/man/updateCheckboxGroupInput.Rd
@@ -36,6 +36,10 @@ inputs in the first place. For example, \code{\link{numericInput}()} and
 
 Any arguments with NULL values will be ignored; they will not result in any
 changes to the input object on the client.
+
+For \code{\link{radioButtons}()}, \code{\link{checkboxGroupInput}()} and
+\code{\link{selectInput}()}, the set of choices can be cleared by using
+\code{choices=character(0)}
 }
 \examples{
 \dontrun{

--- a/man/updateCheckboxInput.Rd
+++ b/man/updateCheckboxInput.Rd
@@ -30,6 +30,10 @@ inputs in the first place. For example, \code{\link{numericInput}()} and
 
 Any arguments with NULL values will be ignored; they will not result in any
 changes to the input object on the client.
+
+For \code{\link{radioButtons}()}, \code{\link{checkboxGroupInput}()} and
+\code{\link{selectInput}()}, the set of choices can be cleared by using
+\code{choices=character(0)}
 }
 \examples{
 \dontrun{

--- a/man/updateDateInput.Rd
+++ b/man/updateDateInput.Rd
@@ -38,6 +38,10 @@ inputs in the first place. For example, \code{\link{numericInput}()} and
 
 Any arguments with NULL values will be ignored; they will not result in any
 changes to the input object on the client.
+
+For \code{\link{radioButtons}()}, \code{\link{checkboxGroupInput}()} and
+\code{\link{selectInput}()}, the set of choices can be cleared by using
+\code{choices=character(0)}
 }
 \examples{
 \dontrun{

--- a/man/updateDateRangeInput.Rd
+++ b/man/updateDateRangeInput.Rd
@@ -41,6 +41,10 @@ inputs in the first place. For example, \code{\link{numericInput}()} and
 
 Any arguments with NULL values will be ignored; they will not result in any
 changes to the input object on the client.
+
+For \code{\link{radioButtons}()}, \code{\link{checkboxGroupInput}()} and
+\code{\link{selectInput}()}, the set of choices can be cleared by using
+\code{choices=character(0)}
 }
 \examples{
 \dontrun{

--- a/man/updateNumericInput.Rd
+++ b/man/updateNumericInput.Rd
@@ -37,6 +37,10 @@ inputs in the first place. For example, \code{\link{numericInput}()} and
 
 Any arguments with NULL values will be ignored; they will not result in any
 changes to the input object on the client.
+
+For \code{\link{radioButtons}()}, \code{\link{checkboxGroupInput}()} and
+\code{\link{selectInput}()}, the set of choices can be cleared by using
+\code{choices=character(0)}
 }
 \examples{
 \dontrun{

--- a/man/updateRadioButtons.Rd
+++ b/man/updateRadioButtons.Rd
@@ -37,6 +37,10 @@ inputs in the first place. For example, \code{\link{numericInput}()} and
 
 Any arguments with NULL values will be ignored; they will not result in any
 changes to the input object on the client.
+
+For \code{\link{radioButtons}()}, \code{\link{checkboxGroupInput}()} and
+\code{\link{selectInput}()}, the set of choices can be cleared by using
+\code{choices=character(0)}
 }
 \examples{
 \dontrun{

--- a/man/updateSelectInput.Rd
+++ b/man/updateSelectInput.Rd
@@ -50,6 +50,10 @@ inputs in the first place. For example, \code{\link{numericInput}()} and
 
 Any arguments with NULL values will be ignored; they will not result in any
 changes to the input object on the client.
+
+For \code{\link{radioButtons}()}, \code{\link{checkboxGroupInput}()} and
+\code{\link{selectInput}()}, the set of choices can be cleared by using
+\code{choices=character(0)}
 }
 \examples{
 \dontrun{

--- a/man/updateSliderInput.Rd
+++ b/man/updateSliderInput.Rd
@@ -37,6 +37,10 @@ inputs in the first place. For example, \code{\link{numericInput}()} and
 
 Any arguments with NULL values will be ignored; they will not result in any
 changes to the input object on the client.
+
+For \code{\link{radioButtons}()}, \code{\link{checkboxGroupInput}()} and
+\code{\link{selectInput}()}, the set of choices can be cleared by using
+\code{choices=character(0)}
 }
 \examples{
 ## Only run this example in interactive R sessions

--- a/man/updateTextInput.Rd
+++ b/man/updateTextInput.Rd
@@ -30,6 +30,10 @@ inputs in the first place. For example, \code{\link{numericInput}()} and
 
 Any arguments with NULL values will be ignored; they will not result in any
 changes to the input object on the client.
+
+For \code{\link{radioButtons}()}, \code{\link{checkboxGroupInput}()} and
+\code{\link{selectInput}()}, the set of choices can be cleared by using
+\code{choices=character(0)}
 }
 \examples{
 \dontrun{


### PR DESCRIPTION
This fixes #981. The new logic is essentially the same as for `updateSelectInput`.

As tested:
* `choices=c("a","b","c")` updates the input with those choices
* `choices=character(0)` removes all choices
* `choices=NULL` has no effect on the current choices

Test app:

```R
runApp(list(
  ui = basicPage(
    actionButton("vector", 'choices=c("a", "b", "c")'),
    actionButton("empty", "choices=character(0)"),
    actionButton("null", "choices=null (no change)"),
    checkboxGroupInput('chkGrp', 'Options', choices = NULL)
  ),
  server = function(input, output, session) {
    observeEvent(input$vector, {
      updateCheckboxGroupInput(session,"chkGrp", choices = c("a", "b", "c"))
    })
    observeEvent(input$empty, {
      updateCheckboxGroupInput(session,"chkGrp", choices = character(0))
    })
    observeEvent(input$null, {
      updateCheckboxGroupInput(session,"chkGrp", choices = NULL)
    })
  })
)
```