### PR TITLE
Fixes #561: make sure DataTables always gets a correct number of columns of data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ r_binary_packages:
   - cairo
   - knitr
 
-r_github_packages:
-  - rstudio/htmltools
-
 notifications:
   email:
     on_success: change

--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,9 @@ shiny 0.13.0.9000
 
 * `flexCol` did not work on RStudio for Windows or Linux.
 
+* Fixed #561: DataTables might pop up a warning when the data is updated
+  extremely frequently.
+
 shiny 0.13.0
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
We should discard the request when the number of columns in the request is different with the number of columns of the actual data. 