### PR TITLE
update use to `stopWithCondition` to `reactiveSTop`

### DIFF
--- a/R/reactives.R
+++ b/R/reactives.R
@@ -82,7 +82,7 @@ ReactiveValues <- R6Class(
       }
 
       if (isInvalid(key))
-        stopWithCondition(c("validation", "shiny.silent.error"), "")
+        reactiveStop(class = "validation")
 
       if (!exists(key, envir=.values, inherits=FALSE))
         NULL


### PR DESCRIPTION
Specifically, do so in the bookmarkable code that was introduced when the idea of `reactiveStop` was still in flux. As per Winston's suggestion [here](https://github.com/rstudio/shiny/pull/1209#discussion_r73452037) (my follow-up comment [here](https://github.com/rstudio/shiny/pull/1209#discussion_r73568224)). I'm pretty sure this is a completely safe merge (I used this line in other parts of the code to sub exactly the same thing). But better safe than sorry.

cc @jcheng5, @wch 