### PR TITLE
Cleaner reactlog labels for reactives and outputs

### DIFF
--- a/R/reactives.R
+++ b/R/reactives.R
@@ -439,10 +439,11 @@ reactive <- function(x, env = parent.frame(), quoted = FALSE, label = NULL,
                      domain = getDefaultReactiveDomain()) {
   fun <- exprToFunction(x, env, quoted)
   # Attach a label and a reference to the original user source for debugging
-  if (is.null(label))
-    label <- sprintf('reactive(%s)', paste(deparse(body(fun)), collapse='\n'))
   srcref <- attr(substitute(x), "srcref", exact = TRUE)
-  label <- srcrefToLabel(srcref[[1]], label)
+  if (is.null(label)) {
+    label <- srcrefToLabel(srcref[[1]],
+      sprintf('reactive(%s)', paste(deparse(body(fun)), collapse='\n')))
+  }
   if (length(srcref) >= 2) attr(label, "srcref") <- srcref[[2]]
   attr(label, "srcfile") <- srcFileOfRef(srcref[[1]])
   o <- Observable$new(fun, label, domain)
@@ -476,10 +477,10 @@ srcrefToLabel <- function(srcref, defaultLabel) {
   if (inherits(res, "try-error"))
     return(defaultLabel)
 
-  if (length(res) != 1 || !is.symbol(res[[1]]))
+  if (length(res) != 1)
     return(defaultLabel)
 
-  return(as.character(res[[1]]))
+  return(as.character(res))
 }
 
 #' @export

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -463,7 +463,7 @@ ShinySession <- R6Class(
         # label for display in the reactive graph
         srcref <- attr(label, "srcref")
         srcfile <- attr(label, "srcfile")
-        label <- sprintf('output$%s <- %s', name, paste(label, collapse='\n'))
+        label <- sprintf('output$%s', name)
         attr(label, "srcref") <- srcref
         attr(label, "srcfile") <- srcfile
 


### PR DESCRIPTION
Instead of showing the code, try to just show the name
of the reactive/output. Uses a fairly flaky algorithm
for determining the name of the reactive; will only
work in cases where the definition of the reactive
begins with "foo <- reactive({".