### PR TITLE
Fix #931: Observer memory leak

### DIFF
--- a/R/reactive-domains.R
+++ b/R/reactive-domains.R
@@ -42,11 +42,11 @@ NULL
 #
 ## ------------------------------------------------------------------------
 createMockDomain <- function() {
-  callbacks <- list()
+  callbacks <- Callbacks$new()
   ended <- FALSE
   domain <- new.env(parent = emptyenv())
   domain$onEnded <- function(callback) {
-    callbacks <<- c(callbacks, callback)
+    return(callbacks$register(callback))
   }
   domain$isEnded <- function() {
     ended
@@ -55,7 +55,7 @@ createMockDomain <- function() {
   domain$end <- function() {
     if (!ended) {
       ended <<- TRUE
-      lapply(callbacks, do.call, list())
+      callbacks$invoke()
     }
     invisible()
   }

--- a/R/reactives.R
+++ b/R/reactives.R
@@ -591,6 +591,10 @@ Observer <- R6Class(
     .domain = 'ANY',
     .priority = numeric(0),
     .autoDestroy = logical(0),
+    # A function that, when invoked, unsubscribes the autoDestroy
+    # listener (or NULL if autodestroy is disabled for this observer).
+    # We must unsubscribe when this observer is destroyed, or else
+    # the observer cannot be garbage collected until the session ends.
     .autoDestroyHandle = 'ANY',
     .invalidateCallbacks = list(),
     .execCount = integer(0),

--- a/R/reactives.R
+++ b/R/reactives.R
@@ -721,12 +721,12 @@ registerDebugHook("observerFunc", environment(), label)
           if (.domain$isEnded()) {
             destroy()
           } else {
-            .autoDestroyHandle <<- onReactiveDomainEnded(.domain, self$.onDomainEnded)
+            .autoDestroyHandle <<- onReactiveDomainEnded(.domain, .onDomainEnded)
           }
         }
       } else {
         if (!is.null(.autoDestroyHandle))
-          self$.autoDestroyHandle()
+          .autoDestroyHandle()
         .autoDestroyHandle <<- NULL
       }
 
@@ -763,7 +763,7 @@ registerDebugHook("observerFunc", environment(), label)
       .destroyed <<- TRUE
 
       if (!is.null(.autoDestroyHandle)) {
-        self$.autoDestroyHandle()
+        .autoDestroyHandle()
       }
       .autoDestroyHandle <<- NULL
 
@@ -773,7 +773,7 @@ registerDebugHook("observerFunc", environment(), label)
     },
     .onDomainEnded = function() {
       if (isTRUE(.autoDestroy)) {
-        self$destroy()
+        destroy()
       }
     }
   )

--- a/R/reactives.R
+++ b/R/reactives.R
@@ -591,6 +591,7 @@ Observer <- R6Class(
     .domain = 'ANY',
     .priority = numeric(0),
     .autoDestroy = logical(0),
+    .autoDestroyHandle = 'ANY',
     .invalidateCallbacks = list(),
     .execCount = integer(0),
     .onResume = 'function',
@@ -620,7 +621,6 @@ registerDebugHook("observerFunc", environment(), label)
       }
       .label <<- label
       .domain <<- domain
-      .autoDestroy <<- autoDestroy
       .priority <<- normalizePriority(priority)
       .execCount <<- 0L
       .suspended <<- suspended
@@ -628,7 +628,9 @@ registerDebugHook("observerFunc", environment(), label)
       .destroyed <<- FALSE
       .prevId <<- ''
 
-      onReactiveDomainEnded(.domain, self$.onDomainEnded)
+      .autoDestroy <<- FALSE
+      .autoDestroyHandle <<- NULL
+      setAutoDestroy(autoDestroy)
 
       # Defer the first running of this until flushReact is called
       .createContext()$invalidate()
@@ -706,11 +708,28 @@ registerDebugHook("observerFunc", environment(), label)
       "Sets whether this observer should be automatically destroyed when its
       domain (if any) ends. If autoDestroy is TRUE and the domain already
       ended, then destroy() is called immediately."
+
+      if (.autoDestroy == autoDestroy) {
+        return(.autoDestroy)
+      }
+
       oldValue <- .autoDestroy
       .autoDestroy <<- autoDestroy
-      if (!is.null(.domain) && .domain$isEnded()) {
-        destroy()
+
+      if (autoDestroy) {
+        if (!.destroyed && !is.null(.domain)) { # Make sure to not try to destroy twice.
+          if (.domain$isEnded()) {
+            destroy()
+          } else {
+            .autoDestroyHandle <<- onReactiveDomainEnded(.domain, self$.onDomainEnded)
+          }
+        }
+      } else {
+        if (!is.null(.autoDestroyHandle))
+          self$.autoDestroyHandle()
+        .autoDestroyHandle <<- NULL
       }
+
       invisible(oldValue)
     },
     suspend = function() {
@@ -743,13 +762,18 @@ registerDebugHook("observerFunc", environment(), label)
       suspend()
       .destroyed <<- TRUE
 
+      if (!is.null(.autoDestroyHandle)) {
+        self$.autoDestroyHandle()
+      }
+      .autoDestroyHandle <<- NULL
+
       if (!is.null(.ctx)) {
         .ctx$invalidate()
       }
     },
     .onDomainEnded = function() {
       if (isTRUE(.autoDestroy)) {
-        destroy()
+        self$destroy()
       }
     }
   )


### PR DESCRIPTION
Observers were being prevented from being garbage collected by
their own onReactiveDomainEnded() event handlers. This commit
fixes that by making sure that those event handlers are only
registered when autoDestroy=TRUE, and that they are unregistered
both on destruction and when autoDestroy is changed.