### PR TITLE
Don't require session to be explicitly passed to invalidateLater

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -30,6 +30,9 @@ shiny 0.12.2.9000
   Shiny UI/server logic and 2) make authoring and maintaining complex Shiny
   apps much easier. See the article linked from `?callModule`.
 
+* `invalidateLater` and `reactiveTimer` no longer require an explicit `session`
+  argument; the default value uses the current session.
+
 shiny 0.12.2
 --------------------------------------------------------------------------------
 

--- a/R/reactives.R
+++ b/R/reactives.R
@@ -894,7 +894,7 @@ setAutoflush <- local({
 #'
 #'   # Anything that calls autoInvalidate will automatically invalidate
 #'   # every 2 seconds.
-#'   autoInvalidate <- reactiveTimer(2000, session)
+#'   autoInvalidate <- reactiveTimer(2000)
 #'
 #'   observe({
 #'     # Invalidate and re-execute this reactive expression every time the
@@ -917,12 +917,7 @@ setAutoflush <- local({
 #' }
 #'
 #' @export
-reactiveTimer <- function(intervalMs=1000, session) {
-  if (missing(session)) {
-    warning("reactiveTimer should be passed a session object or NULL")
-    session <- NULL
-  }
-
+reactiveTimer <- function(intervalMs=1000, session = getDefaultReactiveDomain()) {
   dependents <- Map$new()
   timerCallbacks$schedule(intervalMs, function() {
     # Quit if the session is closed
@@ -989,19 +984,14 @@ reactiveTimer <- function(intervalMs=1000, session) {
 #'   # input$n changes.
 #'   output$plot <- renderPlot({
 #'     # Re-execute this reactive expression after 2000 milliseconds
-#'     invalidateLater(2000, session)
+#'     invalidateLater(2000)
 #'     hist(isolate(input$n))
 #'   })
 #' })
 #' }
 #'
 #' @export
-invalidateLater <- function(millis, session) {
-  if (missing(session)) {
-    warning("invalidateLater should be passed a session object or NULL")
-    session <- NULL
-  }
-
+invalidateLater <- function(millis, session = getDefaultReactiveDomain()) {
   ctx <- .getReactiveEnvironment()$currentContext()
   timerCallbacks$schedule(millis, function() {
     # Quit if the session is closed

--- a/man/invalidateLater.Rd
+++ b/man/invalidateLater.Rd
@@ -4,7 +4,7 @@
 \alias{invalidateLater}
 \title{Scheduled Invalidation}
 \usage{
-invalidateLater(millis, session)
+invalidateLater(millis, session = getDefaultReactiveDomain())
 }
 \arguments{
 \item{millis}{Approximate milliseconds to wait before invalidating the
@@ -45,7 +45,7 @@ shinyServer(function(input, output, session) {
   # input$n changes.
   output$plot <- renderPlot({
     # Re-execute this reactive expression after 2000 milliseconds
-    invalidateLater(2000, session)
+    invalidateLater(2000)
     hist(isolate(input$n))
   })
 })

--- a/man/reactiveTimer.Rd
+++ b/man/reactiveTimer.Rd
@@ -4,7 +4,7 @@
 \alias{reactiveTimer}
 \title{Timer}
 \usage{
-reactiveTimer(intervalMs = 1000, session)
+reactiveTimer(intervalMs = 1000, session = getDefaultReactiveDomain())
 }
 \arguments{
 \item{intervalMs}{How often to fire, in milliseconds}
@@ -39,7 +39,7 @@ shinyServer(function(input, output, session) {
 
   # Anything that calls autoInvalidate will automatically invalidate
   # every 2 seconds.
-  autoInvalidate <- reactiveTimer(2000, session)
+  autoInvalidate <- reactiveTimer(2000)
 
   observe({
     # Invalidate and re-execute this reactive expression every time the


### PR DESCRIPTION
These functions were created before getDefaultReactiveDomain()
existed, so the only way to get ahold of the current session was
if the caller explicitly passed it.

This is slightly backwards incompatible, in that existing calls
to invalidateLater() that don't pass a session argument will
behave slightly differently (bound to the current session instead
of to no session), but those calls would have triggered a warning
for all but the very earliest versions of Shiny.