### PR TITLE
Fix #1144: RadioButtons and checkBoxGroup do not work in modules when they are updated

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -87,6 +87,9 @@ shiny 0.13.2.9005
 * Fixed #1253: Memory could leak when an observer was destroyed without first
   being invalidated.
 
+* Fixed #1144: updateRadioButton and updateCheckboxGroupInput break controls
+  when used in modules (thanks, @sipemu!).
+
 shiny 0.13.2
 --------------------------------------------------------------------------------
 

--- a/R/update-input.R
+++ b/R/update-input.R
@@ -415,11 +415,11 @@ updateInputOptions <- function(session, inputId, label = NULL, choices = NULL,
   if (!is.null(choices))
     choices <- choicesWithNames(choices)
   if (!is.null(selected))
-    selected <- validateSelected(selected, choices, inputId)
+    selected <- validateSelected(selected, choices, session$ns(inputId))
 
   options <- if (!is.null(choices)) {
     format(tagList(
-      generateOptions(inputId, choices, selected, inline, type = type)
+      generateOptions(session$ns(inputId), choices, selected, inline, type = type)
     ))
   }
 

--- a/tests/testthat/test-update-input.R
+++ b/tests/testthat/test-update-input.R
@@ -1,0 +1,37 @@
+context("Update input controls")
+
+test_that("Radio buttons and checkboxes work with modules", {
+  createModuleSession <- function(moduleId) {
+    session <- as.environment(list(
+      ns = NS(moduleId),
+      sendInputMessage = function(inputId, message) {
+        session$lastInputMessage = list(id = inputId, message = message)
+      }
+    ))
+    session
+  }
+
+  sessA <- createModuleSession("modA")
+
+  updateRadioButtons(sessA, "test1", label = "Label", choices = letters[1:5])
+  resultA <- sessA$lastInputMessage
+
+  expect_equal("test1", resultA$id)
+  expect_equal("Label", resultA$message$label)
+  expect_equal("a", resultA$message$value)
+  expect_true(grepl('"modA-test1"', resultA$message$options))
+  expect_false(grepl('"test1"', resultA$message$options))
+
+
+  sessB <- createModuleSession("modB")
+
+  updateCheckboxGroupInput(sessB, "test2", label = "Label", choices = LETTERS[1:5])
+  resultB <- sessB$lastInputMessage
+
+  expect_equal("test2", resultB$id)
+  expect_equal("Label", resultB$message$label)
+  expect_null(resultB$message$value)
+  expect_true(grepl('"modB-test2"', resultB$message$options))
+  expect_false(grepl('"test2"', resultB$message$options))
+
+})


### PR DESCRIPTION
The unqualified input ID was being used to generate name attributes on radio and checkboxes. Wrapping these uses of `inputId` with `session$ns()` fixed it.

P1, and then some! Thanks @sipemu!