### PR TITLE
fixes #1093

### DIFF
--- a/R/update-input.R
+++ b/R/update-input.R
@@ -511,8 +511,8 @@ updateCheckboxGroupInput <- function(session, inputId, label = NULL,
 #' @export
 updateRadioButtons <- function(session, inputId, label = NULL, choices = NULL,
                                selected = NULL, inline = FALSE) {
-  choices <- as.character(choices)
-  selected <- as.character(selected)
+  if (!is.null(choices)) choices <- as.character(choices)
+  if (!is.null(selected)) selected <- as.character(selected)
 
   # you must select at least one radio button
   if (is.null(selected) && !is.null(choices)) selected <- choices[[1]]

--- a/R/update-input.R
+++ b/R/update-input.R
@@ -511,6 +511,9 @@ updateCheckboxGroupInput <- function(session, inputId, label = NULL,
 #' @export
 updateRadioButtons <- function(session, inputId, label = NULL, choices = NULL,
                                selected = NULL, inline = FALSE) {
+  choices <- as.character(choices)
+  selected <- as.character(selected)
+
   # you must select at least one radio button
   if (is.null(selected) && !is.null(choices)) selected <- choices[[1]]
   updateInputOptions(session, inputId, label, choices, selected, inline, type = 'radio')


### PR DESCRIPTION
A very simple casting of `choices` and `selected` to "character" inside the `updateRadioButtons` function.

I spent some time trying to figure out exactly why this bug was occurring (i.e. why it only affects the second set of radio buttons) and didn't get very far.

I also wonder how many other `updateXXX` functions could benefit from a similar type casting... Is there a reason we didn't cast things before?