### PR TITLE
Barbara/remove example extra line

### DIFF
--- a/R/app.R
+++ b/R/app.R
@@ -59,7 +59,6 @@
 #'
 #'   runApp(app)
 #' }
-#'
 #' @export
 shinyApp <- function(ui=NULL, server=NULL, onStart=NULL, options=list(),
                      uiPattern="/") {

--- a/R/bootstrap-layout.R
+++ b/R/bootstrap-layout.R
@@ -418,7 +418,6 @@ flowLayout <- function(..., cellArgs = list()) {
 #' suitable for wrapping inputs.
 #'
 #' @param ... Input controls or other HTML elements.
-#'
 #' @export
 inputPanel <- function(...) {
   div(class = "shiny-input-panel",

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -25,7 +25,6 @@ NULL
 #'   \code{\link{fluidPage}} function instead.
 #'
 #' @seealso \code{\link{fluidPage}}, \code{\link{fixedPage}}
-#'
 #' @export
 bootstrapPage <- function(..., title = NULL, responsive = NULL, theme = NULL) {
 
@@ -153,7 +152,6 @@ basicPage <- function(...) {
 #'     div(style = "background-color: blue; width: 100%; height: 100%;")
 #'   )
 #' )
-#'
 #' @export
 fillPage <- function(..., padding = 0, title = NULL, bootstrap = TRUE,
   theme = NULL) {
@@ -215,7 +213,6 @@ collapseSizes <- function(padding) {
 #'     plotOutput("distPlot")
 #'   )
 #' )
-#'
 #' @export
 pageWithSidebar <- function(headerPanel,
                             sidebarPanel,
@@ -430,7 +427,6 @@ headerPanel <- function(title, windowTitle=title) {
 #'
 #' @param ... UI elements to include inside the panel.
 #' @return The newly created panel.
-#'
 #' @export
 wellPanel <- function(...) {
   div(class="well", ...)
@@ -534,7 +530,6 @@ mainPanel <- function(..., width = 8) {
 #'       )
 #'    )
 #' )
-#'
 #' @export
 conditionalPanel <- function(condition, ...) {
   div('data-display-if'=condition, ...)
@@ -1495,7 +1490,6 @@ downloadLink <- function(outputId, label="Download", class=NULL) {
 #'   tabPanel("Summary", icon = icon("list-alt")),
 #'   tabPanel("Table", icon = icon("table"))
 #' )
-#'
 #' @export
 icon <- function(name, class = NULL, lib = "font-awesome") {
   prefixes <- list(

--- a/R/graph.R
+++ b/R/graph.R
@@ -43,7 +43,6 @@ writeReactLog <- function(file=stdout(), sessionToken = NULL) {
 #'
 #' @param time A boolean that specifies whether or not to display the
 #' time that each reactive.
-#'
 #' @export
 showReactLog <- function(time = TRUE) {
   utils::browseURL(renderReactLog(time = as.logical(time)))

--- a/R/imageutils.R
+++ b/R/imageutils.R
@@ -25,7 +25,6 @@
 #'   R; it won't change the actual ppi of the browser.
 #' @param ... Arguments to be passed through to \code{\link[grDevices]{png}}.
 #'   These can be used to set the width, height, background color, etc.
-#'
 #' @export
 plotPNG <- function(func, filename=tempfile(fileext='.png'),
                     width=400, height=400, res=72, ...) {

--- a/R/input-action.R
+++ b/R/input-action.R
@@ -37,7 +37,6 @@
 #' }
 #'
 #' @seealso \code{\link{observeEvent}} and \code{\link{eventReactive}}
-#'
 #' @export
 actionButton <- function(inputId, label, icon = NULL, width = NULL, ...) {
   tags$button(id=inputId,

--- a/R/input-slider.R
+++ b/R/input-slider.R
@@ -242,7 +242,6 @@ hasDecimals <- function(value) {
 #'   or list of tags (using \code{\link{tag}} and friends), or raw HTML (using
 #'   \code{\link{HTML}}).
 #' @param pauseButton Similar to \code{playButton}, but for the pause button.
-#'
 #' @export
 animationOptions <- function(interval=1000,
                              loop=FALSE,

--- a/R/insert-ui.R
+++ b/R/insert-ui.R
@@ -73,7 +73,6 @@
 #' # Complete app with UI and server components
 #' shinyApp(ui, server)
 #' }
-#'
 #' @export
 insertUI <- function(selector,
   where = c("beforeBegin", "afterBegin", "beforeEnd", "afterEnd"),
@@ -155,7 +154,6 @@ insertUI <- function(selector,
 #' # Complete app with UI and server components
 #' shinyApp(ui, server)
 #' }
-#'
 #' @export
 removeUI <- function(selector,
   multiple = FALSE,

--- a/R/jqueryui.R
+++ b/R/jqueryui.R
@@ -53,7 +53,6 @@
 #'   over text). The default is \code{"auto"}, which is equivalent to
 #'   \code{ifelse(draggable, "move", "inherit")}.
 #' @return An HTML element or list of elements.
-#'
 #' @export
 absolutePanel <- function(...,
                           top = NULL, left = NULL, right = NULL, bottom = NULL,

--- a/R/modules.R
+++ b/R/modules.R
@@ -48,7 +48,6 @@ createSessionProxy <- function(parentSession, ...) {
 #'
 #' @return The return value, if any, from executing the module server function
 #' @seealso \url{http://shiny.rstudio.com/articles/modules.html}
-#'
 #' @export
 callModule <- function(module, id, ..., session = getDefaultReactiveDomain()) {
   childScope <- session$makeScope(id)

--- a/R/reactives.R
+++ b/R/reactives.R
@@ -186,7 +186,6 @@ ReactiveValues <- R6Class(
 #'   these objects must be named.
 #'
 #' @seealso \code{\link{isolate}} and \code{\link{is.reactivevalues}}.
-#'
 #' @export
 reactiveValues <- function(...) {
   args <- list(...)
@@ -317,7 +316,6 @@ as.list.reactivevalues <- function(x, all.names=FALSE, ...) {
 #' # isolate() can also be used when calling from outside a reactive context (e.g.
 #' # at the console)
 #' isolate(reactiveValuesToList(values))
-#'
 #' @export
 reactiveValuesToList <- function(x, all.names=FALSE) {
   .subset2(x, 'impl')$toList(all.names)
@@ -499,7 +497,6 @@ Observable <- R6Class(
 #' isolate(reactiveB())
 #' isolate(reactiveC())
 #' isolate(reactiveD())
-#'
 #' @export
 reactive <- function(x, env = parent.frame(), quoted = FALSE, label = NULL,
                      domain = getDefaultReactiveDomain(),
@@ -878,7 +875,6 @@ registerDebugHook("observerFunc", environment(), label)
 #' # In a normal Shiny app, the web client will trigger flush events. If you
 #' # are at the console, you can force a flush with flushReact()
 #' shiny:::flushReact()
-#'
 #' @export
 observe <- function(x, env=parent.frame(), quoted=FALSE, label=NULL,
                     suspended=FALSE, priority=0,
@@ -1028,7 +1024,6 @@ setAutoflush <- local({
 #'
 #' shinyApp(ui, server)
 #' }
-#'
 #' @export
 reactiveTimer <- function(intervalMs=1000, session = getDefaultReactiveDomain()) {
   dependents <- Map$new()
@@ -1187,7 +1182,6 @@ coerceToFunc <- function(x) {
 #'     data()
 #'   })
 #' }
-#'
 #' @export
 reactivePoll <- function(intervalMillis, session, checkFunc, valueFunc) {
   intervalMillis <- coerceToFunc(intervalMillis)
@@ -1265,7 +1259,6 @@ reactivePoll <- function(intervalMillis, session, checkFunc, valueFunc) {
 #'   })
 #' }
 #' }
-#'
 #' @export
 reactiveFileReader <- function(intervalMillis, session, filePath, readFunc, ...) {
   filePath <- coerceToFunc(filePath)
@@ -1353,7 +1346,6 @@ reactiveFileReader <- function(intervalMillis, session, filePath, readFunc, ...)
 #'
 #' # isolate also works if the reactive expression accesses values from the
 #' # input object, like input$x
-#'
 #' @export
 isolate <- function(expr) {
   ctx <- Context$new(getDefaultReactiveDomain(), '[isolate]', type='isolate')
@@ -1375,7 +1367,6 @@ isolate <- function(expr) {
 #' @return The value of \code{expr}.
 #'
 #' @seealso \code{\link{isolate}}
-#'
 #' @export
 maskReactiveContext <- function(expr) {
   .getReactiveEnvironment()$runWith(NULL, function() {
@@ -1502,7 +1493,6 @@ maskReactiveContext <- function(expr) {
 #'   }
 #'   shinyApp(ui=ui, server=server)
 #' }
-#'
 #' @export
 observeEvent <- function(eventExpr, handlerExpr,
   event.env = parent.frame(), event.quoted = FALSE,

--- a/R/render-table.R
+++ b/R/render-table.R
@@ -46,7 +46,6 @@
 #' @param outputArgs A list of arguments to be passed through to the
 #'   implicit call to \code{\link{tableOutput}} when \code{renderTable} is
 #'   used in an interactive R Markdown document.
-#'
 #' @export
 renderTable <- function(expr, striped = FALSE, hover = FALSE,
                         bordered = FALSE, spacing = c("s", "xs", "m", "l"),

--- a/R/server.R
+++ b/R/server.R
@@ -49,7 +49,6 @@ registerClient <- function(client) {
 #'
 #' @examples
 #' addResourcePath('datasets', system.file('data', package='datasets'))
-#'
 #' @export
 addResourcePath <- function(prefix, directoryPath) {
   prefix <- prefix[1]
@@ -141,7 +140,6 @@ resourcePathHandler <- function(req) {
 #'   })
 #' }
 #' }
-#'
 #' @export
 shinyServer <- function(func) {
   .globals$server <- list(func)
@@ -743,7 +741,6 @@ runApp <- function(appDir=getwd(),
 #'
 #' @param returnValue The value that should be returned from
 #'   \code{\link{runApp}}.
-#'
 #' @export
 stopApp <- function(returnValue = invisible()) {
   # reterror will indicate whether retval is an error (i.e. it should be passed
@@ -862,7 +859,6 @@ runExample <- function(example=NA,
 #' # ...or as a single app object
 #' runGadget(shinyApp(ui, server))
 #' }
-#'
 #' @export
 runGadget <- function(app, server = NULL, port = getOption("shiny.port"),
   viewer = paneViewer(), stopOnCancel = TRUE) {

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -316,7 +316,6 @@ NULL
 #' @return If \code{id} is missing, returns a function that expects an id string
 #'   as its only argument and returns that id with the namespace prepended.
 #' @seealso \url{http://shiny.rstudio.com/articles/modules.html}
-#'
 #' @export
 NS <- function(namespace, id = NULL) {
   if (missing(id)) {

--- a/R/shinyui.R
+++ b/R/shinyui.R
@@ -64,7 +64,6 @@ renderPage <- function(ui, connection, showcase=0) {
 #'
 #' @param ui A user interace definition
 #' @return The user interface definition, without modifications or side effects.
-#'
 #' @export
 shinyUI <- function(ui) {
   .globals$ui <- list(ui)

--- a/R/shinywrappers.R
+++ b/R/shinywrappers.R
@@ -19,7 +19,6 @@ globalVariables('func')
 #'   dynamically generated UIs, such as those created by Shiny code snippets
 #'   embedded in R Markdown documents).
 #' @return The \code{renderFunc} function, with annotations.
-#'
 #' @export
 markRenderFunction <- function(uiFunc, renderFunc, outputArgs = list()) {
   # a mutable object that keeps track of whether `useRenderFunction` has been
@@ -248,7 +247,6 @@ renderImage <- function(expr, env=parent.frame(), quoted=FALSE,
 #'   function, instead of the printed output.
 #'
 #' @example res/text-example.R
-#'
 #' @export
 renderPrint <- function(expr, env = parent.frame(), quoted = FALSE,
                         width = getOption('width'), outputArgs=list()) {
@@ -289,7 +287,6 @@ renderPrint <- function(expr, env = parent.frame(), quoted = FALSE,
 #'   function, rather than the returned text value.
 #'
 #' @example res/text-example.R
-#'
 #' @export
 renderText <- function(expr, env=parent.frame(), quoted=FALSE,
                        outputArgs=list()) {
@@ -321,7 +318,6 @@ renderText <- function(expr, env=parent.frame(), quoted=FALSE,
 #'   interactive R Markdown document.
 #'
 #' @seealso conditionalPanel
-#'
 #' @export
 #' @examples
 #' ## Only run examples in interactive R sessions

--- a/R/utils.R
+++ b/R/utils.R
@@ -23,7 +23,6 @@ NULL
 #' rnormA(3)  # [1]  1.8285879 -0.7468041 -0.4639111
 #' rnormA(5)  # [1]  1.8285879 -0.7468041 -0.4639111 -1.6510126 -1.4686924
 #' rnormB(5)  # [1] -0.7946034  0.2568374 -0.6567597  1.2451387 -0.8375699
-#'
 #' @export
 repeatable <- function(rngfunc, seed = stats::runif(1, 0, .Machine$integer.max)) {
   force(seed)
@@ -400,7 +399,6 @@ makeFunction <- function(args = pairlist(), body, env = parent.frame()) {
 #'
 #' isolate(tripleA())
 #' # "text, text, text"
-#'
 #' @export
 exprToFunction <- function(expr, env=parent.frame(), quoted=FALSE) {
   if (!quoted) {
@@ -434,7 +432,6 @@ exprToFunction <- function(expr, env=parent.frame(), quoted=FALSE) {
 #'   the name of the calling function.
 #' @param wrappedWithLabel,..stacktraceon Advanced use only. For stack manipulation purposes; see
 #'   \code{\link{stacktrace}}.
-#'
 #' @export
 installExprFunction <- function(expr, name, eval.env = parent.frame(2),
                                 quoted = FALSE,
@@ -1169,7 +1166,6 @@ need <- function(expr, message = paste(label, "must be provided"), label) {
 #'   processing as usual but instead of clearing the output, leave it in
 #'   whatever state it happens to be in.
 #' @return The first value that was passed in.
-#'
 #' @export
 req <- function(..., cancelOutput = FALSE) {
   dotloop(function(item) {
@@ -1198,7 +1194,6 @@ req <- function(..., cancelOutput = FALSE) {
 #' If \code{cancelOutput} is called in any non-output context (like in an
 #' \code{\link{observe}} or \code{\link{observeEvent}}), the effect is the same
 #' as \code{\link{req}(FALSE)}.
-#'
 #' @export
 cancelOutput <- function() {
   stopWithCondition(c("shiny.output.cancel", "shiny.silent.error"), "")


### PR DESCRIPTION
To avoid the "extra line" found in the examples' section of Reference page of the Shiny website. See rstudio/shiny-dev-center#25 for more info.