### PR TITLE
Change progress indicators to use notification API

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,8 @@ shiny 0.13.2.9001
   `showNotification` and `hideNotification`. From JavaScript, there is a new
   `Shiny.notification` object that controls notifications. (#1141)
 
+* Progress indicators now use the notification API.
+
 * Improved `renderTable()` function to make the tables look prettier and also
   provide the user with a lot more parameters to customize their tables with.
 

--- a/inst/www/shared/shiny.css
+++ b/inst/www/shared/shiny.css
@@ -124,46 +124,17 @@
   max-width: 100%;
 }
 
-.shiny-progress-container {
-  position: fixed;
-  top: 0px;
-  width: 100%;
-  /* Make sure it draws above all Bootstrap components */
-  z-index: 2000;
-}
-
 .shiny-progress .progress {
-  position: absolute;
-  width: 100%;
-  top: 0px;
-  height: 3px;
-  margin: 0px;
-}
-
-.shiny-progress .bar {
-  opacity: 0.6;
-  transition-duration: 250ms;
-}
-
-.shiny-progress .progress-text {
-  position: absolute;
-  right: 10px;
-  height: 24px;
-  width: 240px;
-  background-color: #eef8ff;
-  margin: 0px;
-  padding: 2px 3px;
-  opacity: 0.85;
+  margin-bottom: 5px;
+  height: 10px;
 }
 
 .shiny-progress .progress-text .progress-message {
-  padding: 0px 3px;
   font-weight: bold;
   font-size: 90%;
 }
 
 .shiny-progress .progress-text .progress-detail {
-  padding: 0px 3px;
   font-size: 80%;
 }
 

--- a/srcjs/shinyapp.js
+++ b/srcjs/shinyapp.js
@@ -643,36 +643,32 @@ var ShinyApp = function() {
         binding.showProgress(true);
       }
     },
+
     // Open a page-level progress bar
     open: function(message) {
-      // Add progress container (for all progress items) if not already present
-      var $container = $('.shiny-progress-container');
-      if ($container.length === 0) {
-        $container = $('<div class="shiny-progress-container"></div>');
-        $('body').append($container);
-      }
-
-      // Add div for just this progress ID
-      var depth = $('.shiny-progress.open').length;
-      var $progress = $(progressHandlers.progressHTML);
-      $progress.attr('id', message.id);
-      $container.append($progress);
-
-      // Stack bars
-      var $progressBar = $progress.find('.progress');
-      $progressBar.css('top', depth * $progressBar.height() + 'px');
-
-      // Stack text objects
-      var $progressText = $progress.find('.progress-text');
-      $progressText.css('top', 3 * $progressBar.height() +
-        depth * $progressText.outerHeight() + 'px');
-
-      $progress.hide();
+      // Progress bar starts hidden; will be made visible if a value is provided
+      // during updates.
+      exports.notifications.show({
+        html:
+          `<div id="shiny-progress-${message.id}" class="shiny-progress">` +
+            '<div class="progress progress-striped active" style="display: none;"><div class="progress-bar"></div></div>' +
+            '<div class="progress-text">' +
+              '<span class="progress-message">message</span> ' +
+              '<span class="progress-detail"></span>' +
+            '</div>' +
+          '</div>',
+        id: message.id,
+        duration: null
+      });
     },
 
     // Update page-level progress bar
     update: function(message) {
-      var $progress = $('#' + message.id + '.shiny-progress');
+      var $progress = $('#shiny-progress-' + message.id);
+
+      if ($progress.length === 0)
+        return;
+
       if (typeof(message.message) !== 'undefined') {
         $progress.find('.progress-message').text(message.message);
       }
@@ -682,40 +678,18 @@ var ShinyApp = function() {
       if (typeof(message.value) !== 'undefined') {
         if (message.value !== null) {
           $progress.find('.progress').show();
-          $progress.find('.bar').width((message.value*100) + '%');
-        }
-        else {
+          $progress.find('.progress-bar').width((message.value*100) + '%');
+
+        } else {
           $progress.find('.progress').hide();
         }
       }
-
-      $progress.fadeIn();
     },
 
     // Close page-level progress bar
     close: function(message) {
-      var $progress = $('#' + message.id + '.shiny-progress');
-      $progress.removeClass('open');
-
-      $progress.fadeOut({
-        complete: function() {
-          $progress.remove();
-
-          // If this was the last shiny-progress, remove container
-          if ($('.shiny-progress').length === 0)
-            $('.shiny-progress-container').remove();
-        }
-      });
-    },
-
-    // The 'bar' class is needed for backward compatibility with Bootstrap 2.
-    progressHTML: '<div class="shiny-progress open">' +
-      '<div class="progress progress-striped active"><div class="progress-bar bar"></div></div>' +
-      '<div class="progress-text">' +
-        '<span class="progress-message">message</span>' +
-        '<span class="progress-detail"></span>' +
-      '</div>' +
-    '</div>'
+      exports.notifications.remove(message.id);
+    }
   };
 
   exports.progressHandlers = progressHandlers;


### PR DESCRIPTION
Screenshot of the progress example from the Shiny gallery, which has several progress bars:
![image](https://cloud.githubusercontent.com/assets/86978/14328782/d71920cc-fbfd-11e5-8fe2-e1a441ff07f2.png)
