### PR TITLE
Add some tests for character encodings

### DIFF
--- a/tests/test-encoding/01-symbols/app.R
+++ b/tests/test-encoding/01-symbols/app.R
@@ -1,0 +1,38 @@
+library(shiny)
+app <- shinyApp(
+  ui = fluidPage(
+    "\u2264 and \u2265",
+    uiOutput("bin_prob_k"),
+    uiOutput("bin_prob_inequality"),
+    uiOutput("bin_prob_out"),
+    plotOutput("pmf")
+  ),
+  server = function(input, output) {
+
+    output$bin_prob_k = renderUI({
+      numericInput("binom4_k", label = "Number of successes (k)", value = 3,
+                   step = 1, min = 0, max = 10)
+    })
+
+    bin_choices = reactive({
+      nms = paste("P(X",c("=","\u2264","<","\u2265",">"),input$binom4_k,")",sep="")
+      return(nms)
+    })
+
+    output$bin_prob_inequality = renderUI({
+      selectInput("bin_prob_type", label = "Inequality type", choices = bin_choices())
+    })
+
+    output$pmf <- renderPlot({
+      n=10
+      prob = 0.4
+      probs = dbinom(0:n, size=n, prob=prob)
+      mtext(input$bin_prob_type, side = 3, col = "red", cex = 1.2)
+    })
+
+    output$bin_prob_out = renderUI({
+      withMathJax(paste0("\\(",input$bin_prob_type,"\\)",sep=""))
+    })
+
+  }
+)

--- a/tests/test-encoding/02-backslash/server.R
+++ b/tests/test-encoding/02-backslash/server.R
@@ -1,0 +1,2 @@
+function(input, output) {
+}

--- a/tests/test-encoding/02-backslash/ui.R
+++ b/tests/test-encoding/02-backslash/ui.R
@@ -1,0 +1,6 @@
+library(shiny)
+
+tagList(
+  p("Chinese: 中文"),
+  helpText("T:\\2_共享区\\11_资料共享\\MO_Task_File")
+)

--- a/tests/test-encoding/test-all.R
+++ b/tests/test-encoding/test-all.R
@@ -1,0 +1,17 @@
+# Assume the working dir is the root dir of the shiny source package, and the
+# shiny-examples repo (https://github.com/rstudio/shiny-examples) is under the
+# same dir as the shiny package
+library(shiny)
+apps <- list.files('tests/test-encoding/', '^[0-9]{2}-', full.names = TRUE)
+apps <- c(apps, '../shiny-examples/022-unicode-chinese/')
+locales <- c('Chinese', 'English')
+
+# Run these apps in the RStudio preview window one by one in different locales.
+# Note 022-unicode-chinese may not work well in the English locale (explained at
+# https://github.com/rstudio/shiny/pull/968)
+for (app in apps) {
+  for (locale in locales) {
+    print(Sys.setlocale(locale = locale))
+    tryCatch(shiny::runApp(app), interrupt = function(e) {})
+  }
+}


### PR DESCRIPTION
`R CMD check` won't run these tests since the R scripts are not in the root directory `tests`. These are meant to be run manually on Windows.