### PR TITLE
Barbara/error handling/port as socket

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -447,6 +447,9 @@ startApp <- function(appObj, port, host, quiet) {
       message('\n', 'Listening on domain socket ', port)
     }
     mask <- attr(port, 'mask')
+    if (is.null(mask)) {
+      stop("`port` is not a valid domain socket (missing `mask` attribute)")
+    }
     return(startPipeServer(port, mask, handlerManager$createHttpuvApp()))
   }
 }

--- a/R/server.R
+++ b/R/server.R
@@ -448,7 +448,10 @@ startApp <- function(appObj, port, host, quiet) {
     }
     mask <- attr(port, 'mask')
     if (is.null(mask)) {
-      stop("`port` is not a valid domain socket (missing `mask` attribute)")
+      stop("`port` is not a valid domain socket (missing `mask` attribute). ",
+           "Note that if you're using the default `host` + `port` ",
+           "configuration (and not domain sockets), then `port` must ",
+           "be numeric, not a string.")
     }
     return(startPipeServer(port, mask, handlerManager$createHttpuvApp()))
   }


### PR DESCRIPTION
In issue #971, the user requests that ports be cast to numeric when they're passed in as a string. However, there is a legitimate use case when the `port` argument may be passed as a string, which is when it is being used *not* to specify the actual port, but to provide a domain socket instead. Fortunately, if this is the case, `port` must include a `mask` attribute. So if that is not present, we know that `port` is being used incorrectly. In that situation, throw an error with a (hopefully) helpful message.