### PR TITLE
Remove unneeded do.call

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -666,9 +666,7 @@ ShinySession <- R6Class(
     },
     dispatch = function(msg) {
       method <- paste('@', msg$method, sep='')
-      # we must use $ instead of [[ here at the moment; see
-      # https://github.com/rstudio/shiny/issues/274
-      func <- try(do.call(`$`, list(self, method)), silent=TRUE)
+      func <- try(self[[method]], silent = TRUE)
       if (inherits(func, 'try-error')) {
         private$sendErrorResponse(msg, paste('Unknown method', msg$method))
       }


### PR DESCRIPTION
It's OK to remove this `do.call` now that we are using R6 instead of Ref Classes. In the testing mentioned in #274, the bug only happens with Ref Classes.

I've tested the `09_upload` app, and it works fine with this change. Still, we can hold off merging until after the next release.