### PR TITLE
Simpler fix for updating hidden sliders (#1010)

### DIFF
--- a/srcjs/input_binding_slider.js
+++ b/srcjs/input_binding_slider.js
@@ -1,11 +1,3 @@
-// Necessary to get hidden sliders to send their updated values
-function forceIonSliderUpdate(slider) {
-  if (slider.$cache && slider.$cache.input)
-    slider.$cache.input.trigger('change');
-  else
-    console.log("Couldn't force ion slider to update");
-}
-
 var sliderInputBinding = {};
 $.extend(sliderInputBinding, textInputBinding, {
   find: function(scope) {
@@ -60,10 +52,9 @@ $.extend(sliderInputBinding, textInputBinding, {
     } else {
       slider.update({ from: value });
     }
-    forceIonSliderUpdate(slider);
   },
   subscribe: function(el, callback) {
-    $(el).on('change.sliderInputBinding', function(event) {
+    $(el).on('change.sliderInputBinding update.sliderInputBinding', function(event) {
       callback(!$(el).data('updating') && !$(el).data('animating'));
     });
   },
@@ -93,7 +84,6 @@ $.extend(sliderInputBinding, textInputBinding, {
     $el.data('updating', true);
     try {
       slider.update(msg);
-      forceIonSliderUpdate(slider);
     } finally {
       $el.data('updating', false);
     }
@@ -205,7 +195,6 @@ $(document).on('click', '.slider-animate-button', function(evt) {
           val.to = val.from + (slider.result.to - slider.result.from);
 
         slider.update(val);
-        forceIonSliderUpdate(slider);
       };
       var sliderStep = function() {
         // Don't overshoot the end
@@ -216,7 +205,6 @@ $(document).on('click', '.slider-animate-button', function(evt) {
           val.to = Math.min(slider.result.max, slider.result.to + slider.options.step);
 
         slider.update(val);
-        forceIonSliderUpdate(slider);
       };
 
       // If we're currently at the end, restart


### PR DESCRIPTION
All that's needed is to add a listener for `update`. This also reverts the previous fix, #1026.