### PR TITLE
avoid overflow in R 3.3.0 radix sort

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -597,7 +597,10 @@ Callbacks <- R6Class(
     .callbacks = 'Map',
 
     initialize = function() {
-      .nextId <<- as.integer(.Machine$integer.max)
+      # NOTE: we avoid using '.Machine$integer.max' directly
+      # as R 3.3.0's 'radixsort' could segfault when sorting
+      # an integer vector containing this value
+      .nextId <<- as.integer(.Machine$integer.max - 1L)
       .callbacks <<- Map$new()
     },
     register = function(callback) {


### PR DESCRIPTION
This PR works around a bug in R 3.3.0's radix sort implementation (where overflows can occur when attempting to sort integers with INT_MAX included). Should resolve https://github.com/rstudio/shiny/issues/1200.