### PR TITLE
Enable plot replaying

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,7 +10,11 @@ shiny 0.13.0.9000
 
 * BREAKING CHANGE: The long-deprecated ability to pass functions (rather than
   expressions) to reactive() and observe() has finally been removed.
+
 * Fixed #776: In some browsers, plots sometimes flickered when updated.
+
+* When resized, plots are drawn with `replayPlot()`, instead of re-executing
+  all plotting code. This results in faster plot rendering.
 
 shiny 0.13.0
 --------------------------------------------------------------------------------

--- a/R/render-plot.R
+++ b/R/render-plot.R
@@ -57,14 +57,8 @@ renderPlot <- function(expr, width='auto', height='auto', res=72, ...,
   else
     heightWrapper <- NULL
 
-  # If renderPlot isn't going to adapt to the height of the div, then the
-  # div needs to adapt to the height of renderPlot. By default, plotOutput
-  # sets the height to 400px, so to make it adapt we need to override it
-  # with NULL.
-  outputFunc <- plotOutput
-  if (!identical(height, 'auto')) formals(outputFunc)['height'] <- list(NULL)
 
-  return(markRenderFunction(outputFunc, function(shinysession, name, ...) {
+  renderFunc <- function(shinysession, name, ...) {
     if (!is.null(widthWrapper))
       width <- widthWrapper()
     if (!is.null(heightWrapper))
@@ -136,7 +130,17 @@ renderPlot <- function(expr, width='auto', height='auto', res=72, ...,
     }
 
     res
-  }))
+  }
+
+
+  # If renderPlot isn't going to adapt to the height of the div, then the
+  # div needs to adapt to the height of renderPlot. By default, plotOutput
+  # sets the height to 400px, so to make it adapt we need to override it
+  # with NULL.
+  outputFunc <- plotOutput
+  if (!identical(height, 'auto')) formals(outputFunc)['height'] <- list(NULL)
+
+  markRenderFunction(outputFunc, renderFunc)
 }
 
 # The coordmap extraction functions below return something like the examples

