### PR TITLE
Fix validation error handling

### DIFF
--- a/R/conditions.R
+++ b/R/conditions.R
@@ -130,6 +130,9 @@ withLogErrors <- function(expr,
   withCallingHandlers(
     captureStackTraces(expr),
     error = function(cond) {
+      # Don't print shiny.silent.error (i.e. validation errors)
+      if (inherits(cond, "shiny.silent.error"))
+        return()
       printError(cond, full = full, offset = offset)
     }
   )

--- a/R/utils.R
+++ b/R/utils.R
@@ -533,10 +533,16 @@ assignNestedList <- function(x = list(), idx, value) {
 # option (e.g. we can set options(shiny.error = recover))
 #' @include conditions.R
 shinyCallingHandlers <- function(expr) {
-  withCallingHandlers(captureStackTraces(expr), error = function(e) {
-    handle <- getOption('shiny.error')
-    if (is.function(handle)) handle()
-  })
+  withCallingHandlers(captureStackTraces(expr),
+    error = function(e) {
+      # Don't intercept shiny.silent.error (i.e. validation errors)
+      if (inherits(e, "shiny.silent.error"))
+        return()
+
+      handle <- getOption('shiny.error')
+      if (is.function(handle)) handle()
+    }
+  )
 }
 
 #' Print message for deprecated functions in Shiny


### PR DESCRIPTION
Validation errors were behaving too much like real errors: they were
being printed with stack traces, and passed to the options(shiny.error)
function. Also, if a reactive() cached a validation error, on future
calls the error would be re-raised (which is correct) without the
custom class names attached (which is not).