### PR TITLE
tiny update following the bigger renderTable() PR

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,8 @@
 shiny 0.13.1.9001
 --------------------------------------------------------------------------------
+* Improved `renderTable()` function to make the tables look prettier and also
+  provide the user with a lot more parameters to customize their tables with.
+
 * Added `updateActionButton()` function, so the user can change an Action Button's
   (or Link's) label and/or icon. Also check that the icon argument (for both
   creation and updating of a button) is valid and throw a warning otherwise.

--- a/R/render-table.R
+++ b/R/render-table.R
@@ -148,8 +148,8 @@ renderTable <- function(expr, striped = FALSE, hover = FALSE,
       } else if (nchar(align) == 1 && valid) {
         cols <- paste0(rep(align, ncol(data)+1), collapse="")
       } else {
-        stop("`align` must contain only the characters `l`, `c`, `r` and/or `?` and
-              have length either equal to 1 or to the total number of columns")
+        stop("`align` must contain only the characters `l`, `c`, `r` and/or `?` and",
+             "have length either equal to 1 or to the total number of columns")
       }
     }
 


### PR DESCRIPTION
-- added NEWS item documenting the change to `renderTable()`
-- fixed tiny bug (`stop()` message was spanning two lines with only one string)