--- a/R/render-plot.R
+++ b/R/render-plot.R
@@ -165,6 +165,7 @@ renderPlot <- function(expr, width='auto', height='auto', res=72, ...,
 
     plotResult <- NULL
     recordedPlot <- NULL
+    coordmap <- NULL
     plotFunc <- function() {
       # Actually perform the plotting
       result <- withVisible(func())
@@ -205,7 +206,7 @@ renderPlot <- function(expr, width='auto', height='auto', res=72, ...,
     list(
       # img is the content that gets sent to the client.
       img = dropNulls(list(
-        src = session$fileUrl(name, outfile, contentType='image/png'),
+        src = session$fileUrl(outputName, outfile, contentType='image/png'),
         width = width,
         height = height,
         coordmap = coordmap,

--- a/R/render-plot.R
+++ b/R/render-plot.R
@@ -99,13 +99,13 @@ renderPlot <- function(expr, width='auto', height='auto', res=72, ...,
   }
 
   # Vars to store session and output, so that they can be accessed from
-  # the render() reactive.
+  # the plotObj() reactive.
   session <- NULL
   outputName <- NULL
 
   # This function is the one that's returned from renderPlot(), and gets
   # wrapped in an observer when the output value is assigned. The expression
-  # passed to renderPlot() is actually run in render(); this function can only
+  # passed to renderPlot() is actually run in plotObj(); this function can only
   # replay a plot if the width/height changes.
   renderFunc <- function(shinysession, name, ...) {
     session <<- shinysession
@@ -119,7 +119,7 @@ renderPlot <- function(expr, width='auto', height='auto', res=72, ...,
     }
 
     # The reactive that runs the expr in renderPlot()
-    plotData <- render()
+    plotData <- plotObj()
 
     img <- plotData$img
 
@@ -160,7 +160,7 @@ renderPlot <- function(expr, width='auto', height='auto', res=72, ...,
   }
 
 
-  render <- reactive({
+  plotObj <- reactive({
     if (replay) {
       isolate({ dims <- getDims() })
     } else {

--- a/R/render-plot.R
+++ b/R/render-plot.R
@@ -57,7 +57,21 @@ renderPlot <- function(expr, width='auto', height='auto', res=72, ...,
   else
     heightWrapper <- function() { height }
 
+
+  # Vars to store session and output, so that they can be accessed from
+  # render().
+  session <- NULL
+  outputName <- NULL
+
+  # This function gets wrapped in an observer
   renderFunc <- function(shinysession, name, ...) {
+    session <<- shinysession
+    outputName <<- name
+    render()
+  }
+
+
+  render <- reactive({
     width <- widthWrapper()
     height <- heightWrapper()
 
@@ -66,15 +80,15 @@ renderPlot <- function(expr, width='auto', height='auto', res=72, ...,
     # height were explicitly specified).
     prefix <- 'output_'
     if (width == 'auto')
-      width <- shinysession$clientData[[paste(prefix, name, '_width', sep='')]];
+      width <- session$clientData[[paste0(prefix, outputName, '_width')]];
     if (height == 'auto')
-      height <- shinysession$clientData[[paste(prefix, name, '_height', sep='')]];
+      height <- session$clientData[[paste0(prefix, outputName, '_height')]];
 
     if (is.null(width) || is.null(height) || width <= 0 || height <= 0)
       return(NULL)
 
     # Resolution multiplier
-    pixelratio <- shinysession$clientData$pixelratio
+    pixelratio <- session$clientData$pixelratio
     if (is.null(pixelratio))
       pixelratio <- 1
 
@@ -122,7 +136,7 @@ renderPlot <- function(expr, width='auto', height='auto', res=72, ...,
 
     # A list of attributes for the img
     res <- list(
-      src=shinysession$fileUrl(name, outfile, contentType='image/png'),
+      src=session$fileUrl(name, outfile, contentType='image/png'),
       width=width, height=height, coordmap=coordmap
     )
 
@@ -133,7 +147,7 @@ renderPlot <- function(expr, width='auto', height='auto', res=72, ...,
     }
 
     res
-  }
+  })
 
 
   # If renderPlot isn't going to adapt to the height of the div, then the

--- a/R/render-plot.R
+++ b/R/render-plot.R
@@ -91,9 +91,6 @@ renderPlot <- function(expr, width='auto', height='auto', res=72, ...,
     session <<- shinysession
     outputName <<- name
 
-    # The reactive that runs the expr in renderPlot()
-    plotData <- render()
-
     width <- widthWrapper()
     height <- heightWrapper()
     # Note that these are reactive calls. A change to the width and height
@@ -107,6 +104,9 @@ renderPlot <- function(expr, width='auto', height='auto', res=72, ...,
     if (is.null(width) || is.null(height) || width <= 0 || height <= 0)
       return(NULL)
 
+    # The reactive that runs the expr in renderPlot()
+    plotData <- render()
+
     img <- plotData$img
 
     # If only the width/height have changed, simply replay the plot and make a
@@ -116,8 +116,10 @@ renderPlot <- function(expr, width='auto', height='auto', res=72, ...,
 
       coordmap <- NULL
       plotFunc <- function() {
-        replayPlot(plotData$recordedPlot)
+        ..stacktraceon..(replayPlot(plotData$recordedPlot))
 
+        # Coordmap must be recalculated after replaying plot, because pixel
+        # dimensions will have changed.
         if (inherits(plotData$plotResult, "ggplot_build_gtable")) {
           coordmap <<- getGgplotCoordmap(plotData$plotResult, pixelratio)
         } else {

--- a/R/render-plot.R
+++ b/R/render-plot.R
@@ -37,10 +37,15 @@
 #'   is useful if you want to save an expression in a variable.
 #' @param func A function that generates a plot (deprecated; use \code{expr}
 #'   instead).
-#'
+#' @param replay If \code{TRUE} (the default), then when a plot is resized,
+#'   Shiny will \emph{replay} the plot drawing commands with
+#'   \code{\link[grDevices]{replayPlot}()} instead of re-executing \code{expr}.
+#'   This can result in faster plot redrawing, but there may be rare cases where
+#'   it is undesirable. If you encounter problems when resizing a plot, set this
+#'   to \code{FALSE}.
 #' @export
 renderPlot <- function(expr, width='auto', height='auto', res=72, ...,
-                       env=parent.frame(), quoted=FALSE, func=NULL) {
+                       env=parent.frame(), quoted=FALSE, func=NULL, replay=TRUE) {
   # This ..stacktraceon is matched by a ..stacktraceoff.. when plotFunc
   # is called
   installExprFunction(expr, "func", env, quoted, ..stacktraceon = TRUE)
@@ -156,7 +161,11 @@ renderPlot <- function(expr, width='auto', height='auto', res=72, ...,
 
 
   render <- reactive({
-    isolate({ dims <- getDims() })
+    if (replay) {
+      isolate({ dims <- getDims() })
+    } else {
+      dims <- getDims()
+    }
 
     if (is.null(dims$width) || is.null(dims$height) ||
         dims$width <= 0 || dims$height <= 0) {

--- a/R/render-plot.R
+++ b/R/render-plot.R
@@ -37,15 +37,16 @@
 #'   is useful if you want to save an expression in a variable.
 #' @param func A function that generates a plot (deprecated; use \code{expr}
 #'   instead).
-#' @param replay If \code{TRUE} (the default), then when a plot is resized,
-#'   Shiny will \emph{replay} the plot drawing commands with
+#' @param execOnResize If \code{FALSE} (the default), then when a plot is
+#'   resized, Shiny will \emph{replay} the plot drawing commands with
 #'   \code{\link[grDevices]{replayPlot}()} instead of re-executing \code{expr}.
 #'   This can result in faster plot redrawing, but there may be rare cases where
-#'   it is undesirable. If you encounter problems when resizing a plot, set this
-#'   to \code{FALSE}.
+#'   it is undesirable. If you encounter problems when resizing a plot, you can
+#'   have Shiny re-execute the code on resize by setting this to \code{TRUE}.
 #' @export
 renderPlot <- function(expr, width='auto', height='auto', res=72, ...,
-                       env=parent.frame(), quoted=FALSE, func=NULL, replay=TRUE) {
+                       env=parent.frame(), quoted=FALSE, func=NULL,
+                       execOnResize=FALSE) {
   # This ..stacktraceon is matched by a ..stacktraceoff.. when plotFunc
   # is called
   installExprFunction(expr, "func", env, quoted, ..stacktraceon = TRUE)
@@ -161,7 +162,7 @@ renderPlot <- function(expr, width='auto', height='auto', res=72, ...,
 
 
   plotObj <- reactive({
-    if (replay) {
+    if (execOnResize) {
       isolate({ dims <- getDims() })
     } else {
       dims <- getDims()

--- a/inst/tests/test-plot-coordmap.R
+++ b/inst/tests/test-plot-coordmap.R
@@ -6,6 +6,16 @@ sortList <- function(x) {
   x[sort(names(x))]
 }
 
+# Extract the print.ggplot function from inside of renderPlot. Yuck.
+print_ggplot_expr <- Filter(function(x) {
+  is.call(x) &&
+  x[[1]] == as.name("<-") &&
+  x[[2]] == as.name("print.ggplot")
+}, body(renderPlot))[[1]]
+# This will create print.ggplot in the current environment
+eval(print_ggplot_expr)
+
+
 test_that("ggplot coordmap", {
   dat <- data.frame(xvar = c(0, 5), yvar = c(10, 20))
 
@@ -17,7 +27,7 @@ test_that("ggplot coordmap", {
     scale_x_continuous(expand = c(0, 0)) +
     scale_y_continuous(expand = c(0, 0))
   png(tmpfile)
-  m <- getGgplotCoordmap(p, 1)
+  m <- getGgplotCoordmap(print(p), 1)
   dev.off()
 
   # Check mapping vars
@@ -32,7 +42,7 @@ test_that("ggplot coordmap", {
   # Scatterplot where aes() is declared in geom
   p <- ggplot(dat, aes(xvar)) + geom_point(aes(y=yvar))
   png(tmpfile)
-  m <- getGgplotCoordmap(p, 1)
+  m <- getGgplotCoordmap(print(p), 1)
   dev.off()
 
   # Check mapping vars
@@ -42,7 +52,7 @@ test_that("ggplot coordmap", {
   # Plot with computed variable (histogram)
   p <- ggplot(dat, aes(xvar)) + geom_histogram(binwidth=1)
   png(tmpfile)
-  m <- getGgplotCoordmap(p, 1)
+  m <- getGgplotCoordmap(print(p), 1)
   dev.off()
 
   # Check mapping vars - no value for y
@@ -63,7 +73,7 @@ test_that("ggplot coordmap with facet_wrap", {
     scale_y_continuous(expand = c(0, 0)) +
     facet_wrap(~ g, ncol = 2)
   png(tmpfile)
-  m <- getGgplotCoordmap(p, 1)
+  m <- getGgplotCoordmap(print(p), 1)
   dev.off()
 
   # Should have 3 panels
@@ -112,7 +122,7 @@ test_that("ggplot coordmap with facet_grid", {
   # facet_grid horizontal
   p1 <- p + facet_grid(. ~ g)
   png(tmpfile)
-  m <- getGgplotCoordmap(p1, 1)
+  m <- getGgplotCoordmap(print(p1), 1)
   dev.off()
 
   # Should have 3 panels
@@ -149,7 +159,7 @@ test_that("ggplot coordmap with facet_grid", {
   # facet_grid vertical
   p1 <- p + facet_grid(g ~ .)
   png(tmpfile)
-  m <- getGgplotCoordmap(p1, 1)
+  m <- getGgplotCoordmap(print(p1), 1)
   dev.off()
 
   # Should have 3 panels
@@ -197,7 +207,7 @@ test_that("ggplot coordmap with 2D facet_grid", {
 
   p1 <- p + facet_grid(g ~ h)
   png(tmpfile)
-  m <- getGgplotCoordmap(p1, 1)
+  m <- getGgplotCoordmap(print(p1), 1)
   dev.off()
 
   # Should have 4 panels

--- a/man/renderPlot.Rd
+++ b/man/renderPlot.Rd
@@ -5,7 +5,7 @@
 \title{Plot Output}
 \usage{
 renderPlot(expr, width = "auto", height = "auto", res = 72, ...,
-  env = parent.frame(), quoted = FALSE, func = NULL)
+  env = parent.frame(), quoted = FALSE, func = NULL, replay = TRUE)
 }
 \arguments{
 \item{expr}{An expression that generates a plot.}
@@ -32,6 +32,13 @@ is useful if you want to save an expression in a variable.}
 
 \item{func}{A function that generates a plot (deprecated; use \code{expr}
 instead).}
+
+\item{replay}{If \code{TRUE} (the default), then when a plot is resized,
+Shiny will \emph{replay} the plot drawing commands with
+\code{\link[grDevices]{replayPlot}()} instead of re-executing \code{expr}.
+This can result in faster plot redrawing, but there may be rare cases where
+it is undesirable. If you encounter problems when resizing a plot, set this
+to \code{FALSE}.}
 }
 \description{
 Renders a reactive plot that is suitable for assigning to an \code{output}

--- a/man/renderPlot.Rd
+++ b/man/renderPlot.Rd
@@ -5,7 +5,8 @@
 \title{Plot Output}
 \usage{
 renderPlot(expr, width = "auto", height = "auto", res = 72, ...,
-  env = parent.frame(), quoted = FALSE, func = NULL, replay = TRUE)
+  env = parent.frame(), quoted = FALSE, func = NULL,
+  execOnResize = FALSE)
 }
 \arguments{
 \item{expr}{An expression that generates a plot.}
@@ -33,12 +34,12 @@ is useful if you want to save an expression in a variable.}
 \item{func}{A function that generates a plot (deprecated; use \code{expr}
 instead).}
 
-\item{replay}{If \code{TRUE} (the default), then when a plot is resized,
-Shiny will \emph{replay} the plot drawing commands with
+\item{execOnResize}{If \code{FALSE} (the default), then when a plot is
+resized, Shiny will \emph{replay} the plot drawing commands with
 \code{\link[grDevices]{replayPlot}()} instead of re-executing \code{expr}.
 This can result in faster plot redrawing, but there may be rare cases where
-it is undesirable. If you encounter problems when resizing a plot, set this
-to \code{FALSE}.}
+it is undesirable. If you encounter problems when resizing a plot, you can
+have Shiny re-execute the code on resize by setting this to \code{TRUE}.}
 }
 \description{
 Renders a reactive plot that is suitable for assigning to an \code{output}


### PR DESCRIPTION
When a plot is made in `renderPlot`, it records the display list with `recordPlot`. Later, if only the height or width has changed (and no other inputs), the plot can be replayed with `replayPlot`, which can give a speed boost, especially with ggplot2.
