### PR TITLE
Correct a regression within modules

### DIFF
--- a/R/modules.R
+++ b/R/modules.R
@@ -3,7 +3,7 @@
 # that value is returned instead. (See Decorator pattern.)
 createSessionProxy <- function(parentSession, ...) {
   e <- new.env(parent = emptyenv())
-  e$parent <= parentSession
+  e$parent <- parentSession
   e$overrides <- list(...)
 
   structure(


### PR DESCRIPTION
Commit 07f2792cf9f65e964d32daf6ae87567128bb9742 introduced an error, replacing `e$parent = parentSession` with `e$parent <= parentSession`, while it should have been `e$parent <- parentSession`