### PR TITLE
Support pool package

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -570,7 +570,8 @@ runApp <- function(appDir=getwd(),
     host <- '0.0.0.0'
 
   # Make warnings print immediately
-  ops <- options(warn = 1)
+  # Set pool.scheduler to support pool package
+  ops <- options(warn = 1, pool.scheduler = scheduleTask)
   on.exit(options(ops), add = TRUE)
 
   workerId(workerId)

--- a/R/timer.R
+++ b/R/timer.R
@@ -71,3 +71,15 @@ TimerCallbacks <- R6Class(
 )
 
 timerCallbacks <- TimerCallbacks$new()
+
+scheduleTask <- function(millis, callback) {
+  cancelled <- FALSE
+  timerCallbacks$schedule(millis, function() {
+    if (!cancelled)
+      callback()
+  })
+
+  function() {
+    cancelled <<- TRUE
+  }
+}


### PR DESCRIPTION
We need to merge this now because people are expecting to be able to use the master version of Shiny to get the desired pool behavior. The really tiny changes don't affect anything else, so I think we're safe. (I'm gonna keep this branch though, because the exact mechanism of setting the scheduler option is still in flux)