### PR TITLE
executeElapsed gets stuck returning TRUE even when nothing was executed

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -87,6 +87,9 @@ shiny 0.13.2.9005
 * Fixed #1253: Memory could leak when an observer was destroyed without first
   being invalidated.
 
+* Fixed #1284: Reactive system was being flushed too often (usually this just
+  means a more-expensive no-op than necessary).
+
 shiny 0.13.2
 --------------------------------------------------------------------------------
 

--- a/R/timer.R
+++ b/R/timer.R
@@ -22,6 +22,11 @@ TimerCallbacks <- R6Class(
       .times <<- data.frame()
     },
     schedule = function(millis, func) {
+      # If args could fail to evaluate, let's make them do that before
+      # we change any state
+      force(millis)
+      force(func)
+
       id <- .nextId
       .nextId <<- .nextId + 1L
 
@@ -56,7 +61,7 @@ TimerCallbacks <- R6Class(
     },
     executeElapsed = function() {
       elapsed <- takeElapsed()
-      if (length(elapsed) == 0)
+      if (nrow(elapsed) == 0)
         return(FALSE)
 
       for (id in elapsed$id) {

--- a/tests/testthat/test-timer.R
+++ b/tests/testthat/test-timer.R
@@ -1,0 +1,25 @@
+context("timer")
+
+test_that("Scheduling works", {
+  ran <- FALSE
+  fun <- function() {
+    ran <<- TRUE
+  }
+
+  timerCallbacks$schedule(500, fun)
+
+  timerCallbacks$executeElapsed()
+  expect_false(ran)
+
+  Sys.sleep(0.1)
+  timerCallbacks$executeElapsed()
+  expect_false(ran)
+
+  Sys.sleep(0.5)
+  expect_true(timerCallbacks$executeElapsed())
+  expect_true(ran)
+
+  # Empty timerCallbacks should return FALSE
+  expect_false(timerCallbacks$executeElapsed())
+  expect_equal(0, nrow(timerCallbacks$takeElapsed()))
+})


### PR DESCRIPTION
Fixes #1278 

`elapsed` is a data frame that's initially 0 columns, 0 rows; as soon as the first task is scheduled, it becomes 3 columns, _n_ rows. Even after _n_ goes to zero (no tasks waiting), the `length(elapsed)` check returns 3, because it's counting columns, not rows.

Correcting this logic to check the row count fixes everything.

TODO: Add unit test