### PR TITLE
Allow to pass arguments to the icon tag function in the icon function

### DIFF
--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -1474,6 +1474,8 @@ downloadLink <- function(outputId, label="Download", class=NULL) {
 #'   \href{http://fontawesome.io/examples/}{usage examples} for details on
 #'   supported styles).
 #' @param lib Icon library to use ("font-awesome" or "glyphicon")
+#' @param ... Other arguments to pass to the icon tag function. This is
+#'   useful for providing additional classes for the tag.
 #'
 #' @return An icon element
 #'
@@ -1497,7 +1499,7 @@ downloadLink <- function(outputId, label="Download", class=NULL) {
 #' ))
 #'
 #' @export
-icon <- function(name, class = NULL, lib = "font-awesome") {
+icon <- function(name, class = NULL, lib = "font-awesome", ...) {
   prefixes <- list(
     "font-awesome" = "fa",
     "glyphicon" = "glyphicon"
@@ -1518,7 +1520,7 @@ icon <- function(name, class = NULL, lib = "font-awesome") {
   if (!is.null(class))
     iconClass <- paste(iconClass, class)
 
-  iconTag <- tags$i(class = iconClass)
+  iconTag <- tags$i(class = iconClass, ...)
 
   # font-awesome needs an additional dependency (glyphicon is in bootstrap)
   if (lib == "font-awesome") {

--- a/man/icon.Rd
+++ b/man/icon.Rd
@@ -19,6 +19,8 @@ in icon names (i.e. the "fa-calendar" icon should be referred to as
 supported styles).}
 
 \item{lib}{Icon library to use ("font-awesome" or "glyphicon")}
+\item{...}{Other arguments to pass to the icon tag function. This is
+useful for providing additional classes for the tag.}
 }
 \value{
 An icon element

--- a/man/icon.Rd
+++ b/man/icon.Rd
@@ -4,7 +4,7 @@
 \alias{icon}
 \title{Create an icon}
 \usage{
-icon(name, class = NULL, lib = "font-awesome")
+icon(name, class = NULL, lib = "font-awesome", ...)
 }
 \arguments{
 \item{name}{Name of icon. Icons are drawn from the
@@ -19,6 +19,7 @@ in icon names (i.e. the "fa-calendar" icon should be referred to as
 supported styles).}
 
 \item{lib}{Icon library to use ("font-awesome" or "glyphicon")}
+
 \item{...}{Other arguments to pass to the icon tag function. This is
 useful for providing additional classes for the tag.}
 }


### PR DESCRIPTION
This allows to add classes/id to an icon making it easy to use CSS selectors to apply styles.