### PR TITLE
Don't use randomly-chosen port numbers that Chrome deems unsafe

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -659,7 +659,14 @@ runApp <- function(appDir=getwd(),
       }
       else {
         # Try up to 20 random ports
-        port <- p_randomInt(3000, 8000)
+        while (TRUE) {
+          port <- p_randomInt(3000, 8000)
+          # Reject ports in this range that are considered unsafe by Chrome
+          # http://superuser.com/questions/188058/which-ports-are-considered-unsafe-on-chrome
+          if (!port %in% c(3659, 4045, 6000, 6665:6669)) {
+            break
+          }
+        }
       }
 
       # Test port to see if we can use it


### PR DESCRIPTION
Still OK to use these ports if the user asks for them explicitly

Chrome actually blocks these URLs from loading.

![image](https://cloud.githubusercontent.com/assets/129551/16360723/855c167e-3b25-11e6-9940-d234cf5c0235.png)
