### PR TITLE
Clean up examples

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -49,6 +49,9 @@ shiny 0.13.2.9001
 
 * Added `placeholder` option to `passwordInput`.
 
+* Almost all code examples now have a runnable example with `shinyApp()`, so
+  that users can run the examples and see them in action. (#1137, #1158)
+
 shiny 0.13.2
 --------------------------------------------------------------------------------
 

--- a/R/bootstrap-layout.R
+++ b/R/bootstrap-layout.R
@@ -31,7 +31,7 @@
 #' @seealso \code{\link{column}}, \code{\link{sidebarLayout}}
 #'
 #' @examples
-#' shinyUI(fluidPage(
+#' fluidPage(
 #'
 #'   # Application title
 #'   titlePanel("Hello Shiny!"),
@@ -52,9 +52,9 @@
 #'       plotOutput("distPlot")
 #'     )
 #'   )
-#' ))
+#' )
 #'
-#' shinyUI(fluidPage(
+#' fluidPage(
 #'   title = "Hello Shiny!",
 #'   fluidRow(
 #'     column(width = 4,
@@ -64,7 +64,7 @@
 #'       "3 offset 2"
 #'     )
 #'   )
-#' ))
+#' )
 #'
 #' @rdname fluidPage
 #' @export
@@ -115,7 +115,7 @@ fluidRow <- function(...) {
 #' @seealso \code{\link{column}}
 #'
 #' @examples
-#' shinyUI(fixedPage(
+#' fixedPage(
 #'   title = "Hello, Shiny!",
 #'   fixedRow(
 #'     column(width = 4,
@@ -125,7 +125,7 @@ fluidRow <- function(...) {
 #'       "3 offset 2"
 #'     )
 #'   )
-#' ))
+#' )
 #'
 #' @rdname fixedPage
 #' @export
@@ -227,7 +227,7 @@ titlePanel <- function(title, windowTitle=title) {
 #'
 #' @examples
 #' # Define UI
-#' shinyUI(fluidPage(
+#' fluidPage(
 #'
 #'   # Application title
 #'   titlePanel("Hello Shiny!"),
@@ -248,7 +248,7 @@ titlePanel <- function(title, windowTitle=title) {
 #'       plotOutput("distPlot")
 #'     )
 #'   )
-#' ))
+#' )
 #'
 #' @export
 sidebarLayout <- function(sidebarPanel,
@@ -286,13 +286,13 @@ sidebarLayout <- function(sidebarPanel,
 #' @seealso \code{\link{fluidPage}}, \code{\link{flowLayout}}
 #'
 #' @examples
-#' shinyUI(fluidPage(
+#' fluidPage(
 #'   verticalLayout(
 #'     a(href="http://example.com/link1", "Link One"),
 #'     a(href="http://example.com/link2", "Link Two"),
 #'     a(href="http://example.com/link3", "Link Three")
 #'   )
-#' ))
+#' )
 #' @export
 verticalLayout <- function(..., fluid = TRUE) {
   lapply(list(...), function(row) {

--- a/R/bootstrap-layout.R
+++ b/R/bootstrap-layout.R
@@ -31,7 +31,11 @@
 #' @seealso \code{\link{column}}, \code{\link{sidebarLayout}}
 #'
 #' @examples
-#' fluidPage(
+#' ## Only run examples in interactive R sessions
+#' if (interactive()) {
+#'
+#' # Example of UI with fluidPage
+#' ui <- fluidPage(
 #'
 #'   # Application title
 #'   titlePanel("Hello Shiny!"),
@@ -54,7 +58,19 @@
 #'   )
 #' )
 #'
-#' fluidPage(
+#' # Server logic
+#' server <- function(input, output) {
+#'   output$distPlot <- renderPlot({
+#'     hist(rnorm(input$obs))
+#'   })
+#' }
+#'
+#' # Complete app with UI and server components
+#' shinyApp(ui, server)
+#'
+#'
+#' # UI demonstrating column layouts
+#' ui <- fluidPage(
 #'   title = "Hello Shiny!",
 #'   fluidRow(
 #'     column(width = 4,
@@ -66,6 +82,8 @@
 #'   )
 #' )
 #'
+#' shinyApp(ui, server = function(input, output) { })
+#' }
 #' @rdname fluidPage
 #' @export
 fluidPage <- function(..., title = NULL, responsive = NULL, theme = NULL) {
@@ -115,7 +133,10 @@ fluidRow <- function(...) {
 #' @seealso \code{\link{column}}
 #'
 #' @examples
-#' fixedPage(
+#' ## Only run examples in interactive R sessions
+#' if (interactive()) {
+#'
+#' ui <- fixedPage(
 #'   title = "Hello, Shiny!",
 #'   fixedRow(
 #'     column(width = 4,
@@ -126,6 +147,9 @@ fluidRow <- function(...) {
 #'     )
 #'   )
 #' )
+#'
+#' shinyApp(ui, server = function(input, output) { })
+#' }
 #'
 #' @rdname fixedPage
 #' @export
@@ -160,24 +184,43 @@ fixedRow <- function(...) {
 #' @seealso \code{\link{fluidRow}}, \code{\link{fixedRow}}.
 #'
 #' @examples
-#' fluidRow(
-#'   column(4,
-#'     sliderInput("obs", "Number of observations:",
-#'                 min = 1, max = 1000, value = 500)
-#'   ),
-#'   column(8,
-#'     plotOutput("distPlot")
+#' ## Only run examples in interactive R sessions
+#' if (interactive()) {
+#'
+#' ui <- fluidPage(
+#'   fluidRow(
+#'     column(4,
+#'       sliderInput("obs", "Number of observations:",
+#'                   min = 1, max = 1000, value = 500)
+#'     ),
+#'     column(8,
+#'       plotOutput("distPlot")
+#'     )
 #'   )
 #' )
 #'
-#' fluidRow(
-#'   column(width = 4,
-#'     "4"
-#'   ),
-#'   column(width = 3, offset = 2,
-#'     "3 offset 2"
+#' server <- function(input, output) {
+#'   output$distPlot <- renderPlot({
+#'     hist(rnorm(input$obs))
+#'   })
+#' }
+#'
+#' shinyApp(ui, server)
+#'
+#'
+#'
+#' ui <- fluidPage(
+#'   fluidRow(
+#'     column(width = 4,
+#'       "4"
+#'     ),
+#'     column(width = 3, offset = 2,
+#'       "3 offset 2"
+#'     )
 #'   )
 #' )
+#' shinyApp(ui, server = function(input, output) { })
+#' }
 #' @export
 column <- function(width, ..., offset = 0) {
 
@@ -202,8 +245,14 @@ column <- function(width, ..., offset = 0) {
 #'
 #'
 #' @examples
-#' titlePanel("Hello Shiny!")
+#' ## Only run examples in interactive R sessions
+#' if (interactive()) {
 #'
+#' ui <- fluidPage(
+#'   titlePanel("Hello Shiny!")
+#' )
+#' shinyApp(ui, server = function(input, output) { })
+#' }
 #' @export
 titlePanel <- function(title, windowTitle=title) {
   tagList(
@@ -226,8 +275,11 @@ titlePanel <- function(title, windowTitle=title) {
 #'   layout.
 #'
 #' @examples
+#' ## Only run examples in interactive R sessions
+#' if (interactive()) {
+#'
 #' # Define UI
-#' fluidPage(
+#' ui <- fluidPage(
 #'
 #'   # Application title
 #'   titlePanel("Hello Shiny!"),
@@ -250,6 +302,16 @@ titlePanel <- function(title, windowTitle=title) {
 #'   )
 #' )
 #'
+#' # Server logic
+#' server <- function(input, output) {
+#'   output$distPlot <- renderPlot({
+#'     hist(rnorm(input$obs))
+#'   })
+#' }
+#'
+#' # Complete app with UI and server components
+#' shinyApp(ui, server)
+#' }
 #' @export
 sidebarLayout <- function(sidebarPanel,
                           mainPanel,
@@ -286,13 +348,18 @@ sidebarLayout <- function(sidebarPanel,
 #' @seealso \code{\link{fluidPage}}, \code{\link{flowLayout}}
 #'
 #' @examples
-#' fluidPage(
+#' ## Only run examples in interactive R sessions
+#' if (interactive()) {
+#'
+#' ui <- fluidPage(
 #'   verticalLayout(
 #'     a(href="http://example.com/link1", "Link One"),
 #'     a(href="http://example.com/link2", "Link Two"),
 #'     a(href="http://example.com/link3", "Link Three")
 #'   )
 #' )
+#' shinyApp(ui, server = function(input, output) { })
+#' }
 #' @export
 verticalLayout <- function(..., fluid = TRUE) {
   lapply(list(...), function(row) {
@@ -319,11 +386,16 @@ verticalLayout <- function(..., fluid = TRUE) {
 #' @seealso \code{\link{verticalLayout}}
 #'
 #' @examples
-#' flowLayout(
+#' ## Only run examples in interactive R sessions
+#' if (interactive()) {
+#'
+#' ui <- flowLayout(
 #'   numericInput("rows", "How many rows?", 5),
 #'   selectInput("letter", "Which letter?", LETTERS),
 #'   sliderInput("value", "What value?", 0, 100, 50)
 #' )
+#' shinyApp(ui, server = function(input, output) { })
+#' }
 #' @export
 flowLayout <- function(..., cellArgs = list()) {
 
@@ -369,21 +441,33 @@ inputPanel <- function(...) {
 #'   of the layout.
 #'
 #' @examples
+#' ## Only run examples in interactive R sessions
+#' if (interactive()) {
+#'
+#' # Server code used for all examples
+#' server <- function(input, output) {
+#'   output$plot1 <- renderPlot(plot(cars))
+#'   output$plot2 <- renderPlot(plot(pressure))
+#'   output$plot3 <- renderPlot(plot(AirPassengers))
+#' }
+#'
 #' # Equal sizing
-#' splitLayout(
+#' ui <- splitLayout(
 #'   plotOutput("plot1"),
 #'   plotOutput("plot2")
 #' )
+#' shinyApp(ui, server)
 #'
 #' # Custom widths
-#' splitLayout(cellWidths = c("25%", "75%"),
+#' ui <- splitLayout(cellWidths = c("25%", "75%"),
 #'   plotOutput("plot1"),
 #'   plotOutput("plot2")
 #' )
+#' shinyApp(ui, server)
 #'
 #' # All cells at 300 pixels wide, with cell padding
 #' # and a border around everything
-#' splitLayout(
+#' ui <- splitLayout(
 #'   style = "border: 1px solid silver;",
 #'   cellWidths = 300,
 #'   cellArgs = list(style = "padding: 6px"),
@@ -391,6 +475,8 @@ inputPanel <- function(...) {
 #'   plotOutput("plot2"),
 #'   plotOutput("plot3")
 #' )
+#' shinyApp(ui, server)
+#' }
 #' @export
 splitLayout <- function(..., cellWidths = NULL, cellArgs = list()) {
 
@@ -460,10 +546,7 @@ splitLayout <- function(..., cellWidths = NULL, cellArgs = list()) {
 #'   not determined by the height of its contents.
 #'
 #' @examples
-#' \donttest{
 #' # Only run this example in interactive R sessions.
-#' # NOTE: This example should be run with example(fillRow, ask = FALSE) to
-#' # avoid being prompted to hit Enter during plot rendering.
 #' if (interactive()) {
 #'
 #' ui <- fillPage(fillRow(
@@ -482,7 +565,6 @@ splitLayout <- function(..., cellWidths = NULL, cellArgs = list()) {
 #'
 #' shinyApp(ui, server)
 #'
-#' }
 #' }
 #' @export
 fillRow <- function(..., flex = 1, width = "100%", height = "100%") {

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -196,7 +196,7 @@ collapseSizes <- function(padding) {
 #'
 #' @examples
 #' # Define UI
-#' shinyUI(pageWithSidebar(
+#' pageWithSidebar(
 #'
 #'   # Application title
 #'   headerPanel("Hello Shiny!"),
@@ -214,7 +214,7 @@ collapseSizes <- function(padding) {
 #'   mainPanel(
 #'     plotOutput("distPlot")
 #'   )
-#' ))
+#' )
 #'
 #' @export
 pageWithSidebar <- function(headerPanel,
@@ -291,13 +291,13 @@ pageWithSidebar <- function(headerPanel,
 #'   \code{\link{updateNavbarPage}}
 #'
 #' @examples
-#' shinyUI(navbarPage("App Title",
+#' navbarPage("App Title",
 #'   tabPanel("Plot"),
 #'   tabPanel("Summary"),
 #'   tabPanel("Table")
-#' ))
+#' )
 #'
-#' shinyUI(navbarPage("App Title",
+#' navbarPage("App Title",
 #'   tabPanel("Plot"),
 #'   navbarMenu("More",
 #'     tabPanel("Summary"),
@@ -305,7 +305,7 @@ pageWithSidebar <- function(headerPanel,
 #'     "Section header",
 #'     tabPanel("Table")
 #'   )
-#' ))
+#' )
 #' @export
 navbarPage <- function(title,
                        ...,
@@ -679,7 +679,7 @@ tabsetPanel <- function(...,
 #'
 #' @seealso \code{\link{tabPanel}}, \code{\link{updateNavlistPanel}}
 #' @examples
-#' shinyUI(fluidPage(
+#' fluidPage(
 #'
 #'   titlePanel("Application Title"),
 #'
@@ -689,7 +689,7 @@ tabsetPanel <- function(...,
 #'     tabPanel("Second"),
 #'     tabPanel("Third")
 #'   )
-#' ))
+#' )
 #' @export
 navlistPanel <- function(...,
                          id = NULL,
@@ -1493,11 +1493,11 @@ downloadLink <- function(outputId, label="Download", class=NULL) {
 #' # add an icon to a submit button
 #' submitButton("Update View", icon = icon("refresh"))
 #'
-#' shinyUI(navbarPage("App Title",
+#' navbarPage("App Title",
 #'   tabPanel("Plot", icon = icon("bar-chart-o")),
 #'   tabPanel("Summary", icon = icon("list-alt")),
 #'   tabPanel("Table", icon = icon("table"))
-#' ))
+#' )
 #'
 #' @export
 icon <- function(name, class = NULL, lib = "font-awesome") {

--- a/R/input-action.R
+++ b/R/input-action.R
@@ -11,19 +11,29 @@
 #'
 #' @family input elements
 #' @examples
-#' \dontrun{
-#' # In server.R
-#' output$distPlot <- renderPlot({
-#'   # Take a dependency on input$goButton
-#'   input$goButton
+#' ## Only run examples in interactive R sessions
+#' if (interactive()) {
 #'
-#'   # Use isolate() to avoid dependency on input$obs
-#'   dist <- isolate(rnorm(input$obs))
-#'   hist(dist)
-#' })
+#' ui <- fluidPage(
+#'   sliderInput("obs", "Number of observations", 0, 1000, 500),
+#'   actionButton("goButton", "Go!"),
+#'   plotOutput("distPlot")
+#' )
 #'
-#' # In ui.R
-#' actionButton("goButton", "Go!")
+#' server <- function(input, output) {
+#'   output$distPlot <- renderPlot({
+#'     # Take a dependency on input$goButton. This will run once initially,
+#'     # because the value changes from NULL to 0.
+#'     input$goButton
+#'
+#'     # Use isolate() to avoid dependency on input$obs
+#'     dist <- isolate(rnorm(input$obs))
+#'     hist(dist)
+#'   })
+#' }
+#'
+#' shinyApp(ui, server)
+#'
 #' }
 #'
 #' @seealso \code{\link{observeEvent}} and \code{\link{eventReactive}}

--- a/R/input-checkbox.R
+++ b/R/input-checkbox.R
@@ -10,7 +10,18 @@
 #' @seealso \code{\link{checkboxGroupInput}}, \code{\link{updateCheckboxInput}}
 #'
 #' @examples
-#' checkboxInput("outliers", "Show outliers", FALSE)
+#' ## Only run examples in interactive R sessions
+#' if (interactive()) {
+#'
+#' ui <- fluidPage(
+#'   checkboxInput("somevalue", "Some value", FALSE),
+#'   verbatimTextOutput("value")
+#' )
+#' server <- function(input, output) {
+#'   output$value <- renderText({ input$somevalue })
+#' }
+#' shinyApp(ui, server)
+#' }
 #' @export
 checkboxInput <- function(inputId, label, value = FALSE, width = NULL) {
   inputTag <- tags$input(id = inputId, type="checkbox")

--- a/R/input-checkboxgroup.R
+++ b/R/input-checkboxgroup.R
@@ -15,11 +15,25 @@
 #' @seealso \code{\link{checkboxInput}}, \code{\link{updateCheckboxGroupInput}}
 #'
 #' @examples
-#' checkboxGroupInput("variable", "Variable:",
-#'                    c("Cylinders" = "cyl",
-#'                      "Transmission" = "am",
-#'                      "Gears" = "gear"))
+#' ## Only run examples in interactive R sessions
+#' if (interactive()) {
 #'
+#' ui <- fluidPage(
+#'   checkboxGroupInput("variable", "Variables to show:",
+#'                      c("Cylinders" = "cyl",
+#'                        "Transmission" = "am",
+#'                        "Gears" = "gear")),
+#'   tableOutput("data")
+#' )
+#'
+#' server <- function(input, output) {
+#'   output$data <- renderTable({
+#'     mtcars[, c("mpg", input$variable), drop = FALSE]
+#'   }, rownames = TRUE)
+#' }
+#'
+#' shinyApp(ui, server)
+#' }
 #' @export
 checkboxGroupInput <- function(inputId, label, choices, selected = NULL,
   inline = FALSE, width = NULL) {

--- a/R/input-date.R
+++ b/R/input-date.R
@@ -43,26 +43,33 @@
 #' @seealso \code{\link{dateRangeInput}}, \code{\link{updateDateInput}}
 #'
 #' @examples
-#' dateInput("date", "Date:", value = "2012-02-29")
+#' ## Only run examples in interactive R sessions
+#' if (interactive()) {
 #'
-#' # Default value is the date in client's time zone
-#' dateInput("date", "Date:")
+#' ui <- fluidPage(
+#'   dateInput("date1", "Date:", value = "2012-02-29"),
 #'
-#' # value is always yyyy-mm-dd, even if the display format is different
-#' dateInput("date", "Date:", value = "2012-02-29", format = "mm/dd/yy")
+#'   # Default value is the date in client's time zone
+#'   dateInput("date2", "Date:"),
 #'
-#' # Pass in a Date object
-#' dateInput("date", "Date:", value = Sys.Date()-10)
+#'   # value is always yyyy-mm-dd, even if the display format is different
+#'   dateInput("date3", "Date:", value = "2012-02-29", format = "mm/dd/yy"),
 #'
-#' # Use different language and different first day of week
-#' dateInput("date", "Date:",
+#'   # Pass in a Date object
+#'   dateInput("date4", "Date:", value = Sys.Date()-10),
+#'
+#'   # Use different language and different first day of week
+#'   dateInput("date5", "Date:",
 #'           language = "de",
-#'           weekstart = 1)
+#'           weekstart = 1),
 #'
-#' # Start with decade view instead of default month view
-#' dateInput("date", "Date:",
-#'           startview = "decade")
+#'   # Start with decade view instead of default month view
+#'   dateInput("date6", "Date:",
+#'             startview = "decade")
+#' )
 #'
+#' shinyApp(ui, server = function(input, output) { })
+#' }
 #' @export
 dateInput <- function(inputId, label, value = NULL, min = NULL, max = NULL,
   format = "yyyy-mm-dd", startview = "month", weekstart = 0, language = "en",

--- a/R/input-daterange.R
+++ b/R/input-daterange.R
@@ -32,37 +32,44 @@
 #' @seealso \code{\link{dateInput}}, \code{\link{updateDateRangeInput}}
 #'
 #' @examples
-#' dateRangeInput("daterange", "Date range:",
-#'                start = "2001-01-01",
-#'                end   = "2010-12-31")
+#' ## Only run examples in interactive R sessions
+#' if (interactive()) {
 #'
-#' # Default start and end is the current date in the client's time zone
-#' dateRangeInput("daterange", "Date range:")
+#' ui <- fluidPage(
+#'   dateRangeInput("daterange1", "Date range:",
+#'                  start = "2001-01-01",
+#'                  end   = "2010-12-31"),
 #'
-#' # start and end are always specified in yyyy-mm-dd, even if the display
-#' # format is different
-#' dateRangeInput("daterange", "Date range:",
-#'                start  = "2001-01-01",
-#'                end    = "2010-12-31",
-#'                min    = "2001-01-01",
-#'                max    = "2012-12-21",
-#'                format = "mm/dd/yy",
-#'                separator = " - ")
+#'   # Default start and end is the current date in the client's time zone
+#'   dateRangeInput("daterange2", "Date range:"),
 #'
-#' # Pass in Date objects
-#' dateRangeInput("daterange", "Date range:",
-#'                start = Sys.Date()-10,
-#'                end = Sys.Date()+10)
+#'   # start and end are always specified in yyyy-mm-dd, even if the display
+#'   # format is different
+#'   dateRangeInput("daterange3", "Date range:",
+#'                  start  = "2001-01-01",
+#'                  end    = "2010-12-31",
+#'                  min    = "2001-01-01",
+#'                  max    = "2012-12-21",
+#'                  format = "mm/dd/yy",
+#'                  separator = " - "),
 #'
-#' # Use different language and different first day of week
-#' dateRangeInput("daterange", "Date range:",
-#'                language = "de",
-#'                weekstart = 1)
+#'   # Pass in Date objects
+#'   dateRangeInput("daterange4", "Date range:",
+#'                  start = Sys.Date()-10,
+#'                  end = Sys.Date()+10),
 #'
-#' # Start with decade view instead of default month view
-#' dateRangeInput("daterange", "Date range:",
-#'                startview = "decade")
+#'   # Use different language and different first day of week
+#'   dateRangeInput("daterange5", "Date range:",
+#'                  language = "de",
+#'                  weekstart = 1),
 #'
+#'   # Start with decade view instead of default month view
+#'   dateRangeInput("daterange6", "Date range:",
+#'                  startview = "decade")
+#' )
+#'
+#' shinyApp(ui, server = function(input, output) { })
+#' }
 #' @export
 dateRangeInput <- function(inputId, label, start = NULL, end = NULL,
     min = NULL, max = NULL, format = "yyyy-mm-dd", startview = "month",

--- a/R/input-file.R
+++ b/R/input-file.R
@@ -28,6 +28,46 @@
 #' @param accept A character vector of MIME types; gives the browser a hint of
 #'   what kind of files the server is expecting.
 #'
+#' @examples
+#' ## Only run examples in interactive R sessions
+#' if (interactive()) {
+#'
+#' ui <- fluidPage(
+#'   sidebarLayout(
+#'     sidebarPanel(
+#'       fileInput("file1", "Choose CSV File",
+#'         accept = c(
+#'           "text/csv",
+#'           "text/comma-separated-values,text/plain",
+#'           ".csv")
+#'         ),
+#'       tags$hr(),
+#'       checkboxInput("header", "Header", TRUE)
+#'     ),
+#'     mainPanel(
+#'       tableOutput("contents")
+#'     )
+#'   )
+#' )
+#'
+#' server <- function(input, output) {
+#'   output$contents <- renderTable({
+#'     # input$file1 will be NULL initially. After the user selects
+#'     # and uploads a file, it will be a data frame with 'name',
+#'     # 'size', 'type', and 'datapath' columns. The 'datapath'
+#'     # column will contain the local filenames where the data can
+#'     # be found.
+#'     inFile <- input$file1
+#'
+#'     if (is.null(inFile))
+#'       return(NULL)
+#'
+#'     read.csv(inFile$datapath, header = input$header)
+#'   })
+#' }
+#'
+#' shinyApp(ui, server)
+#' }
 #' @export
 fileInput <- function(inputId, label, multiple = FALSE, accept = NULL,
   width = NULL) {

--- a/R/input-numeric.R
+++ b/R/input-numeric.R
@@ -13,8 +13,18 @@
 #' @seealso \code{\link{updateNumericInput}}
 #'
 #' @examples
-#' numericInput("obs", "Observations:", 10,
-#'              min = 1, max = 100)
+#' ## Only run examples in interactive R sessions
+#' if (interactive()) {
+#'
+#' ui <- fluidPage(
+#'   numericInput("obs", "Observations:", 10, min = 1, max = 100),
+#'   verbatimTextOutput("value")
+#' )
+#' server <- function(input, output) {
+#'   output$value <- renderText({ input$obs })
+#' }
+#' shinyApp(ui, server)
+#' }
 #' @export
 numericInput <- function(inputId, label, value, min = NA, max = NA, step = NA,
   width = NULL) {

--- a/R/input-password.R
+++ b/R/input-password.R
@@ -9,7 +9,22 @@
 #' @seealso \code{\link{updateTextInput}}
 #'
 #' @examples
-#' passwordInput("password", "Password:")
+#' ## Only run examples in interactive R sessions
+#' if (interactive()) {
+#'
+#' ui <- fluidPage(
+#'   passwordInput("password", "Password:"),
+#'   actionButton("go", "Go"),
+#'   verbatimTextOutput("value")
+#' )
+#' server <- function(input, output) {
+#'   output$value <- renderText({
+#'     req(input$go)
+#'     isolate(input$password)
+#'   })
+#' }
+#' shinyApp(ui, server)
+#' }
 #' @export
 passwordInput <- function(inputId, label, value = "", width = NULL,
                           placeholder = NULL) {

--- a/R/input-radiobuttons.R
+++ b/R/input-radiobuttons.R
@@ -21,11 +21,33 @@
 #' @seealso \code{\link{updateRadioButtons}}
 #'
 #' @examples
-#' radioButtons("dist", "Distribution type:",
-#'              c("Normal" = "norm",
-#'                "Uniform" = "unif",
-#'                "Log-normal" = "lnorm",
-#'                "Exponential" = "exp"))
+#' ## Only run examples in interactive R sessions
+#' if (interactive()) {
+#'
+#' ui <- fluidPage(
+#'   radioButtons("dist", "Distribution type:",
+#'                c("Normal" = "norm",
+#'                  "Uniform" = "unif",
+#'                  "Log-normal" = "lnorm",
+#'                  "Exponential" = "exp")),
+#'   plotOutput("distPlot")
+#' )
+#'
+#' server <- function(input, output) {
+#'   output$distPlot <- renderPlot({
+#'     dist <- switch(input$dist,
+#'                    norm = rnorm,
+#'                    unif = runif,
+#'                    lnorm = rlnorm,
+#'                    exp = rexp,
+#'                    rnorm)
+#'
+#'     hist(dist(500))
+#'   })
+#' }
+#'
+#' shinyApp(ui, server)
+#' }
 #' @export
 radioButtons <- function(inputId, label, choices, selected = NULL,
   inline = FALSE, width = NULL) {

--- a/R/input-select.R
+++ b/R/input-select.R
@@ -31,10 +31,25 @@
 #' @seealso \code{\link{updateSelectInput}}
 #'
 #' @examples
-#' selectInput("variable", "Variable:",
-#'             c("Cylinders" = "cyl",
-#'               "Transmission" = "am",
-#'               "Gears" = "gear"))
+#' ## Only run examples in interactive R sessions
+#' if (interactive()) {
+#'
+#' ui <- fluidPage(
+#'   selectInput("variable", "Variable:",
+#'               c("Cylinders" = "cyl",
+#'                 "Transmission" = "am",
+#'                 "Gears" = "gear")),
+#'   tableOutput("data")
+#' )
+#'
+#' server <- function(input, output) {
+#'   output$data <- renderTable({
+#'     mtcars[, c("mpg", input$variable), drop = FALSE]
+#'   }, rownames = TRUE)
+#' }
+#'
+#' shinyApp(ui, server)
+#' }
 #' @export
 selectInput <- function(inputId, label, choices, selected = NULL,
                         multiple = FALSE, selectize = TRUE, width = NULL,

--- a/R/input-slider.R
+++ b/R/input-slider.R
@@ -48,6 +48,27 @@
 #' @family input elements
 #' @seealso \code{\link{updateSliderInput}}
 #'
+#' @examples
+#' ## Only run examples in interactive R sessions
+#' if (interactive()) {
+#'
+#' ui <- fluidPage(
+#'   sliderInput("obs", "Number of observations:",
+#'     min = 0, max = 1000, value = 500
+#'   ),
+#'   plotOutput("distPlot")
+#' )
+#'
+#' # Server logic
+#' server <- function(input, output) {
+#'   output$distPlot <- renderPlot({
+#'     hist(rnorm(input$obs))
+#'   })
+#' }
+#'
+#' # Complete app with UI and server components
+#' shinyApp(ui, server)
+#' }
 #' @export
 sliderInput <- function(inputId, label, min, max, value, step = NULL,
                         round = FALSE, format = NULL, locale = NULL,

--- a/R/input-text.R
+++ b/R/input-text.R
@@ -16,7 +16,18 @@
 #' @seealso \code{\link{updateTextInput}}
 #'
 #' @examples
-#' textInput("caption", "Caption:", "Data Summary")
+#' ## Only run examples in interactive R sessions
+#' if (interactive()) {
+#'
+#' ui <- fluidPage(
+#'   textInput("caption", "Caption", "Data Summary"),
+#'   verbatimTextOutput("value")
+#' )
+#' server <- function(input, output) {
+#'   output$value <- renderText({ input$caption })
+#' }
+#' shinyApp(ui, server)
+#' }
 #' @export
 textInput <- function(inputId, label, value = "", width = NULL,
   placeholder = NULL) {

--- a/R/notifications.R
+++ b/R/notifications.R
@@ -24,6 +24,7 @@
 #' @return An ID for the notification.
 #'
 #' @examples
+#' ## Only run examples in interactive R sessions
 #' if (interactive()) {
 #' # Show a message when button is clicked
 #' shinyApp(

--- a/R/progress.R
+++ b/R/progress.R
@@ -57,7 +57,7 @@
 #' @examples
 #' \dontrun{
 #' # server.R
-#' shinyServer(function(input, output, session) {
+#' function(input, output, session) {
 #'   output$plot <- renderPlot({
 #'     progress <- shiny::Progress$new(session, min=1, max=15)
 #'     on.exit(progress$close())
@@ -71,7 +71,7 @@
 #'     }
 #'     plot(cars)
 #'   })
-#' })
+#' }
 #' }
 #' @seealso \code{\link{withProgress}}
 #' @format NULL
@@ -206,7 +206,7 @@ Progress <- R6Class(
 #' @examples
 #' \dontrun{
 #' # server.R
-#' shinyServer(function(input, output) {
+#' function(input, output) {
 #'   output$plot <- renderPlot({
 #'     withProgress(message = 'Calculation in progress',
 #'                  detail = 'This may take a while...', value = 0, {
@@ -217,7 +217,7 @@ Progress <- R6Class(
 #'     })
 #'     plot(cars)
 #'   })
-#' })
+#' }
 #' }
 #' @seealso \code{\link{Progress}}
 #' @rdname withProgress

--- a/R/progress.R
+++ b/R/progress.R
@@ -55,11 +55,16 @@
 #'   progress bar.
 #'
 #' @examples
-#' \dontrun{
-#' # server.R
-#' function(input, output, session) {
+#' ## Only run examples in interactive R sessions
+#' if (interactive()) {
+#'
+#' ui <- fluidPage(
+#'   plotOutput("plot")
+#' )
+#'
+#' server <- function(input, output, session) {
 #'   output$plot <- renderPlot({
-#'     progress <- shiny::Progress$new(session, min=1, max=15)
+#'     progress <- Progress$new(session, min=1, max=15)
 #'     on.exit(progress$close())
 #'
 #'     progress$set(message = 'Calculation in progress',
@@ -72,6 +77,8 @@
 #'     plot(cars)
 #'   })
 #' }
+#'
+#' shinyApp(ui, server)
 #' }
 #' @seealso \code{\link{withProgress}}
 #' @format NULL
@@ -204,9 +211,14 @@ Progress <- R6Class(
 #'   progress bar, if it is currently visible.
 #'
 #' @examples
-#' \dontrun{
-#' # server.R
-#' function(input, output) {
+#' ## Only run examples in interactive R sessions
+#' if (interactive()) {
+#'
+#' ui <- fluidPage(
+#'   plotOutput("plot")
+#' )
+#'
+#' server <- function(input, output) {
 #'   output$plot <- renderPlot({
 #'     withProgress(message = 'Calculation in progress',
 #'                  detail = 'This may take a while...', value = 0, {
@@ -218,6 +230,8 @@ Progress <- R6Class(
 #'     plot(cars)
 #'   })
 #' }
+#'
+#' shinyApp(ui, server)
 #' }
 #' @seealso \code{\link{Progress}}
 #' @rdname withProgress

--- a/R/reactives.R
+++ b/R/reactives.R
@@ -931,8 +931,15 @@ setAutoflush <- local({
 #' @seealso \code{\link{invalidateLater}}
 #'
 #' @examples
-#' \dontrun{
-#' function(input, output, session) {
+#' ## Only run examples in interactive R sessions
+#' if (interactive()) {
+#'
+#' ui <- fluidPage(
+#'   sliderInput("n", "Number of observations", 2, 1000, 500),
+#'   plotOutput("plot")
+#' )
+#'
+#' server <- function(input, output) {
 #'
 #'   # Anything that calls autoInvalidate will automatically invalidate
 #'   # every 2 seconds.
@@ -953,9 +960,11 @@ setAutoflush <- local({
 #'   # input$n changes.
 #'   output$plot <- renderPlot({
 #'     autoInvalidate()
-#'     hist(isolate(input$n))
+#'     hist(rnorm(isolate(input$n)))
 #'   })
 #' }
+#'
+#' shinyApp(ui, server)
 #' }
 #'
 #' @export
@@ -1009,8 +1018,15 @@ reactiveTimer <- function(intervalMs=1000, session = getDefaultReactiveDomain())
 #' @seealso \code{\link{reactiveTimer}} is a slightly less safe alternative.
 #'
 #' @examples
-#' \dontrun{
-#' function(input, output, session) {
+#' ## Only run examples in interactive R sessions
+#' if (interactive()) {
+#'
+#' ui <- fluidPage(
+#'   sliderInput("n", "Number of observations", 2, 1000, 500),
+#'   plotOutput("plot")
+#' )
+#'
+#' server <- function(input, output, session) {
 #'
 #'   observe({
 #'     # Re-execute this reactive expression after 1000 milliseconds
@@ -1027,11 +1043,12 @@ reactiveTimer <- function(intervalMs=1000, session = getDefaultReactiveDomain())
 #'   output$plot <- renderPlot({
 #'     # Re-execute this reactive expression after 2000 milliseconds
 #'     invalidateLater(2000)
-#'     hist(isolate(input$n))
+#'     hist(rnorm(isolate(input$n)))
 #'   })
 #' }
-#' }
 #'
+#' shinyApp(ui, server)
+#' }
 #' @export
 invalidateLater <- function(millis, session = getDefaultReactiveDomain()) {
   ctx <- .getReactiveEnvironment()$currentContext()
@@ -1101,14 +1118,12 @@ coerceToFunc <- function(x) {
 #' @seealso \code{\link{reactiveFileReader}}
 #'
 #' @examples
-#' \dontrun{
 #' # Assume the existence of readTimestamp and readValue functions
 #' function(input, output, session) {
 #'   data <- reactivePoll(1000, session, readTimestamp, readValue)
 #'   output$dataTable <- renderTable({
 #'     data()
 #'   })
-#' }
 #' }
 #'
 #' @export

--- a/R/reactives.R
+++ b/R/reactives.R
@@ -932,7 +932,7 @@ setAutoflush <- local({
 #'
 #' @examples
 #' \dontrun{
-#' shinyServer(function(input, output, session) {
+#' function(input, output, session) {
 #'
 #'   # Anything that calls autoInvalidate will automatically invalidate
 #'   # every 2 seconds.
@@ -955,7 +955,7 @@ setAutoflush <- local({
 #'     autoInvalidate()
 #'     hist(isolate(input$n))
 #'   })
-#' })
+#' }
 #' }
 #'
 #' @export
@@ -1010,7 +1010,7 @@ reactiveTimer <- function(intervalMs=1000, session = getDefaultReactiveDomain())
 #'
 #' @examples
 #' \dontrun{
-#' shinyServer(function(input, output, session) {
+#' function(input, output, session) {
 #'
 #'   observe({
 #'     # Re-execute this reactive expression after 1000 milliseconds
@@ -1029,7 +1029,7 @@ reactiveTimer <- function(intervalMs=1000, session = getDefaultReactiveDomain())
 #'     invalidateLater(2000)
 #'     hist(isolate(input$n))
 #'   })
-#' })
+#' }
 #' }
 #'
 #' @export
@@ -1103,12 +1103,12 @@ coerceToFunc <- function(x) {
 #' @examples
 #' \dontrun{
 #' # Assume the existence of readTimestamp and readValue functions
-#' shinyServer(function(input, output, session) {
+#' function(input, output, session) {
 #'   data <- reactivePoll(1000, session, readTimestamp, readValue)
 #'   output$dataTable <- renderTable({
 #'     data()
 #'   })
-#' })
+#' }
 #' }
 #'
 #' @export
@@ -1170,7 +1170,7 @@ reactivePoll <- function(intervalMillis, session, checkFunc, valueFunc) {
 #' @examples
 #' \dontrun{
 #' # Per-session reactive file reader
-#' shinyServer(function(input, output, session)) {
+#' function(input, output, session) {
 #'   fileData <- reactiveFileReader(1000, session, 'data.csv', read.csv)
 #'
 #'   output$data <- renderTable({
@@ -1182,7 +1182,7 @@ reactivePoll <- function(intervalMillis, session, checkFunc, valueFunc) {
 #' # the same reader, so read.csv only gets executed once no matter how many
 #' # user sessions are connected.
 #' fileData <- reactiveFileReader(1000, session, 'data.csv', read.csv)
-#' shinyServer(function(input, output, session)) {
+#' function(input, output, session) {
 #'   output$data <- renderTable({
 #'     fileData()
 #'   })

--- a/R/run-url.R
+++ b/R/run-url.R
@@ -22,7 +22,7 @@
 #' @export
 #' @examples
 #' ## Only run this example in interactive R sessions
-#'   if (interactive()) {
+#' if (interactive()) {
 #'   runUrl('https://github.com/rstudio/shiny_example/archive/master.tar.gz')
 #'
 #'   # Can run an app from a subdirectory in the archive

--- a/R/shinywrappers.R
+++ b/R/shinywrappers.R
@@ -131,9 +131,17 @@ as.tags.shiny.render.function <- function(x, ..., inline = FALSE) {
 #' @export
 #'
 #' @examples
-#' \dontrun{
+#' ## Only run examples in interactive R sessions
+#' if (interactive()) {
 #'
-#' function(input, output, clientData) {
+#' ui <- fluidPage(
+#'   sliderInput("n", "Number of observations", 2, 1000, 500),
+#'   plotOutput("plot1"),
+#'   plotOutput("plot2"),
+#'   plotOutput("plot3")
+#' )
+#'
+#' server <- function(input, output, session) {
 #'
 #'   # A plot of fixed size
 #'   output$plot1 <- renderImage({
@@ -155,14 +163,14 @@ as.tags.shiny.render.function <- function(x, ..., inline = FALSE) {
 #'   output$plot2 <- renderImage({
 #'     # Read plot2's width and height. These are reactive values, so this
 #'     # expression will re-run whenever these values change.
-#'     width  <- clientData$output_plot2_width
-#'     height <- clientData$output_plot2_height
+#'     width  <- session$clientData$output_plot2_width
+#'     height <- session$clientData$output_plot2_height
 #'
 #'     # A temp file to save the output.
 #'     outfile <- tempfile(fileext='.png')
 #'
 #'     png(outfile, width=width, height=height)
-#'     hist(rnorm(input$obs))
+#'     hist(rnorm(input$n))
 #'     dev.off()
 #'
 #'     # Return a list containing the filename
@@ -173,6 +181,8 @@ as.tags.shiny.render.function <- function(x, ..., inline = FALSE) {
 #'   }, deleteFile = TRUE)
 #'
 #'   # Send a pre-rendered image, and don't delete the image after sending it
+#'   # NOTE: For this example to work, it would require files in a subdirectory
+#'   # named images/
 #'   output$plot3 <- renderImage({
 #'     # When input$n is 1, filename is ./images/image1.jpeg
 #'     filename <- normalizePath(file.path('./images',
@@ -183,6 +193,7 @@ as.tags.shiny.render.function <- function(x, ..., inline = FALSE) {
 #'   }, deleteFile = FALSE)
 #' }
 #'
+#' shinyApp(ui, server)
 #' }
 renderImage <- function(expr, env=parent.frame(), quoted=FALSE,
                         deleteFile=TRUE, outputArgs=list()) {
@@ -318,13 +329,24 @@ renderText <- function(expr, env=parent.frame(), quoted=FALSE,
 #'
 #' @export
 #' @examples
-#' \dontrun{
-#'   output$moreControls <- renderUI({
-#'     list(
+#' ## Only run examples in interactive R sessions
+#' if (interactive()) {
 #'
+#' ui <- fluidPage(
+#'   uiOutput("moreControls")
+#' )
+#'
+#' server <- function(input, output) {
+#'   output$moreControls <- renderUI({
+#'     tagList(
+#'       sliderInput("n", "N", 1, 1000, 500),
+#'       textInput("label", "Label")
 #'     )
 #'   })
 #' }
+#' shinyApp(ui, server)
+#' }
+#'
 renderUI <- function(expr, env=parent.frame(), quoted=FALSE,
                      outputArgs=list()) {
   installExprFunction(expr, "func", env, quoted)
@@ -368,21 +390,29 @@ renderUI <- function(expr, env=parent.frame(), quoted=FALSE,
 #'   in an interactive R Markdown document.
 #'
 #' @examples
-#' \dontrun{
-#' # In server.R:
-#' output$downloadData <- downloadHandler(
-#'   filename = function() {
-#'     paste('data-', Sys.Date(), '.csv', sep='')
-#'   },
-#'   content = function(file) {
-#'     write.csv(data, file)
-#'   }
+#' ## Only run examples in interactive R sessions
+#' if (interactive()) {
+#'
+#' ui <- fluidPage(
+#'   downloadLink("downloadData", "Download")
 #' )
 #'
-#' # In ui.R:
-#' downloadLink('downloadData', 'Download')
+#' server <- function(input, output) {
+#'   # Our dataset
+#'   data <- mtcars
+#'
+#'   output$downloadData <- downloadHandler(
+#'     filename = function() {
+#'       paste("data-", Sys.Date(), ".csv", sep="")
+#'     },
+#'     content = function(file) {
+#'       write.csv(data, file)
+#'     }
+#'   )
 #' }
 #'
+#' shinyApp(ui, server)
+#' }
 #' @export
 downloadHandler <- function(filename, content, contentType=NA, outputArgs=list()) {
   renderFunc <- function(shinysession, name, ...) {

--- a/R/shinywrappers.R
+++ b/R/shinywrappers.R
@@ -133,7 +133,7 @@ as.tags.shiny.render.function <- function(x, ..., inline = FALSE) {
 #' @examples
 #' \dontrun{
 #'
-#' shinyServer(function(input, output, clientData) {
+#' function(input, output, clientData) {
 #'
 #'   # A plot of fixed size
 #'   output$plot1 <- renderImage({
@@ -181,7 +181,7 @@ as.tags.shiny.render.function <- function(x, ..., inline = FALSE) {
 #'     # Return a list containing the filename
 #'     list(src = filename)
 #'   }, deleteFile = FALSE)
-#' })
+#' }
 #'
 #' }
 renderImage <- function(expr, env=parent.frame(), quoted=FALSE,

--- a/R/update-input.R
+++ b/R/update-input.R
@@ -6,9 +6,16 @@
 #' @seealso \code{\link{textInput}}
 #'
 #' @examples
-#' \dontrun{
-#' function(input, output, session) {
+#' ## Only run examples in interactive R sessions
+#' if (interactive()) {
 #'
+#' ui <- fluidPage(
+#'   sliderInput("controller", "Controller", 0, 20, 10),
+#'   textInput("inText", "Input text"),
+#'   textInput("inText2", "Input text 2")
+#' )
+#'
+#' server <- function(input, output, session) {
 #'   observe({
 #'     # We'll use the input$controller variable multiple times, so save it as x
 #'     # for convenience.
@@ -23,6 +30,8 @@
 #'       value = paste("New text", x))
 #'   })
 #' }
+#'
+#' shinyApp(ui, server)
 #' }
 #' @export
 updateTextInput <- function(session, inputId, label = NULL, value = NULL) {
@@ -39,16 +48,24 @@ updateTextInput <- function(session, inputId, label = NULL, value = NULL) {
 #' @seealso \code{\link{checkboxInput}}
 #'
 #' @examples
-#' \dontrun{
-#' function(input, output, session) {
+#' ## Only run examples in interactive R sessions
+#' if (interactive()) {
 #'
+#' ui <- fluidPage(
+#'   sliderInput("controller", "Controller", 0, 1, 0, step = 1),
+#'   checkboxInput("inCheckbox", "Input checkbox")
+#' )
+#'
+#' server <- function(input, output, session) {
 #'   observe({
-#'     # TRUE if input$controller is even, FALSE otherwise.
-#'     x_even <- input$controller %% 2 == 0
+#'     # TRUE if input$controller is odd, FALSE if even.
+#'     x_even <- input$controller %% 2 == 1
 #'
 #'     updateCheckboxInput(session, "inCheckbox", value = x_even)
 #'   })
 #' }
+#'
+#' shinyApp(ui, server)
 #' }
 #' @export
 updateCheckboxInput <- updateTextInput
@@ -63,10 +80,23 @@ updateCheckboxInput <- updateTextInput
 #' @seealso \code{\link{actionButton}}
 #'
 #' @examples
-#' \dontrun{
-#' function(input, output, session) {
+#' ## Only run examples in interactive R sessions
+#' if (interactive()) {
 #'
+#' ui <- fluidPage(
+#'   actionButton("update", "Update other buttons"),
+#'   br(),
+#'   actionButton("goButton", "Go"),
+#'   br(),
+#'   actionButton("goButton2", "Go 2", icon = icon("area-chart")),
+#'   br(),
+#'   actionButton("goButton3", "Go 3")
+#' )
+#'
+#' server <- function(input, output, session) {
 #'   observe({
+#'     req(input$update)
+#'
 #'     # Updates goButton's label and icon
 #'     updateActionButton(session, "goButton",
 #'       label = "New label",
@@ -80,9 +110,11 @@ updateCheckboxInput <- updateTextInput
 #'     # Leaves goButton3's icon, if it exists,
 #'     # unchaged and changes its label
 #'     updateActionButton(session, "goButton3",
-#'       label = "New label")
+#'       label = "New label 3")
 #'   })
 #' }
+#'
+#' shinyApp(ui, server)
 #' }
 #' @export
 updateActionButton <- function(session, inputId, label = NULL, icon = NULL) {
@@ -105,9 +137,15 @@ updateActionButton <- function(session, inputId, label = NULL, icon = NULL) {
 #' @seealso \code{\link{dateInput}}
 #'
 #' @examples
-#' \dontrun{
-#' function(input, output, session) {
+#' ## Only run examples in interactive R sessions
+#' if (interactive()) {
 #'
+#' ui <- fluidPage(
+#'   sliderInput("controller", "Controller", 1, 30, 10),
+#'   dateInput("inDate", "Input date")
+#' )
+#'
+#' server <- function(input, output, session) {
 #'   observe({
 #'     # We'll use the input$controller variable multiple times, so save it as x
 #'     # for convenience.
@@ -121,6 +159,8 @@ updateActionButton <- function(session, inputId, label = NULL, icon = NULL) {
 #'     )
 #'   })
 #' }
+#'
+#' shinyApp(ui, server)
 #' }
 #' @export
 updateDateInput <- function(session, inputId, label = NULL, value = NULL,
@@ -152,9 +192,15 @@ updateDateInput <- function(session, inputId, label = NULL, value = NULL,
 #' @seealso \code{\link{dateRangeInput}}
 #'
 #' @examples
-#' \dontrun{
-#' function(input, output, session) {
+#' ## Only run examples in interactive R sessions
+#' if (interactive()) {
 #'
+#' ui <- fluidPage(
+#'   sliderInput("controller", "Controller", 1, 30, 10),
+#'   dateRangeInput("inDateRange", "Input date range")
+#' )
+#'
+#' server <- function(input, output, session) {
 #'   observe({
 #'     # We'll use the input$controller variable multiple times, so save it as x
 #'     # for convenience.
@@ -162,10 +208,13 @@ updateDateInput <- function(session, inputId, label = NULL, value = NULL,
 #'
 #'     updateDateRangeInput(session, "inDateRange",
 #'       label = paste("Date range label", x),
-#'       start = paste("2013-01-", x, sep=""))
-#'       end = paste("2013-12-", x, sep=""))
+#'       start = paste("2013-01-", x, sep=""),
+#'       end = paste("2013-12-", x, sep="")
+#'     )
 #'   })
 #' }
+#'
+#' shinyApp(ui, server)
 #' }
 #' @export
 updateDateRangeInput <- function(session, inputId, label = NULL,
@@ -200,22 +249,31 @@ updateDateRangeInput <- function(session, inputId, label = NULL,
 #' \code{\link{navbarPage}}
 #'
 #' @examples
-#' \dontrun{
-#' function(input, output, session) {
+#' ## Only run examples in interactive R sessions
+#' if (interactive()) {
 #'
-#'   observe({
-#'     # TRUE if input$controller is even, FALSE otherwise.
-#'     x_even <- input$controller %% 2 == 0
+#' ui <- fluidPage(sidebarLayout(
+#'   sidebarPanel(
+#'     sliderInput("controller", "Controller", 1, 3, 1)
+#'   ),
+#'   mainPanel(
+#'     tabsetPanel(id = "inTabset",
+#'       tabPanel(title = "Panel 1", value = "panel1", "Panel 1 content"),
+#'       tabPanel(title = "Panel 2", value = "panel2", "Panel 2 content"),
+#'       tabPanel(title = "Panel 3", value = "panel3", "Panel 3 content")
+#'     )
+#'   )
+#' ))
 #'
-#'     # Change the selected tab.
-#'     # Note that the tabset container must have been created with an 'id' argument
-#'     if (x_even) {
-#'       updateTabsetPanel(session, "inTabset", selected = "panel2")
-#'     } else {
-#'       updateTabsetPanel(session, "inTabset", selected = "panel1")
-#'     }
+#' server <- function(input, output, session) {
+#'   observeEvent(input$controller, {
+#'     updateTabsetPanel(session, "inTabset",
+#'       selected = paste0("panel", input$controller)
+#'     )
 #'   })
 #' }
+#'
+#' shinyApp(ui, server)
 #' }
 #' @export
 updateTabsetPanel <- function(session, inputId, selected = NULL) {
@@ -242,10 +300,18 @@ updateNavlistPanel <- updateTabsetPanel
 #' @seealso \code{\link{numericInput}}
 #'
 #' @examples
-#' \dontrun{
-#' function(input, output, session) {
+#' ## Only run examples in interactive R sessions
+#' if (interactive()) {
 #'
-#'   observe({
+#' ui <- fluidPage(
+#'   sliderInput("controller", "Controller", 0, 20, 10),
+#'   numericInput("inNumber", "Input number", 0),
+#'   numericInput("inNumber2", "Input number 2", 0)
+#' )
+#'
+#' server <- function(input, output, session) {
+#'
+#'   observeEvent(input$controller, {
 #'     # We'll use the input$controller variable multiple times, so save it as x
 #'     # for convenience.
 #'     x <- input$controller
@@ -257,6 +323,8 @@ updateNavlistPanel <- updateTabsetPanel
 #'       value = x, min = x-10, max = x+10, step = 5)
 #'   })
 #' }
+#'
+#' shinyApp(ui, server)
 #' }
 #' @export
 updateNumericInput <- function(session, inputId, label = NULL, value = NULL,
@@ -368,31 +436,35 @@ updateInputOptions <- function(session, inputId, label = NULL, choices = NULL,
 #' @seealso \code{\link{checkboxGroupInput}}
 #'
 #' @examples
-#' \dontrun{
-#' function(input, output, session) {
+#' ## Only run examples in interactive R sessions
+#' if (interactive()) {
 #'
+#' ui <- fluidPage(
+#'   p("The first checkbox group controls the second"),
+#'   checkboxGroupInput("inCheckboxGroup", "Input checkbox",
+#'     c("Item A", "Item B", "Item C")),
+#'   checkboxGroupInput("inCheckboxGroup2", "Input checkbox 2",
+#'     c("Item A", "Item B", "Item C"))
+#' )
+#'
+#' server <- function(input, output, session) {
 #'   observe({
-#'     # We'll use the input$controller variable multiple times, so save it as x
-#'     # for convenience.
-#'     x <- input$controller
+#'     x <- input$inCheckboxGroup
 #'
-#'     # Create a list of new options, where the name of the items is something
-#'     # like 'option label x 1', and the values are 'option-x-1'.
-#'     cb_options <- list()
-#'     cb_options[[sprintf("option label %d 1", x)]] <- sprintf("option-%d-1", x)
-#'     cb_options[[sprintf("option label %d 2", x)]] <- sprintf("option-%d-2", x)
-#'
-#'     # Change values for input$inCheckboxGroup
-#'     updateCheckboxGroupInput(session, "inCheckboxGroup", choices = cb_options)
+#'     # Can use character(0) to remove all choices
+#'     if (is.null(x))
+#'       x <- character(0)
 #'
 #'     # Can also set the label and select items
 #'     updateCheckboxGroupInput(session, "inCheckboxGroup2",
-#'       label = paste("checkboxgroup label", x),
-#'       choices = cb_options,
-#'       selected = sprintf("option-%d-2", x)
+#'       label = paste("Checkboxgroup label", length(x)),
+#'       choices = x,
+#'       selected = x
 #'     )
 #'   })
 #' }
+#'
+#' shinyApp(ui, server)
 #' }
 #' @export
 updateCheckboxGroupInput <- function(session, inputId, label = NULL,
@@ -410,29 +482,31 @@ updateCheckboxGroupInput <- function(session, inputId, label = NULL,
 #' @seealso \code{\link{radioButtons}}
 #'
 #' @examples
-#' \dontrun{
-#' function(input, output, session) {
+#' ## Only run examples in interactive R sessions
+#' if (interactive()) {
 #'
+#' ui <- fluidPage(
+#'   p("The first radio button group controls the second"),
+#'   radioButtons("inRadioButtons", "Input radio buttons",
+#'     c("Item A", "Item B", "Item C")),
+#'   radioButtons("inRadioButtons2", "Input radio buttons 2",
+#'     c("Item A", "Item B", "Item C"))
+#' )
+#'
+#' server <- function(input, output, session) {
 #'   observe({
-#'     # We'll use the input$controller variable multiple times, so save it as x
-#'     # for convenience.
-#'     x <- input$controller
+#'     x <- input$inRadioButtons
 #'
-#'     r_options <- list()
-#'     r_options[[sprintf("option label %d 1", x)]] <- sprintf("option-%d-1", x)
-#'     r_options[[sprintf("option label %d 2", x)]] <- sprintf("option-%d-2", x)
-#'
-#'     # Change values for input$inRadio
-#'     updateRadioButtons(session, "inRadio", choices = r_options)
-#'
-#'     # Can also set the label and select an item
-#'     updateRadioButtons(session, "inRadio2",
-#'       label = paste("Radio label", x),
-#'       choices = r_options,
-#'       selected = sprintf("option-%d-2", x)
+#'     # Can also set the label and select items
+#'     updateRadioButtons(session, "inRadioButtons2",
+#'       label = paste("radioButtons label", x),
+#'       choices = x,
+#'       selected = x
 #'     )
 #'   })
 #' }
+#'
+#' shinyApp(ui, server)
 #' }
 #' @export
 updateRadioButtons <- function(session, inputId, label = NULL, choices = NULL,
@@ -451,32 +525,35 @@ updateRadioButtons <- function(session, inputId, label = NULL, choices = NULL,
 #' @seealso \code{\link{selectInput}}
 #'
 #' @examples
-#' \dontrun{
-#' function(input, output, session) {
+#' ## Only run examples in interactive R sessions
+#' if (interactive()) {
 #'
+#' ui <- fluidPage(
+#'   p("The checkbox group controls the select input"),
+#'   checkboxGroupInput("inCheckboxGroup", "Input checkbox",
+#'     c("Item A", "Item B", "Item C")),
+#'   selectInput("inSelect", "Select input",
+#'     c("Item A", "Item B", "Item C"))
+#' )
+#'
+#' server <- function(input, output, session) {
 #'   observe({
-#'     # We'll use the input$controller variable multiple times, so save it as x
-#'     # for convenience.
-#'     x <- input$controller
+#'     x <- input$inCheckboxGroup
 #'
-#'     # Create a list of new options, where the name of the items is something
-#'     # like 'option label x 1', and the values are 'option-x-1'.
-#'     s_options <- list()
-#'     s_options[[sprintf("option label %d 1", x)]] <- sprintf("option-%d-1", x)
-#'     s_options[[sprintf("option label %d 2", x)]] <- sprintf("option-%d-2", x)
+#'     # Can use character(0) to remove all choices
+#'     if (is.null(x))
+#'       x <- character(0)
 #'
-#'     # Change values for input$inSelect
-#'     updateSelectInput(session, "inSelect", choices = s_options)
-#'
-#'     # Can also set the label and select an item (or more than one if it's a
-#'     # multi-select)
-#'     updateSelectInput(session, "inSelect2",
-#'       label = paste("Select label", x),
-#'       choices = s_options,
-#'       selected = sprintf("option-%d-2", x)
+#'     # Can also set the label and select items
+#'     updateSelectInput(session, "inSelect",
+#'       label = paste("Select input label", length(x)),
+#'       choices = x,
+#'       selected = tail(x, 1)
 #'     )
 #'   })
 #' }
+#'
+#' shinyApp(ui, server)
 #' }
 #' @export
 updateSelectInput <- function(session, inputId, label = NULL, choices = NULL,

--- a/R/update-input.R
+++ b/R/update-input.R
@@ -7,7 +7,7 @@
 #'
 #' @examples
 #' \dontrun{
-#' shinyServer(function(input, output, session) {
+#' function(input, output, session) {
 #'
 #'   observe({
 #'     # We'll use the input$controller variable multiple times, so save it as x
@@ -22,7 +22,7 @@
 #'       label = paste("New label", x),
 #'       value = paste("New text", x))
 #'   })
-#' })
+#' }
 #' }
 #' @export
 updateTextInput <- function(session, inputId, label = NULL, value = NULL) {
@@ -40,7 +40,7 @@ updateTextInput <- function(session, inputId, label = NULL, value = NULL) {
 #'
 #' @examples
 #' \dontrun{
-#' shinyServer(function(input, output, session) {
+#' function(input, output, session) {
 #'
 #'   observe({
 #'     # TRUE if input$controller is even, FALSE otherwise.
@@ -48,7 +48,7 @@ updateTextInput <- function(session, inputId, label = NULL, value = NULL) {
 #'
 #'     updateCheckboxInput(session, "inCheckbox", value = x_even)
 #'   })
-#' })
+#' }
 #' }
 #' @export
 updateCheckboxInput <- updateTextInput
@@ -64,7 +64,7 @@ updateCheckboxInput <- updateTextInput
 #'
 #' @examples
 #' \dontrun{
-#' shinyServer(function(input, output, session) {
+#' function(input, output, session) {
 #'
 #'   observe({
 #'     # Updates goButton's label and icon
@@ -82,7 +82,7 @@ updateCheckboxInput <- updateTextInput
 #'     updateActionButton(session, "goButton3",
 #'       label = "New label")
 #'   })
-#' })
+#' }
 #' }
 #' @export
 updateActionButton <- function(session, inputId, label = NULL, icon = NULL) {
@@ -106,7 +106,7 @@ updateActionButton <- function(session, inputId, label = NULL, icon = NULL) {
 #'
 #' @examples
 #' \dontrun{
-#' shinyServer(function(input, output, session) {
+#' function(input, output, session) {
 #'
 #'   observe({
 #'     # We'll use the input$controller variable multiple times, so save it as x
@@ -120,7 +120,7 @@ updateActionButton <- function(session, inputId, label = NULL, icon = NULL) {
 #'       max   = paste("2013-04-", x+1, sep="")
 #'     )
 #'   })
-#' })
+#' }
 #' }
 #' @export
 updateDateInput <- function(session, inputId, label = NULL, value = NULL,
@@ -153,7 +153,7 @@ updateDateInput <- function(session, inputId, label = NULL, value = NULL,
 #'
 #' @examples
 #' \dontrun{
-#' shinyServer(function(input, output, session) {
+#' function(input, output, session) {
 #'
 #'   observe({
 #'     # We'll use the input$controller variable multiple times, so save it as x
@@ -165,7 +165,7 @@ updateDateInput <- function(session, inputId, label = NULL, value = NULL,
 #'       start = paste("2013-01-", x, sep=""))
 #'       end = paste("2013-12-", x, sep=""))
 #'   })
-#' })
+#' }
 #' }
 #' @export
 updateDateRangeInput <- function(session, inputId, label = NULL,
@@ -201,7 +201,7 @@ updateDateRangeInput <- function(session, inputId, label = NULL,
 #'
 #' @examples
 #' \dontrun{
-#' shinyServer(function(input, output, session) {
+#' function(input, output, session) {
 #'
 #'   observe({
 #'     # TRUE if input$controller is even, FALSE otherwise.
@@ -215,7 +215,7 @@ updateDateRangeInput <- function(session, inputId, label = NULL,
 #'       updateTabsetPanel(session, "inTabset", selected = "panel1")
 #'     }
 #'   })
-#' })
+#' }
 #' }
 #' @export
 updateTabsetPanel <- function(session, inputId, selected = NULL) {
@@ -243,7 +243,7 @@ updateNavlistPanel <- updateTabsetPanel
 #'
 #' @examples
 #' \dontrun{
-#' shinyServer(function(input, output, session) {
+#' function(input, output, session) {
 #'
 #'   observe({
 #'     # We'll use the input$controller variable multiple times, so save it as x
@@ -256,7 +256,7 @@ updateNavlistPanel <- updateTabsetPanel
 #'       label = paste("Number label ", x),
 #'       value = x, min = x-10, max = x+10, step = 5)
 #'   })
-#' })
+#' }
 #' }
 #' @export
 updateNumericInput <- function(session, inputId, label = NULL, value = NULL,
@@ -369,7 +369,7 @@ updateInputOptions <- function(session, inputId, label = NULL, choices = NULL,
 #'
 #' @examples
 #' \dontrun{
-#' shinyServer(function(input, output, session) {
+#' function(input, output, session) {
 #'
 #'   observe({
 #'     # We'll use the input$controller variable multiple times, so save it as x
@@ -392,7 +392,7 @@ updateInputOptions <- function(session, inputId, label = NULL, choices = NULL,
 #'       selected = sprintf("option-%d-2", x)
 #'     )
 #'   })
-#' })
+#' }
 #' }
 #' @export
 updateCheckboxGroupInput <- function(session, inputId, label = NULL,
@@ -411,7 +411,7 @@ updateCheckboxGroupInput <- function(session, inputId, label = NULL,
 #'
 #' @examples
 #' \dontrun{
-#' shinyServer(function(input, output, session) {
+#' function(input, output, session) {
 #'
 #'   observe({
 #'     # We'll use the input$controller variable multiple times, so save it as x
@@ -432,7 +432,7 @@ updateCheckboxGroupInput <- function(session, inputId, label = NULL,
 #'       selected = sprintf("option-%d-2", x)
 #'     )
 #'   })
-#' })
+#' }
 #' }
 #' @export
 updateRadioButtons <- function(session, inputId, label = NULL, choices = NULL,
@@ -452,7 +452,7 @@ updateRadioButtons <- function(session, inputId, label = NULL, choices = NULL,
 #'
 #' @examples
 #' \dontrun{
-#' shinyServer(function(input, output, session) {
+#' function(input, output, session) {
 #'
 #'   observe({
 #'     # We'll use the input$controller variable multiple times, so save it as x
@@ -476,7 +476,7 @@ updateRadioButtons <- function(session, inputId, label = NULL, choices = NULL,
 #'       selected = sprintf("option-%d-2", x)
 #'     )
 #'   })
-#' })
+#' }
 #' }
 #' @export
 updateSelectInput <- function(session, inputId, label = NULL, choices = NULL,

--- a/R/utils.R
+++ b/R/utils.R
@@ -478,7 +478,7 @@ installExprFunction <- function(expr, name, eval.env = parent.frame(2),
 #'
 #' \dontrun{
 #' # Example of usage within a Shiny app
-#' shinyServer(function(input, output, session) {
+#' function(input, output, session) {
 #'
 #'   output$queryText <- renderText({
 #'     query <- parseQueryString(session$clientData$url_search)
@@ -494,7 +494,7 @@ installExprFunction <- function(expr, name, eval.env = parent.frame(2),
 #'     # Return a string with key-value pairs
 #'     paste(names(query), query, sep = "=", collapse=", ")
 #'   })
-#' })
+#' }
 #' }
 #'
 parseQueryString <- function(str, nested = FALSE) {

--- a/inst/examples/01_hello/server.R
+++ b/inst/examples/01_hello/server.R
@@ -1,7 +1,7 @@
 library(shiny)
 
 # Define server logic required to draw a histogram
-shinyServer(function(input, output) {
+function(input, output) {
 
   # Expression that generates a histogram. The expression is
   # wrapped in a call to renderPlot to indicate that:
@@ -18,4 +18,4 @@ shinyServer(function(input, output) {
     hist(x, breaks = bins, col = 'darkgray', border = 'white')
   })
 
-})
+}

--- a/inst/examples/01_hello/ui.R
+++ b/inst/examples/01_hello/ui.R
@@ -1,7 +1,7 @@
 library(shiny)
 
 # Define UI for application that draws a histogram
-shinyUI(fluidPage(
+fluidPage(
 
   # Application title
   titlePanel("Hello Shiny!"),
@@ -21,4 +21,4 @@ shinyUI(fluidPage(
       plotOutput("distPlot")
     )
   )
-))
+)

--- a/inst/examples/02_text/server.R
+++ b/inst/examples/02_text/server.R
@@ -3,7 +3,7 @@ library(datasets)
 
 # Define server logic required to summarize and view the selected
 # dataset
-shinyServer(function(input, output) {
+function(input, output) {
   
   # Return the requested dataset
   datasetInput <- reactive({
@@ -23,4 +23,4 @@ shinyServer(function(input, output) {
   output$view <- renderTable({
     head(datasetInput(), n = input$obs)
   })
-})
+}

--- a/inst/examples/02_text/ui.R
+++ b/inst/examples/02_text/ui.R
@@ -1,7 +1,7 @@
 library(shiny)
 
 # Define UI for dataset viewer application
-shinyUI(fluidPage(
+fluidPage(
   
   # Application title
   titlePanel("Shiny Text"),
@@ -24,4 +24,4 @@ shinyUI(fluidPage(
       tableOutput("view")
     )
   )
-))
+)

--- a/inst/examples/03_reactivity/server.R
+++ b/inst/examples/03_reactivity/server.R
@@ -3,7 +3,7 @@ library(datasets)
 
 # Define server logic required to summarize and view the selected
 # dataset
-shinyServer(function(input, output) {
+function(input, output) {
 
   # By declaring datasetInput as a reactive expression we ensure 
   # that:
@@ -50,4 +50,4 @@ shinyServer(function(input, output) {
   output$view <- renderTable({
     head(datasetInput(), n = input$obs)
   })
-})
+}

--- a/inst/examples/03_reactivity/ui.R
+++ b/inst/examples/03_reactivity/ui.R
@@ -1,7 +1,7 @@
 library(shiny)
 
 # Define UI for dataset viewer application
-shinyUI(fluidPage(
+fluidPage(
   
   # Application title
   titlePanel("Reactivity"),
@@ -31,4 +31,4 @@ shinyUI(fluidPage(
       tableOutput("view")
     )
   )
-))
+)

--- a/inst/examples/04_mpg/server.R
+++ b/inst/examples/04_mpg/server.R
@@ -11,7 +11,7 @@ mpgData$am <- factor(mpgData$am, labels = c("Automatic", "Manual"))
 
 # Define server logic required to plot various variables against
 # mpg
-shinyServer(function(input, output) {
+function(input, output) {
 
   # Compute the formula text in a reactive expression since it is
   # shared by the output$caption and output$mpgPlot functions
@@ -31,4 +31,4 @@ shinyServer(function(input, output) {
             data = mpgData,
             outline = input$outliers)
   })
-})
+}

--- a/inst/examples/04_mpg/ui.R
+++ b/inst/examples/04_mpg/ui.R
@@ -1,7 +1,7 @@
 library(shiny)
 
 # Define UI for miles per gallon application
-shinyUI(fluidPage(
+fluidPage(
   
   # Application title
   titlePanel("Miles Per Gallon"),
@@ -26,4 +26,4 @@ shinyUI(fluidPage(
       plotOutput("mpgPlot")
     )
   )
-))
+)

--- a/inst/examples/05_sliders/server.R
+++ b/inst/examples/05_sliders/server.R
@@ -1,7 +1,7 @@
 library(shiny)
 
 # Define server logic for slider examples
-shinyServer(function(input, output) {
+function(input, output) {
   
   # Reactive expression to compose a data frame containing all of
   # the values
@@ -26,4 +26,4 @@ shinyServer(function(input, output) {
   output$values <- renderTable({
     sliderValues()
   })
-})
+}

--- a/inst/examples/05_sliders/ui.R
+++ b/inst/examples/05_sliders/ui.R
@@ -1,7 +1,7 @@
 library(shiny)
 
 # Define UI for slider demo application
-shinyUI(fluidPage(
+fluidPage(
 
   #  Application title
   titlePanel("Sliders"),
@@ -40,4 +40,4 @@ shinyUI(fluidPage(
       tableOutput("values")
     )
   )
-))
+)

--- a/inst/examples/06_tabsets/server.R
+++ b/inst/examples/06_tabsets/server.R
@@ -1,7 +1,7 @@
 library(shiny)
 
 # Define server logic for random distribution application
-shinyServer(function(input, output) {
+function(input, output) {
   
   # Reactive expression to generate the requested distribution.
   # This is called whenever the inputs change. The output
@@ -41,4 +41,4 @@ shinyServer(function(input, output) {
     data.frame(x=data())
   })
   
-})
+}

--- a/inst/examples/06_tabsets/ui.R
+++ b/inst/examples/06_tabsets/ui.R
@@ -1,7 +1,7 @@
 library(shiny)
 
 # Define UI for random distribution application 
-shinyUI(fluidPage(
+fluidPage(
     
   # Application title
   titlePanel("Tabsets"),
@@ -35,4 +35,4 @@ shinyUI(fluidPage(
       )
     )
   )
-))
+)

--- a/inst/examples/07_widgets/server.R
+++ b/inst/examples/07_widgets/server.R
@@ -3,7 +3,7 @@ library(datasets)
 
 # Define server logic required to summarize and view the 
 # selected dataset
-shinyServer(function(input, output) {
+function(input, output) {
   
   # Return the requested dataset
   datasetInput <- reactive({
@@ -23,4 +23,4 @@ shinyServer(function(input, output) {
   output$view <- renderTable({
     head(datasetInput(), n = input$obs)
   })
-})
+}

--- a/inst/examples/07_widgets/ui.R
+++ b/inst/examples/07_widgets/ui.R
@@ -1,7 +1,7 @@
 library(shiny)
 
 # Define UI for dataset viewer application
-shinyUI(fluidPage(
+fluidPage(
   
   # Application title.
   titlePanel("More Widgets"),
@@ -40,4 +40,4 @@ shinyUI(fluidPage(
       tableOutput("view")
     )
   )
-))
+)

--- a/inst/examples/08_html/server.R
+++ b/inst/examples/08_html/server.R
@@ -1,7 +1,7 @@
 library(shiny)
 
 # Define server logic for random distribution application
-shinyServer(function(input, output) {
+function(input, output) {
   
   # Reactive expression to generate the requested distribution. This is 
   # called whenever the inputs change. The output expressions defined 
@@ -39,4 +39,4 @@ shinyServer(function(input, output) {
     data.frame(x=data())
   })
   
-})
+}

--- a/inst/examples/09_upload/server.R
+++ b/inst/examples/09_upload/server.R
@@ -1,6 +1,6 @@
 library(shiny)
 
-shinyServer(function(input, output) {
+function(input, output) {
   output$contents <- renderTable({
     
     # input$file1 will be NULL initially. After the user selects
@@ -17,4 +17,4 @@ shinyServer(function(input, output) {
     read.csv(inFile$datapath, header=input$header, sep=input$sep, 
 				 quote=input$quote)
   })
-})
+}

--- a/inst/examples/09_upload/ui.R
+++ b/inst/examples/09_upload/ui.R
@@ -1,6 +1,6 @@
 library(shiny)
 
-shinyUI(fluidPage(
+fluidPage(
   titlePanel("Uploading Files"),
   sidebarLayout(
     sidebarPanel(
@@ -25,4 +25,4 @@ shinyUI(fluidPage(
       tableOutput('contents')
     )
   )
-))
+)

--- a/inst/examples/10_download/server.R
+++ b/inst/examples/10_download/server.R
@@ -1,4 +1,4 @@
-shinyServer(function(input, output) {
+function(input, output) {
   datasetInput <- reactive({
     switch(input$dataset,
            "rock" = rock,
@@ -18,4 +18,4 @@ shinyServer(function(input, output) {
       write.csv(datasetInput(), file)
     }
   )
-})
+}

--- a/inst/examples/10_download/ui.R
+++ b/inst/examples/10_download/ui.R
@@ -1,4 +1,4 @@
-shinyUI(fluidPage(
+fluidPage(
   titlePanel('Downloading Data'),
   sidebarLayout(
     sidebarPanel(
@@ -10,4 +10,4 @@ shinyUI(fluidPage(
       tableOutput('table')
     )
   )
-))
+)

--- a/inst/examples/11_timer/server.R
+++ b/inst/examples/11_timer/server.R
@@ -1,6 +1,6 @@
-shinyServer(function(input, output, session) {
+function(input, output, session) {
   output$currentTime <- renderText({
     invalidateLater(1000, session)
     paste("The current time is", Sys.time())
   })
-})
+}

--- a/inst/examples/11_timer/ui.R
+++ b/inst/examples/11_timer/ui.R
@@ -1,3 +1,3 @@
-shinyUI(fluidPage(
+fluidPage(
   textOutput("currentTime")
-))
+)

--- a/man/Progress.Rd
+++ b/man/Progress.Rd
@@ -69,11 +69,16 @@ to be removed.
   }
 }
 \examples{
-\dontrun{
-# server.R
-function(input, output, session) {
+## Only run examples in interactive R sessions
+if (interactive()) {
+
+ui <- fluidPage(
+  plotOutput("plot")
+)
+
+server <- function(input, output, session) {
   output$plot <- renderPlot({
-    progress <- shiny::Progress$new(session, min=1, max=15)
+    progress <- Progress$new(session, min=1, max=15)
     on.exit(progress$close())
 
     progress$set(message = 'Calculation in progress',
@@ -86,6 +91,8 @@ function(input, output, session) {
     plot(cars)
   })
 }
+
+shinyApp(ui, server)
 }
 }
 \seealso{

--- a/man/Progress.Rd
+++ b/man/Progress.Rd
@@ -71,7 +71,7 @@ to be removed.
 \examples{
 \dontrun{
 # server.R
-shinyServer(function(input, output, session) {
+function(input, output, session) {
   output$plot <- renderPlot({
     progress <- shiny::Progress$new(session, min=1, max=15)
     on.exit(progress$close())
@@ -85,7 +85,7 @@ shinyServer(function(input, output, session) {
     }
     plot(cars)
   })
-})
+}
 }
 }
 \seealso{

--- a/man/actionButton.Rd
+++ b/man/actionButton.Rd
@@ -27,19 +27,29 @@ Creates an action button or link whose value is initially zero, and increments b
 each time it is pressed.
 }
 \examples{
-\dontrun{
-# In server.R
-output$distPlot <- renderPlot({
-  # Take a dependency on input$goButton
-  input$goButton
+## Only run examples in interactive R sessions
+if (interactive()) {
 
-  # Use isolate() to avoid dependency on input$obs
-  dist <- isolate(rnorm(input$obs))
-  hist(dist)
-})
+ui <- fluidPage(
+  sliderInput("obs", "Number of observations", 0, 1000, 500),
+  actionButton("goButton", "Go!"),
+  plotOutput("distPlot")
+)
 
-# In ui.R
-actionButton("goButton", "Go!")
+server <- function(input, output) {
+  output$distPlot <- renderPlot({
+    # Take a dependency on input$goButton. This will run once initially,
+    # because the value changes from NULL to 0.
+    input$goButton
+
+    # Use isolate() to avoid dependency on input$obs
+    dist <- isolate(rnorm(input$obs))
+    hist(dist)
+  })
+}
+
+shinyApp(ui, server)
+
 }
 
 }

--- a/man/checkboxGroupInput.Rd
+++ b/man/checkboxGroupInput.Rd
@@ -31,11 +31,25 @@ independently. The server will receive the input as a character vector of the
 selected values.
 }
 \examples{
-checkboxGroupInput("variable", "Variable:",
-                   c("Cylinders" = "cyl",
-                     "Transmission" = "am",
-                     "Gears" = "gear"))
+## Only run examples in interactive R sessions
+if (interactive()) {
 
+ui <- fluidPage(
+  checkboxGroupInput("variable", "Variables to show:",
+                     c("Cylinders" = "cyl",
+                       "Transmission" = "am",
+                       "Gears" = "gear")),
+  tableOutput("data")
+)
+
+server <- function(input, output) {
+  output$data <- renderTable({
+    mtcars[, c("mpg", input$variable), drop = FALSE]
+  }, rownames = TRUE)
+}
+
+shinyApp(ui, server)
+}
 }
 \seealso{
 \code{\link{checkboxInput}}, \code{\link{updateCheckboxGroupInput}}

--- a/man/checkboxInput.Rd
+++ b/man/checkboxInput.Rd
@@ -23,7 +23,18 @@ A checkbox control that can be added to a UI definition.
 Create a checkbox that can be used to specify logical values.
 }
 \examples{
-checkboxInput("outliers", "Show outliers", FALSE)
+## Only run examples in interactive R sessions
+if (interactive()) {
+
+ui <- fluidPage(
+  checkboxInput("somevalue", "Some value", FALSE),
+  verbatimTextOutput("value")
+)
+server <- function(input, output) {
+  output$value <- renderText({ input$somevalue })
+}
+shinyApp(ui, server)
+}
 }
 \seealso{
 \code{\link{checkboxGroupInput}}, \code{\link{updateCheckboxInput}}

--- a/man/column.Rd
+++ b/man/column.Rd
@@ -23,24 +23,43 @@ Create a column for use within a  \code{\link{fluidRow}} or
 \code{\link{fixedRow}}
 }
 \examples{
-fluidRow(
-  column(4,
-    sliderInput("obs", "Number of observations:",
-                min = 1, max = 1000, value = 500)
-  ),
-  column(8,
-    plotOutput("distPlot")
+## Only run examples in interactive R sessions
+if (interactive()) {
+
+ui <- fluidPage(
+  fluidRow(
+    column(4,
+      sliderInput("obs", "Number of observations:",
+                  min = 1, max = 1000, value = 500)
+    ),
+    column(8,
+      plotOutput("distPlot")
+    )
   )
 )
 
-fluidRow(
-  column(width = 4,
-    "4"
-  ),
-  column(width = 3, offset = 2,
-    "3 offset 2"
+server <- function(input, output) {
+  output$distPlot <- renderPlot({
+    hist(rnorm(input$obs))
+  })
+}
+
+shinyApp(ui, server)
+
+
+
+ui <- fluidPage(
+  fluidRow(
+    column(width = 4,
+      "4"
+    ),
+    column(width = 3, offset = 2,
+      "3 offset 2"
+    )
   )
 )
+shinyApp(ui, server = function(input, output) { })
+}
 }
 \seealso{
 \code{\link{fluidRow}}, \code{\link{fixedRow}}.

--- a/man/dateInput.Rd
+++ b/man/dateInput.Rd
@@ -63,26 +63,33 @@ the browser. It allows the following values:
 }
 }
 \examples{
-dateInput("date", "Date:", value = "2012-02-29")
+## Only run examples in interactive R sessions
+if (interactive()) {
 
-# Default value is the date in client's time zone
-dateInput("date", "Date:")
+ui <- fluidPage(
+  dateInput("date1", "Date:", value = "2012-02-29"),
 
-# value is always yyyy-mm-dd, even if the display format is different
-dateInput("date", "Date:", value = "2012-02-29", format = "mm/dd/yy")
+  # Default value is the date in client's time zone
+  dateInput("date2", "Date:"),
 
-# Pass in a Date object
-dateInput("date", "Date:", value = Sys.Date()-10)
+  # value is always yyyy-mm-dd, even if the display format is different
+  dateInput("date3", "Date:", value = "2012-02-29", format = "mm/dd/yy"),
 
-# Use different language and different first day of week
-dateInput("date", "Date:",
+  # Pass in a Date object
+  dateInput("date4", "Date:", value = Sys.Date()-10),
+
+  # Use different language and different first day of week
+  dateInput("date5", "Date:",
           language = "de",
-          weekstart = 1)
+          weekstart = 1),
 
-# Start with decade view instead of default month view
-dateInput("date", "Date:",
-          startview = "decade")
+  # Start with decade view instead of default month view
+  dateInput("date6", "Date:",
+            startview = "decade")
+)
 
+shinyApp(ui, server = function(input, output) { })
+}
 }
 \seealso{
 \code{\link{dateRangeInput}}, \code{\link{updateDateInput}}

--- a/man/dateRangeInput.Rd
+++ b/man/dateRangeInput.Rd
@@ -69,37 +69,44 @@ the browser. It allows the following values:
 }
 }
 \examples{
-dateRangeInput("daterange", "Date range:",
-               start = "2001-01-01",
-               end   = "2010-12-31")
+## Only run examples in interactive R sessions
+if (interactive()) {
 
-# Default start and end is the current date in the client's time zone
-dateRangeInput("daterange", "Date range:")
+ui <- fluidPage(
+  dateRangeInput("daterange1", "Date range:",
+                 start = "2001-01-01",
+                 end   = "2010-12-31"),
 
-# start and end are always specified in yyyy-mm-dd, even if the display
-# format is different
-dateRangeInput("daterange", "Date range:",
-               start  = "2001-01-01",
-               end    = "2010-12-31",
-               min    = "2001-01-01",
-               max    = "2012-12-21",
-               format = "mm/dd/yy",
-               separator = " - ")
+  # Default start and end is the current date in the client's time zone
+  dateRangeInput("daterange2", "Date range:"),
 
-# Pass in Date objects
-dateRangeInput("daterange", "Date range:",
-               start = Sys.Date()-10,
-               end = Sys.Date()+10)
+  # start and end are always specified in yyyy-mm-dd, even if the display
+  # format is different
+  dateRangeInput("daterange3", "Date range:",
+                 start  = "2001-01-01",
+                 end    = "2010-12-31",
+                 min    = "2001-01-01",
+                 max    = "2012-12-21",
+                 format = "mm/dd/yy",
+                 separator = " - "),
 
-# Use different language and different first day of week
-dateRangeInput("daterange", "Date range:",
-               language = "de",
-               weekstart = 1)
+  # Pass in Date objects
+  dateRangeInput("daterange4", "Date range:",
+                 start = Sys.Date()-10,
+                 end = Sys.Date()+10),
 
-# Start with decade view instead of default month view
-dateRangeInput("daterange", "Date range:",
-               startview = "decade")
+  # Use different language and different first day of week
+  dateRangeInput("daterange5", "Date range:",
+                 language = "de",
+                 weekstart = 1),
 
+  # Start with decade view instead of default month view
+  dateRangeInput("daterange6", "Date range:",
+                 startview = "decade")
+)
+
+shinyApp(ui, server = function(input, output) { })
+}
 }
 \seealso{
 \code{\link{dateInput}}, \code{\link{updateDateRangeInput}}

--- a/man/downloadHandler.Rd
+++ b/man/downloadHandler.Rd
@@ -37,20 +37,28 @@ the user initiates the download. Assign the return value to a slot on
 download available.
 }
 \examples{
-\dontrun{
-# In server.R:
-output$downloadData <- downloadHandler(
-  filename = function() {
-    paste('data-', Sys.Date(), '.csv', sep='')
-  },
-  content = function(file) {
-    write.csv(data, file)
-  }
+## Only run examples in interactive R sessions
+if (interactive()) {
+
+ui <- fluidPage(
+  downloadLink("downloadData", "Download")
 )
 
-# In ui.R:
-downloadLink('downloadData', 'Download')
+server <- function(input, output) {
+  # Our dataset
+  data <- mtcars
+
+  output$downloadData <- downloadHandler(
+    filename = function() {
+      paste("data-", Sys.Date(), ".csv", sep="")
+    },
+    content = function(file) {
+      write.csv(data, file)
+    }
+  )
 }
 
+shinyApp(ui, server)
+}
 }
 

--- a/man/fileInput.Rd
+++ b/man/fileInput.Rd
@@ -42,6 +42,47 @@ the following columns:
   operation.}
 }
 }
+\examples{
+## Only run examples in interactive R sessions
+if (interactive()) {
+
+ui <- fluidPage(
+  sidebarLayout(
+    sidebarPanel(
+      fileInput("file1", "Choose CSV File",
+        accept = c(
+          "text/csv",
+          "text/comma-separated-values,text/plain",
+          ".csv")
+        ),
+      tags$hr(),
+      checkboxInput("header", "Header", TRUE)
+    ),
+    mainPanel(
+      tableOutput("contents")
+    )
+  )
+)
+
+server <- function(input, output) {
+  output$contents <- renderTable({
+    # input$file1 will be NULL initially. After the user selects
+    # and uploads a file, it will be a data frame with 'name',
+    # 'size', 'type', and 'datapath' columns. The 'datapath'
+    # column will contain the local filenames where the data can
+    # be found.
+    inFile <- input$file1
+
+    if (is.null(inFile))
+      return(NULL)
+
+    read.csv(inFile$datapath, header = input$header)
+  })
+}
+
+shinyApp(ui, server)
+}
+}
 \seealso{
 Other input.elements: \code{\link{actionButton}},
   \code{\link{checkboxGroupInput}},

--- a/man/fillRow.Rd
+++ b/man/fillRow.Rd
@@ -54,10 +54,7 @@ If you try to use \code{fillRow} and \code{fillCol} inside of other
   }
 }
 \examples{
-\donttest{
 # Only run this example in interactive R sessions.
-# NOTE: This example should be run with example(fillRow, ask = FALSE) to
-# avoid being prompted to hit Enter during plot rendering.
 if (interactive()) {
 
 ui <- fillPage(fillRow(
@@ -76,7 +73,6 @@ server <- function(input, output, session) {
 
 shinyApp(ui, server)
 
-}
 }
 }
 

--- a/man/fixedPage.Rd
+++ b/man/fixedPage.Rd
@@ -46,7 +46,7 @@ See the \href{http://shiny.rstudio.com/articles/layout-guide.html}{
   pages.
 }
 \examples{
-shinyUI(fixedPage(
+fixedPage(
   title = "Hello, Shiny!",
   fixedRow(
     column(width = 4,
@@ -56,7 +56,7 @@ shinyUI(fixedPage(
       "3 offset 2"
     )
   )
-))
+)
 
 }
 \seealso{

--- a/man/fixedPage.Rd
+++ b/man/fixedPage.Rd
@@ -46,7 +46,10 @@ See the \href{http://shiny.rstudio.com/articles/layout-guide.html}{
   pages.
 }
 \examples{
-fixedPage(
+## Only run examples in interactive R sessions
+if (interactive()) {
+
+ui <- fixedPage(
   title = "Hello, Shiny!",
   fixedRow(
     column(width = 4,
@@ -57,6 +60,9 @@ fixedPage(
     )
   )
 )
+
+shinyApp(ui, server = function(input, output) { })
+}
 
 }
 \seealso{

--- a/man/flowLayout.Rd
+++ b/man/flowLayout.Rd
@@ -20,11 +20,16 @@ well with elements that have a percentage-based width (e.g.
 \code{\link{plotOutput}} at its default setting of \code{width = "100\%"}).
 }
 \examples{
-flowLayout(
+## Only run examples in interactive R sessions
+if (interactive()) {
+
+ui <- flowLayout(
   numericInput("rows", "How many rows?", 5),
   selectInput("letter", "Which letter?", LETTERS),
   sliderInput("value", "What value?", 0, 100, 50)
 )
+shinyApp(ui, server = function(input, output) { })
+}
 }
 \seealso{
 \code{\link{verticalLayout}}

--- a/man/fluidPage.Rd
+++ b/man/fluidPage.Rd
@@ -45,7 +45,11 @@ See the \href{http://shiny.rstudio.com/articles/layout-guide.html}{
   pages.
 }
 \examples{
-fluidPage(
+## Only run examples in interactive R sessions
+if (interactive()) {
+
+# Example of UI with fluidPage
+ui <- fluidPage(
 
   # Application title
   titlePanel("Hello Shiny!"),
@@ -68,7 +72,19 @@ fluidPage(
   )
 )
 
-fluidPage(
+# Server logic
+server <- function(input, output) {
+  output$distPlot <- renderPlot({
+    hist(rnorm(input$obs))
+  })
+}
+
+# Complete app with UI and server components
+shinyApp(ui, server)
+
+
+# UI demonstrating column layouts
+ui <- fluidPage(
   title = "Hello Shiny!",
   fluidRow(
     column(width = 4,
@@ -80,6 +96,8 @@ fluidPage(
   )
 )
 
+shinyApp(ui, server = function(input, output) { })
+}
 }
 \seealso{
 \code{\link{column}}, \code{\link{sidebarLayout}}

--- a/man/fluidPage.Rd
+++ b/man/fluidPage.Rd
@@ -45,7 +45,7 @@ See the \href{http://shiny.rstudio.com/articles/layout-guide.html}{
   pages.
 }
 \examples{
-shinyUI(fluidPage(
+fluidPage(
 
   # Application title
   titlePanel("Hello Shiny!"),
@@ -66,9 +66,9 @@ shinyUI(fluidPage(
       plotOutput("distPlot")
     )
   )
-))
+)
 
-shinyUI(fluidPage(
+fluidPage(
   title = "Hello Shiny!",
   fluidRow(
     column(width = 4,
@@ -78,7 +78,7 @@ shinyUI(fluidPage(
       "3 offset 2"
     )
   )
-))
+)
 
 }
 \seealso{

--- a/man/icon.Rd
+++ b/man/icon.Rd
@@ -36,11 +36,11 @@ icon("cog", lib = "glyphicon") # From glyphicon library
 # add an icon to a submit button
 submitButton("Update View", icon = icon("refresh"))
 
-shinyUI(navbarPage("App Title",
+navbarPage("App Title",
   tabPanel("Plot", icon = icon("bar-chart-o")),
   tabPanel("Summary", icon = icon("list-alt")),
   tabPanel("Table", icon = icon("table"))
-))
+)
 
 }
 \seealso{

--- a/man/invalidateLater.Rd
+++ b/man/invalidateLater.Rd
@@ -28,8 +28,15 @@ possible to stop this cycle by adding conditional logic that prevents the
 \code{invalidateLater} from being run.
 }
 \examples{
-\dontrun{
-function(input, output, session) {
+## Only run examples in interactive R sessions
+if (interactive()) {
+
+ui <- fluidPage(
+  sliderInput("n", "Number of observations", 2, 1000, 500),
+  plotOutput("plot")
+)
+
+server <- function(input, output, session) {
 
   observe({
     # Re-execute this reactive expression after 1000 milliseconds
@@ -46,11 +53,12 @@ function(input, output, session) {
   output$plot <- renderPlot({
     # Re-execute this reactive expression after 2000 milliseconds
     invalidateLater(2000)
-    hist(isolate(input$n))
+    hist(rnorm(isolate(input$n)))
   })
 }
-}
 
+shinyApp(ui, server)
+}
 }
 \seealso{
 \code{\link{reactiveTimer}} is a slightly less safe alternative.

--- a/man/invalidateLater.Rd
+++ b/man/invalidateLater.Rd
@@ -29,7 +29,7 @@ possible to stop this cycle by adding conditional logic that prevents the
 }
 \examples{
 \dontrun{
-shinyServer(function(input, output, session) {
+function(input, output, session) {
 
   observe({
     # Re-execute this reactive expression after 1000 milliseconds
@@ -48,7 +48,7 @@ shinyServer(function(input, output, session) {
     invalidateLater(2000)
     hist(isolate(input$n))
   })
-})
+}
 }
 
 }

--- a/man/navbarPage.Rd
+++ b/man/navbarPage.Rd
@@ -80,13 +80,13 @@ The \code{navbarMenu} function can be used to create an embedded
   example below).
 }
 \examples{
-shinyUI(navbarPage("App Title",
+navbarPage("App Title",
   tabPanel("Plot"),
   tabPanel("Summary"),
   tabPanel("Table")
-))
+)
 
-shinyUI(navbarPage("App Title",
+navbarPage("App Title",
   tabPanel("Plot"),
   navbarMenu("More",
     tabPanel("Summary"),
@@ -94,7 +94,7 @@ shinyUI(navbarPage("App Title",
     "Section header",
     tabPanel("Table")
   )
-))
+)
 }
 \seealso{
 \code{\link{tabPanel}}, \code{\link{tabsetPanel}},

--- a/man/navlistPanel.Rd
+++ b/man/navlistPanel.Rd
@@ -40,7 +40,7 @@ You can include headers within the \code{navlistPanel} by including
   doesn't support separators.
 }
 \examples{
-shinyUI(fluidPage(
+fluidPage(
 
   titlePanel("Application Title"),
 
@@ -50,7 +50,7 @@ shinyUI(fluidPage(
     tabPanel("Second"),
     tabPanel("Third")
   )
-))
+)
 }
 \seealso{
 \code{\link{tabPanel}}, \code{\link{updateNavlistPanel}}

--- a/man/numericInput.Rd
+++ b/man/numericInput.Rd
@@ -30,8 +30,18 @@ A numeric input control that can be added to a UI definition.
 Create an input control for entry of numeric values
 }
 \examples{
-numericInput("obs", "Observations:", 10,
-             min = 1, max = 100)
+## Only run examples in interactive R sessions
+if (interactive()) {
+
+ui <- fluidPage(
+  numericInput("obs", "Observations:", 10, min = 1, max = 100),
+  verbatimTextOutput("value")
+)
+server <- function(input, output) {
+  output$value <- renderText({ input$obs })
+}
+shinyApp(ui, server)
+}
 }
 \seealso{
 \code{\link{updateNumericInput}}

--- a/man/pageWithSidebar.Rd
+++ b/man/pageWithSidebar.Rd
@@ -26,7 +26,7 @@ along with \code{\link{sidebarLayout}} to implement a page with a sidebar.
 }
 \examples{
 # Define UI
-shinyUI(pageWithSidebar(
+pageWithSidebar(
 
   # Application title
   headerPanel("Hello Shiny!"),
@@ -44,7 +44,7 @@ shinyUI(pageWithSidebar(
   mainPanel(
     plotOutput("distPlot")
   )
-))
+)
 
 }
 

--- a/man/parseQueryString.Rd
+++ b/man/parseQueryString.Rd
@@ -24,7 +24,7 @@ parseQueryString("?foo=1&bar=b\%20a\%20r")
 
 \dontrun{
 # Example of usage within a Shiny app
-shinyServer(function(input, output, session) {
+function(input, output, session) {
 
   output$queryText <- renderText({
     query <- parseQueryString(session$clientData$url_search)
@@ -40,7 +40,7 @@ shinyServer(function(input, output, session) {
     # Return a string with key-value pairs
     paste(names(query), query, sep = "=", collapse=", ")
   })
-})
+}
 }
 
 }

--- a/man/passwordInput.Rd
+++ b/man/passwordInput.Rd
@@ -28,7 +28,22 @@ A text input control that can be added to a UI definition.
 Create an password control for entry of passwords.
 }
 \examples{
-passwordInput("password", "Password:")
+## Only run examples in interactive R sessions
+if (interactive()) {
+
+ui <- fluidPage(
+  passwordInput("password", "Password:"),
+  actionButton("go", "Go"),
+  verbatimTextOutput("value")
+)
+server <- function(input, output) {
+  output$value <- renderText({
+    req(input$go)
+    isolate(input$password)
+  })
+}
+shinyApp(ui, server)
+}
 }
 \seealso{
 \code{\link{updateTextInput}}

--- a/man/radioButtons.Rd
+++ b/man/radioButtons.Rd
@@ -38,11 +38,33 @@ Instead, consider having the first of your choices be \code{c("None selected"
 = "")}.
 }
 \examples{
-radioButtons("dist", "Distribution type:",
-             c("Normal" = "norm",
-               "Uniform" = "unif",
-               "Log-normal" = "lnorm",
-               "Exponential" = "exp"))
+## Only run examples in interactive R sessions
+if (interactive()) {
+
+ui <- fluidPage(
+  radioButtons("dist", "Distribution type:",
+               c("Normal" = "norm",
+                 "Uniform" = "unif",
+                 "Log-normal" = "lnorm",
+                 "Exponential" = "exp")),
+  plotOutput("distPlot")
+)
+
+server <- function(input, output) {
+  output$distPlot <- renderPlot({
+    dist <- switch(input$dist,
+                   norm = rnorm,
+                   unif = runif,
+                   lnorm = rlnorm,
+                   exp = rexp,
+                   rnorm)
+
+    hist(dist(500))
+  })
+}
+
+shinyApp(ui, server)
+}
 }
 \seealso{
 \code{\link{updateRadioButtons}}

--- a/man/reactiveFileReader.Rd
+++ b/man/reactiveFileReader.Rd
@@ -47,7 +47,7 @@ reactive values and reactive expressions.
 \examples{
 \dontrun{
 # Per-session reactive file reader
-shinyServer(function(input, output, session)) {
+function(input, output, session) {
   fileData <- reactiveFileReader(1000, session, 'data.csv', read.csv)
 
   output$data <- renderTable({
@@ -59,7 +59,7 @@ shinyServer(function(input, output, session)) {
 # the same reader, so read.csv only gets executed once no matter how many
 # user sessions are connected.
 fileData <- reactiveFileReader(1000, session, 'data.csv', read.csv)
-shinyServer(function(input, output, session)) {
+function(input, output, session) {
   output$data <- renderTable({
     fileData()
   })

--- a/man/reactivePoll.Rd
+++ b/man/reactivePoll.Rd
@@ -57,14 +57,12 @@ will be executed in a reactive context; therefore, they may read reactive
 values and reactive expressions.
 }
 \examples{
-\dontrun{
 # Assume the existence of readTimestamp and readValue functions
 function(input, output, session) {
   data <- reactivePoll(1000, session, readTimestamp, readValue)
   output$dataTable <- renderTable({
     data()
   })
-}
 }
 
 }

--- a/man/reactivePoll.Rd
+++ b/man/reactivePoll.Rd
@@ -59,12 +59,12 @@ values and reactive expressions.
 \examples{
 \dontrun{
 # Assume the existence of readTimestamp and readValue functions
-shinyServer(function(input, output, session) {
+function(input, output, session) {
   data <- reactivePoll(1000, session, readTimestamp, readValue)
   output$dataTable <- renderTable({
     data()
   })
-})
+}
 }
 
 }

--- a/man/reactiveTimer.Rd
+++ b/man/reactiveTimer.Rd
@@ -35,7 +35,7 @@ See \code{\link{invalidateLater}} as a safer and simpler alternative.
 }
 \examples{
 \dontrun{
-shinyServer(function(input, output, session) {
+function(input, output, session) {
 
   # Anything that calls autoInvalidate will automatically invalidate
   # every 2 seconds.
@@ -58,7 +58,7 @@ shinyServer(function(input, output, session) {
     autoInvalidate()
     hist(isolate(input$n))
   })
-})
+}
 }
 
 }

--- a/man/reactiveTimer.Rd
+++ b/man/reactiveTimer.Rd
@@ -34,8 +34,15 @@ needed.
 See \code{\link{invalidateLater}} as a safer and simpler alternative.
 }
 \examples{
-\dontrun{
-function(input, output, session) {
+## Only run examples in interactive R sessions
+if (interactive()) {
+
+ui <- fluidPage(
+  sliderInput("n", "Number of observations", 2, 1000, 500),
+  plotOutput("plot")
+)
+
+server <- function(input, output) {
 
   # Anything that calls autoInvalidate will automatically invalidate
   # every 2 seconds.
@@ -56,9 +63,11 @@ function(input, output, session) {
   # input$n changes.
   output$plot <- renderPlot({
     autoInvalidate()
-    hist(isolate(input$n))
+    hist(rnorm(isolate(input$n)))
   })
 }
+
+shinyApp(ui, server)
 }
 
 }

--- a/man/renderImage.Rd
+++ b/man/renderImage.Rd
@@ -45,9 +45,17 @@ The corresponding HTML output tag should be \code{div} or \code{img} and have
 the CSS class name \code{shiny-image-output}.
 }
 \examples{
-\dontrun{
+## Only run examples in interactive R sessions
+if (interactive()) {
 
-function(input, output, clientData) {
+ui <- fluidPage(
+  sliderInput("n", "Number of observations", 2, 1000, 500),
+  plotOutput("plot1"),
+  plotOutput("plot2"),
+  plotOutput("plot3")
+)
+
+server <- function(input, output, session) {
 
   # A plot of fixed size
   output$plot1 <- renderImage({
@@ -69,14 +77,14 @@ function(input, output, clientData) {
   output$plot2 <- renderImage({
     # Read plot2's width and height. These are reactive values, so this
     # expression will re-run whenever these values change.
-    width  <- clientData$output_plot2_width
-    height <- clientData$output_plot2_height
+    width  <- session$clientData$output_plot2_width
+    height <- session$clientData$output_plot2_height
 
     # A temp file to save the output.
     outfile <- tempfile(fileext='.png')
 
     png(outfile, width=width, height=height)
-    hist(rnorm(input$obs))
+    hist(rnorm(input$n))
     dev.off()
 
     # Return a list containing the filename
@@ -87,6 +95,8 @@ function(input, output, clientData) {
   }, deleteFile = TRUE)
 
   # Send a pre-rendered image, and don't delete the image after sending it
+  # NOTE: For this example to work, it would require files in a subdirectory
+  # named images/
   output$plot3 <- renderImage({
     # When input$n is 1, filename is ./images/image1.jpeg
     filename <- normalizePath(file.path('./images',
@@ -97,6 +107,7 @@ function(input, output, clientData) {
   }, deleteFile = FALSE)
 }
 
+shinyApp(ui, server)
 }
 }
 \seealso{

--- a/man/renderImage.Rd
+++ b/man/renderImage.Rd
@@ -47,7 +47,7 @@ the CSS class name \code{shiny-image-output}.
 \examples{
 \dontrun{
 
-shinyServer(function(input, output, clientData) {
+function(input, output, clientData) {
 
   # A plot of fixed size
   output$plot1 <- renderImage({
@@ -95,7 +95,7 @@ shinyServer(function(input, output, clientData) {
     # Return a list containing the filename
     list(src = filename)
   }, deleteFile = FALSE)
-})
+}
 
 }
 }

--- a/man/renderUI.Rd
+++ b/man/renderUI.Rd
@@ -28,13 +28,24 @@ The corresponding HTML output tag should be \code{div} and have the CSS class
 name \code{shiny-html-output} (or use \code{\link{uiOutput}}).
 }
 \examples{
-\dontrun{
-  output$moreControls <- renderUI({
-    list(
+## Only run examples in interactive R sessions
+if (interactive()) {
 
+ui <- fluidPage(
+  uiOutput("moreControls")
+)
+
+server <- function(input, output) {
+  output$moreControls <- renderUI({
+    tagList(
+      sliderInput("n", "N", 1, 1000, 500),
+      textInput("label", "Label")
     )
   })
 }
+shinyApp(ui, server)
+}
+
 }
 \seealso{
 conditionalPanel

--- a/man/runUrl.Rd
+++ b/man/runUrl.Rd
@@ -55,7 +55,7 @@ respectively.
 }
 \examples{
 ## Only run this example in interactive R sessions
-  if (interactive()) {
+if (interactive()) {
   runUrl('https://github.com/rstudio/shiny_example/archive/master.tar.gz')
 
   # Can run an app from a subdirectory in the archive

--- a/man/selectInput.Rd
+++ b/man/selectInput.Rd
@@ -70,10 +70,25 @@ The selectize input created from \code{selectizeInput()} allows
   \code{selectInput(..., selectize = FALSE)}.
 }
 \examples{
-selectInput("variable", "Variable:",
-            c("Cylinders" = "cyl",
-              "Transmission" = "am",
-              "Gears" = "gear"))
+## Only run examples in interactive R sessions
+if (interactive()) {
+
+ui <- fluidPage(
+  selectInput("variable", "Variable:",
+              c("Cylinders" = "cyl",
+                "Transmission" = "am",
+                "Gears" = "gear")),
+  tableOutput("data")
+)
+
+server <- function(input, output) {
+  output$data <- renderTable({
+    mtcars[, c("mpg", input$variable), drop = FALSE]
+  }, rownames = TRUE)
+}
+
+shinyApp(ui, server)
+}
 }
 \seealso{
 \code{\link{updateSelectInput}}

--- a/man/showNotification.Rd
+++ b/man/showNotification.Rd
@@ -44,6 +44,7 @@ An ID for the notification.
 These functions show and remove notifications in a Shiny application.
 }
 \examples{
+## Only run examples in interactive R sessions
 if (interactive()) {
 # Show a message when button is clicked
 shinyApp(

--- a/man/sidebarLayout.Rd
+++ b/man/sidebarLayout.Rd
@@ -25,7 +25,7 @@ area occupies 2/3 of the horizontal width and typically contains outputs.
 }
 \examples{
 # Define UI
-shinyUI(fluidPage(
+fluidPage(
 
   # Application title
   titlePanel("Hello Shiny!"),
@@ -46,7 +46,7 @@ shinyUI(fluidPage(
       plotOutput("distPlot")
     )
   )
-))
+)
 
 }
 

--- a/man/sidebarLayout.Rd
+++ b/man/sidebarLayout.Rd
@@ -24,8 +24,11 @@ distinct background color and typically contains input controls. The main
 area occupies 2/3 of the horizontal width and typically contains outputs.
 }
 \examples{
+## Only run examples in interactive R sessions
+if (interactive()) {
+
 # Define UI
-fluidPage(
+ui <- fluidPage(
 
   # Application title
   titlePanel("Hello Shiny!"),
@@ -48,5 +51,15 @@ fluidPage(
   )
 )
 
+# Server logic
+server <- function(input, output) {
+  output$distPlot <- renderPlot({
+    hist(rnorm(input$obs))
+  })
+}
+
+# Complete app with UI and server components
+shinyApp(ui, server)
+}
 }
 

--- a/man/sliderInput.Rd
+++ b/man/sliderInput.Rd
@@ -92,6 +92,28 @@ or list of tags (using \code{\link{tag}} and friends), or raw HTML (using
 \description{
 Constructs a slider widget to select a numeric value from a range.
 }
+\examples{
+## Only run examples in interactive R sessions
+if (interactive()) {
+
+ui <- fluidPage(
+  sliderInput("obs", "Number of observations:",
+    min = 0, max = 1000, value = 500
+  ),
+  plotOutput("distPlot")
+)
+
+# Server logic
+server <- function(input, output) {
+  output$distPlot <- renderPlot({
+    hist(rnorm(input$obs))
+  })
+}
+
+# Complete app with UI and server components
+shinyApp(ui, server)
+}
+}
 \seealso{
 \code{\link{updateSliderInput}}
 

--- a/man/splitLayout.Rd
+++ b/man/splitLayout.Rd
@@ -23,21 +23,33 @@ Lays out elements horizontally, dividing the available horizontal space into
 equal parts (by default).
 }
 \examples{
+## Only run examples in interactive R sessions
+if (interactive()) {
+
+# Server code used for all examples
+server <- function(input, output) {
+  output$plot1 <- renderPlot(plot(cars))
+  output$plot2 <- renderPlot(plot(pressure))
+  output$plot3 <- renderPlot(plot(AirPassengers))
+}
+
 # Equal sizing
-splitLayout(
+ui <- splitLayout(
   plotOutput("plot1"),
   plotOutput("plot2")
 )
+shinyApp(ui, server)
 
 # Custom widths
-splitLayout(cellWidths = c("25\%", "75\%"),
+ui <- splitLayout(cellWidths = c("25\%", "75\%"),
   plotOutput("plot1"),
   plotOutput("plot2")
 )
+shinyApp(ui, server)
 
 # All cells at 300 pixels wide, with cell padding
 # and a border around everything
-splitLayout(
+ui <- splitLayout(
   style = "border: 1px solid silver;",
   cellWidths = 300,
   cellArgs = list(style = "padding: 6px"),
@@ -45,5 +57,7 @@ splitLayout(
   plotOutput("plot2"),
   plotOutput("plot3")
 )
+shinyApp(ui, server)
+}
 }
 

--- a/man/textInput.Rd
+++ b/man/textInput.Rd
@@ -27,7 +27,18 @@ A text input control that can be added to a UI definition.
 Create an input control for entry of unstructured text values
 }
 \examples{
-textInput("caption", "Caption:", "Data Summary")
+## Only run examples in interactive R sessions
+if (interactive()) {
+
+ui <- fluidPage(
+  textInput("caption", "Caption", "Data Summary"),
+  verbatimTextOutput("value")
+)
+server <- function(input, output) {
+  output$value <- renderText({ input$caption })
+}
+shinyApp(ui, server)
+}
 }
 \seealso{
 \code{\link{updateTextInput}}

--- a/man/titlePanel.Rd
+++ b/man/titlePanel.Rd
@@ -20,7 +20,13 @@ Calling this function has the side effect of including a
   explicitly using the `title` parameter of the top-level page function.
 }
 \examples{
-titlePanel("Hello Shiny!")
+## Only run examples in interactive R sessions
+if (interactive()) {
 
+ui <- fluidPage(
+  titlePanel("Hello Shiny!")
+)
+shinyApp(ui, server = function(input, output) { })
+}
 }
 

--- a/man/updateActionButton.Rd
+++ b/man/updateActionButton.Rd
@@ -37,10 +37,23 @@ For \code{\link{radioButtons}()}, \code{\link{checkboxGroupInput}()} and
 \code{choices=character(0)}.
 }
 \examples{
-\dontrun{
-function(input, output, session) {
+## Only run examples in interactive R sessions
+if (interactive()) {
 
+ui <- fluidPage(
+  actionButton("update", "Update other buttons"),
+  br(),
+  actionButton("goButton", "Go"),
+  br(),
+  actionButton("goButton2", "Go 2", icon = icon("area-chart")),
+  br(),
+  actionButton("goButton3", "Go 3")
+)
+
+server <- function(input, output, session) {
   observe({
+    req(input$update)
+
     # Updates goButton's label and icon
     updateActionButton(session, "goButton",
       label = "New label",
@@ -54,9 +67,11 @@ function(input, output, session) {
     # Leaves goButton3's icon, if it exists,
     # unchaged and changes its label
     updateActionButton(session, "goButton3",
-      label = "New label")
+      label = "New label 3")
   })
 }
+
+shinyApp(ui, server)
 }
 }
 \seealso{

--- a/man/updateActionButton.Rd
+++ b/man/updateActionButton.Rd
@@ -38,7 +38,7 @@ For \code{\link{radioButtons}()}, \code{\link{checkboxGroupInput}()} and
 }
 \examples{
 \dontrun{
-shinyServer(function(input, output, session) {
+function(input, output, session) {
 
   observe({
     # Updates goButton's label and icon
@@ -56,7 +56,7 @@ shinyServer(function(input, output, session) {
     updateActionButton(session, "goButton3",
       label = "New label")
   })
-})
+}
 }
 }
 \seealso{

--- a/man/updateCheckboxGroupInput.Rd
+++ b/man/updateCheckboxGroupInput.Rd
@@ -43,7 +43,7 @@ For \code{\link{radioButtons}()}, \code{\link{checkboxGroupInput}()} and
 }
 \examples{
 \dontrun{
-shinyServer(function(input, output, session) {
+function(input, output, session) {
 
   observe({
     # We'll use the input$controller variable multiple times, so save it as x
@@ -66,7 +66,7 @@ shinyServer(function(input, output, session) {
       selected = sprintf("option-\%d-2", x)
     )
   })
-})
+}
 }
 }
 \seealso{

--- a/man/updateCheckboxGroupInput.Rd
+++ b/man/updateCheckboxGroupInput.Rd
@@ -42,31 +42,35 @@ For \code{\link{radioButtons}()}, \code{\link{checkboxGroupInput}()} and
 \code{choices=character(0)}.
 }
 \examples{
-\dontrun{
-function(input, output, session) {
+## Only run examples in interactive R sessions
+if (interactive()) {
 
+ui <- fluidPage(
+  p("The first checkbox group controls the second"),
+  checkboxGroupInput("inCheckboxGroup", "Input checkbox",
+    c("Item A", "Item B", "Item C")),
+  checkboxGroupInput("inCheckboxGroup2", "Input checkbox 2",
+    c("Item A", "Item B", "Item C"))
+)
+
+server <- function(input, output, session) {
   observe({
-    # We'll use the input$controller variable multiple times, so save it as x
-    # for convenience.
-    x <- input$controller
+    x <- input$inCheckboxGroup
 
-    # Create a list of new options, where the name of the items is something
-    # like 'option label x 1', and the values are 'option-x-1'.
-    cb_options <- list()
-    cb_options[[sprintf("option label \%d 1", x)]] <- sprintf("option-\%d-1", x)
-    cb_options[[sprintf("option label \%d 2", x)]] <- sprintf("option-\%d-2", x)
-
-    # Change values for input$inCheckboxGroup
-    updateCheckboxGroupInput(session, "inCheckboxGroup", choices = cb_options)
+    # Can use character(0) to remove all choices
+    if (is.null(x))
+      x <- character(0)
 
     # Can also set the label and select items
     updateCheckboxGroupInput(session, "inCheckboxGroup2",
-      label = paste("checkboxgroup label", x),
-      choices = cb_options,
-      selected = sprintf("option-\%d-2", x)
+      label = paste("Checkboxgroup label", length(x)),
+      choices = x,
+      selected = x
     )
   })
 }
+
+shinyApp(ui, server)
 }
 }
 \seealso{

--- a/man/updateCheckboxInput.Rd
+++ b/man/updateCheckboxInput.Rd
@@ -37,7 +37,7 @@ For \code{\link{radioButtons}()}, \code{\link{checkboxGroupInput}()} and
 }
 \examples{
 \dontrun{
-shinyServer(function(input, output, session) {
+function(input, output, session) {
 
   observe({
     # TRUE if input$controller is even, FALSE otherwise.
@@ -45,7 +45,7 @@ shinyServer(function(input, output, session) {
 
     updateCheckboxInput(session, "inCheckbox", value = x_even)
   })
-})
+}
 }
 }
 \seealso{

--- a/man/updateCheckboxInput.Rd
+++ b/man/updateCheckboxInput.Rd
@@ -36,16 +36,24 @@ For \code{\link{radioButtons}()}, \code{\link{checkboxGroupInput}()} and
 \code{choices=character(0)}.
 }
 \examples{
-\dontrun{
-function(input, output, session) {
+## Only run examples in interactive R sessions
+if (interactive()) {
 
+ui <- fluidPage(
+  sliderInput("controller", "Controller", 0, 1, 0, step = 1),
+  checkboxInput("inCheckbox", "Input checkbox")
+)
+
+server <- function(input, output, session) {
   observe({
-    # TRUE if input$controller is even, FALSE otherwise.
-    x_even <- input$controller \%\% 2 == 0
+    # TRUE if input$controller is odd, FALSE if even.
+    x_even <- input$controller \%\% 2 == 1
 
     updateCheckboxInput(session, "inCheckbox", value = x_even)
   })
 }
+
+shinyApp(ui, server)
 }
 }
 \seealso{

--- a/man/updateDateInput.Rd
+++ b/man/updateDateInput.Rd
@@ -45,7 +45,7 @@ For \code{\link{radioButtons}()}, \code{\link{checkboxGroupInput}()} and
 }
 \examples{
 \dontrun{
-shinyServer(function(input, output, session) {
+function(input, output, session) {
 
   observe({
     # We'll use the input$controller variable multiple times, so save it as x
@@ -59,7 +59,7 @@ shinyServer(function(input, output, session) {
       max   = paste("2013-04-", x+1, sep="")
     )
   })
-})
+}
 }
 }
 \seealso{

--- a/man/updateDateInput.Rd
+++ b/man/updateDateInput.Rd
@@ -44,9 +44,15 @@ For \code{\link{radioButtons}()}, \code{\link{checkboxGroupInput}()} and
 \code{choices=character(0)}.
 }
 \examples{
-\dontrun{
-function(input, output, session) {
+## Only run examples in interactive R sessions
+if (interactive()) {
 
+ui <- fluidPage(
+  sliderInput("controller", "Controller", 1, 30, 10),
+  dateInput("inDate", "Input date")
+)
+
+server <- function(input, output, session) {
   observe({
     # We'll use the input$controller variable multiple times, so save it as x
     # for convenience.
@@ -60,6 +66,8 @@ function(input, output, session) {
     )
   })
 }
+
+shinyApp(ui, server)
 }
 }
 \seealso{

--- a/man/updateDateRangeInput.Rd
+++ b/man/updateDateRangeInput.Rd
@@ -47,9 +47,15 @@ For \code{\link{radioButtons}()}, \code{\link{checkboxGroupInput}()} and
 \code{choices=character(0)}.
 }
 \examples{
-\dontrun{
-function(input, output, session) {
+## Only run examples in interactive R sessions
+if (interactive()) {
 
+ui <- fluidPage(
+  sliderInput("controller", "Controller", 1, 30, 10),
+  dateRangeInput("inDateRange", "Input date range")
+)
+
+server <- function(input, output, session) {
   observe({
     # We'll use the input$controller variable multiple times, so save it as x
     # for convenience.
@@ -57,10 +63,13 @@ function(input, output, session) {
 
     updateDateRangeInput(session, "inDateRange",
       label = paste("Date range label", x),
-      start = paste("2013-01-", x, sep=""))
-      end = paste("2013-12-", x, sep=""))
+      start = paste("2013-01-", x, sep=""),
+      end = paste("2013-12-", x, sep="")
+    )
   })
 }
+
+shinyApp(ui, server)
 }
 }
 \seealso{

--- a/man/updateDateRangeInput.Rd
+++ b/man/updateDateRangeInput.Rd
@@ -48,7 +48,7 @@ For \code{\link{radioButtons}()}, \code{\link{checkboxGroupInput}()} and
 }
 \examples{
 \dontrun{
-shinyServer(function(input, output, session) {
+function(input, output, session) {
 
   observe({
     # We'll use the input$controller variable multiple times, so save it as x
@@ -60,7 +60,7 @@ shinyServer(function(input, output, session) {
       start = paste("2013-01-", x, sep=""))
       end = paste("2013-12-", x, sep=""))
   })
-})
+}
 }
 }
 \seealso{

--- a/man/updateNumericInput.Rd
+++ b/man/updateNumericInput.Rd
@@ -44,7 +44,7 @@ For \code{\link{radioButtons}()}, \code{\link{checkboxGroupInput}()} and
 }
 \examples{
 \dontrun{
-shinyServer(function(input, output, session) {
+function(input, output, session) {
 
   observe({
     # We'll use the input$controller variable multiple times, so save it as x
@@ -57,7 +57,7 @@ shinyServer(function(input, output, session) {
       label = paste("Number label ", x),
       value = x, min = x-10, max = x+10, step = 5)
   })
-})
+}
 }
 }
 \seealso{

--- a/man/updateNumericInput.Rd
+++ b/man/updateNumericInput.Rd
@@ -43,10 +43,18 @@ For \code{\link{radioButtons}()}, \code{\link{checkboxGroupInput}()} and
 \code{choices=character(0)}.
 }
 \examples{
-\dontrun{
-function(input, output, session) {
+## Only run examples in interactive R sessions
+if (interactive()) {
 
-  observe({
+ui <- fluidPage(
+  sliderInput("controller", "Controller", 0, 20, 10),
+  numericInput("inNumber", "Input number", 0),
+  numericInput("inNumber2", "Input number 2", 0)
+)
+
+server <- function(input, output, session) {
+
+  observeEvent(input$controller, {
     # We'll use the input$controller variable multiple times, so save it as x
     # for convenience.
     x <- input$controller
@@ -58,6 +66,8 @@ function(input, output, session) {
       value = x, min = x-10, max = x+10, step = 5)
   })
 }
+
+shinyApp(ui, server)
 }
 }
 \seealso{

--- a/man/updateRadioButtons.Rd
+++ b/man/updateRadioButtons.Rd
@@ -43,29 +43,31 @@ For \code{\link{radioButtons}()}, \code{\link{checkboxGroupInput}()} and
 \code{choices=character(0)}.
 }
 \examples{
-\dontrun{
-function(input, output, session) {
+## Only run examples in interactive R sessions
+if (interactive()) {
 
+ui <- fluidPage(
+  p("The first radio button group controls the second"),
+  radioButtons("inRadioButtons", "Input radio buttons",
+    c("Item A", "Item B", "Item C")),
+  radioButtons("inRadioButtons2", "Input radio buttons 2",
+    c("Item A", "Item B", "Item C"))
+)
+
+server <- function(input, output, session) {
   observe({
-    # We'll use the input$controller variable multiple times, so save it as x
-    # for convenience.
-    x <- input$controller
+    x <- input$inRadioButtons
 
-    r_options <- list()
-    r_options[[sprintf("option label \%d 1", x)]] <- sprintf("option-\%d-1", x)
-    r_options[[sprintf("option label \%d 2", x)]] <- sprintf("option-\%d-2", x)
-
-    # Change values for input$inRadio
-    updateRadioButtons(session, "inRadio", choices = r_options)
-
-    # Can also set the label and select an item
-    updateRadioButtons(session, "inRadio2",
-      label = paste("Radio label", x),
-      choices = r_options,
-      selected = sprintf("option-\%d-2", x)
+    # Can also set the label and select items
+    updateRadioButtons(session, "inRadioButtons2",
+      label = paste("radioButtons label", x),
+      choices = x,
+      selected = x
     )
   })
 }
+
+shinyApp(ui, server)
 }
 }
 \seealso{

--- a/man/updateRadioButtons.Rd
+++ b/man/updateRadioButtons.Rd
@@ -44,7 +44,7 @@ For \code{\link{radioButtons}()}, \code{\link{checkboxGroupInput}()} and
 }
 \examples{
 \dontrun{
-shinyServer(function(input, output, session) {
+function(input, output, session) {
 
   observe({
     # We'll use the input$controller variable multiple times, so save it as x
@@ -65,7 +65,7 @@ shinyServer(function(input, output, session) {
       selected = sprintf("option-\%d-2", x)
     )
   })
-})
+}
 }
 }
 \seealso{

--- a/man/updateSelectInput.Rd
+++ b/man/updateSelectInput.Rd
@@ -57,7 +57,7 @@ For \code{\link{radioButtons}()}, \code{\link{checkboxGroupInput}()} and
 }
 \examples{
 \dontrun{
-shinyServer(function(input, output, session) {
+function(input, output, session) {
 
   observe({
     # We'll use the input$controller variable multiple times, so save it as x
@@ -81,7 +81,7 @@ shinyServer(function(input, output, session) {
       selected = sprintf("option-\%d-2", x)
     )
   })
-})
+}
 }
 }
 \seealso{

--- a/man/updateSelectInput.Rd
+++ b/man/updateSelectInput.Rd
@@ -56,32 +56,35 @@ For \code{\link{radioButtons}()}, \code{\link{checkboxGroupInput}()} and
 \code{choices=character(0)}.
 }
 \examples{
-\dontrun{
-function(input, output, session) {
+## Only run examples in interactive R sessions
+if (interactive()) {
 
+ui <- fluidPage(
+  p("The checkbox group controls the select input"),
+  checkboxGroupInput("inCheckboxGroup", "Input checkbox",
+    c("Item A", "Item B", "Item C")),
+  selectInput("inSelect", "Select input",
+    c("Item A", "Item B", "Item C"))
+)
+
+server <- function(input, output, session) {
   observe({
-    # We'll use the input$controller variable multiple times, so save it as x
-    # for convenience.
-    x <- input$controller
+    x <- input$inCheckboxGroup
 
-    # Create a list of new options, where the name of the items is something
-    # like 'option label x 1', and the values are 'option-x-1'.
-    s_options <- list()
-    s_options[[sprintf("option label \%d 1", x)]] <- sprintf("option-\%d-1", x)
-    s_options[[sprintf("option label \%d 2", x)]] <- sprintf("option-\%d-2", x)
+    # Can use character(0) to remove all choices
+    if (is.null(x))
+      x <- character(0)
 
-    # Change values for input$inSelect
-    updateSelectInput(session, "inSelect", choices = s_options)
-
-    # Can also set the label and select an item (or more than one if it's a
-    # multi-select)
-    updateSelectInput(session, "inSelect2",
-      label = paste("Select label", x),
-      choices = s_options,
-      selected = sprintf("option-\%d-2", x)
+    # Can also set the label and select items
+    updateSelectInput(session, "inSelect",
+      label = paste("Select input label", length(x)),
+      choices = x,
+      selected = tail(x, 1)
     )
   })
 }
+
+shinyApp(ui, server)
 }
 }
 \seealso{

--- a/man/updateTabsetPanel.Rd
+++ b/man/updateTabsetPanel.Rd
@@ -26,7 +26,7 @@ Change the selected tab on the client
 }
 \examples{
 \dontrun{
-shinyServer(function(input, output, session) {
+function(input, output, session) {
 
   observe({
     # TRUE if input$controller is even, FALSE otherwise.
@@ -40,7 +40,7 @@ shinyServer(function(input, output, session) {
       updateTabsetPanel(session, "inTabset", selected = "panel1")
     }
   })
-})
+}
 }
 }
 \seealso{

--- a/man/updateTabsetPanel.Rd
+++ b/man/updateTabsetPanel.Rd
@@ -25,22 +25,31 @@ or \code{navbarPage} object.}
 Change the selected tab on the client
 }
 \examples{
-\dontrun{
-function(input, output, session) {
+## Only run examples in interactive R sessions
+if (interactive()) {
 
-  observe({
-    # TRUE if input$controller is even, FALSE otherwise.
-    x_even <- input$controller \%\% 2 == 0
+ui <- fluidPage(sidebarLayout(
+  sidebarPanel(
+    sliderInput("controller", "Controller", 1, 3, 1)
+  ),
+  mainPanel(
+    tabsetPanel(id = "inTabset",
+      tabPanel(title = "Panel 1", value = "panel1", "Panel 1 content"),
+      tabPanel(title = "Panel 2", value = "panel2", "Panel 2 content"),
+      tabPanel(title = "Panel 3", value = "panel3", "Panel 3 content")
+    )
+  )
+))
 
-    # Change the selected tab.
-    # Note that the tabset container must have been created with an 'id' argument
-    if (x_even) {
-      updateTabsetPanel(session, "inTabset", selected = "panel2")
-    } else {
-      updateTabsetPanel(session, "inTabset", selected = "panel1")
-    }
+server <- function(input, output, session) {
+  observeEvent(input$controller, {
+    updateTabsetPanel(session, "inTabset",
+      selected = paste0("panel", input$controller)
+    )
   })
 }
+
+shinyApp(ui, server)
 }
 }
 \seealso{

--- a/man/updateTextInput.Rd
+++ b/man/updateTextInput.Rd
@@ -36,9 +36,16 @@ For \code{\link{radioButtons}()}, \code{\link{checkboxGroupInput}()} and
 \code{choices=character(0)}.
 }
 \examples{
-\dontrun{
-function(input, output, session) {
+## Only run examples in interactive R sessions
+if (interactive()) {
 
+ui <- fluidPage(
+  sliderInput("controller", "Controller", 0, 20, 10),
+  textInput("inText", "Input text"),
+  textInput("inText2", "Input text 2")
+)
+
+server <- function(input, output, session) {
   observe({
     # We'll use the input$controller variable multiple times, so save it as x
     # for convenience.
@@ -53,6 +60,8 @@ function(input, output, session) {
       value = paste("New text", x))
   })
 }
+
+shinyApp(ui, server)
 }
 }
 \seealso{

--- a/man/updateTextInput.Rd
+++ b/man/updateTextInput.Rd
@@ -37,7 +37,7 @@ For \code{\link{radioButtons}()}, \code{\link{checkboxGroupInput}()} and
 }
 \examples{
 \dontrun{
-shinyServer(function(input, output, session) {
+function(input, output, session) {
 
   observe({
     # We'll use the input$controller variable multiple times, so save it as x
@@ -52,7 +52,7 @@ shinyServer(function(input, output, session) {
       label = paste("New label", x),
       value = paste("New text", x))
   })
-})
+}
 }
 }
 \seealso{

--- a/man/verticalLayout.Rd
+++ b/man/verticalLayout.Rd
@@ -17,13 +17,18 @@ Create a container that includes one or more rows of content (each element
 passed to the container will appear on it's own line in the UI)
 }
 \examples{
-fluidPage(
+## Only run examples in interactive R sessions
+if (interactive()) {
+
+ui <- fluidPage(
   verticalLayout(
     a(href="http://example.com/link1", "Link One"),
     a(href="http://example.com/link2", "Link Two"),
     a(href="http://example.com/link3", "Link Three")
   )
 )
+shinyApp(ui, server = function(input, output) { })
+}
 }
 \seealso{
 \code{\link{fluidPage}}, \code{\link{flowLayout}}

--- a/man/verticalLayout.Rd
+++ b/man/verticalLayout.Rd
@@ -17,13 +17,13 @@ Create a container that includes one or more rows of content (each element
 passed to the container will appear on it's own line in the UI)
 }
 \examples{
-shinyUI(fluidPage(
+fluidPage(
   verticalLayout(
     a(href="http://example.com/link1", "Link One"),
     a(href="http://example.com/link2", "Link Two"),
     a(href="http://example.com/link3", "Link Three")
   )
-))
+)
 }
 \seealso{
 \code{\link{fluidPage}}, \code{\link{flowLayout}}

--- a/man/withProgress.Rd
+++ b/man/withProgress.Rd
@@ -74,9 +74,14 @@ is not common) or otherwise cannot be encapsulated by a single scope. In that
 case, you can use the \code{Progress} reference class.
 }
 \examples{
-\dontrun{
-# server.R
-function(input, output) {
+## Only run examples in interactive R sessions
+if (interactive()) {
+
+ui <- fluidPage(
+  plotOutput("plot")
+)
+
+server <- function(input, output) {
   output$plot <- renderPlot({
     withProgress(message = 'Calculation in progress',
                  detail = 'This may take a while...', value = 0, {
@@ -88,6 +93,8 @@ function(input, output) {
     plot(cars)
   })
 }
+
+shinyApp(ui, server)
 }
 }
 \seealso{

--- a/man/withProgress.Rd
+++ b/man/withProgress.Rd
@@ -76,7 +76,7 @@ case, you can use the \code{Progress} reference class.
 \examples{
 \dontrun{
 # server.R
-shinyServer(function(input, output) {
+function(input, output) {
   output$plot <- renderPlot({
     withProgress(message = 'Calculation in progress',
                  detail = 'This may take a while...', value = 0, {
@@ -87,7 +87,7 @@ shinyServer(function(input, output) {
     })
     plot(cars)
   })
-})
+}
 }
 }
 \seealso{


### PR DESCRIPTION
Closes #1137. This PR does two main things to examples:

* Removes almost all uses of `shinyUI()` and `shinyServer()`, since they aren't needed anymore. The only remaining cases are places where it's necessary, like in the examples for those functions.
* Converts almost all examples that had just fragments of code into fully-runnable examples that use `shinyApp()`. This makes the examples much more useful since the users can run them and see them in action.
