### PR TITLE
Fix for https://github.com/rstudio/shiny/issues/692

### DIFF
--- a/R/shinyui.R
+++ b/R/shinyui.R
@@ -20,7 +20,7 @@ withMathJax <- function(...) {
       singleton(tags$script(src = path, type = 'text/javascript'))
     ),
     ...,
-    tags$script(HTML('MathJax.Hub.Queue(["Typeset", MathJax.Hub]);'))
+    tags$script(HTML('if (window.MathJax) MathJax.Hub.Queue(["Typeset", MathJax.Hub]);'))
   )
 }
 


### PR DESCRIPTION
As @yihui suggested, adding `if (window.MathJax)` to `withMathJax` should ensure that conditional panels will not break when a user is off-line and cannot access MathJax.js from CDN