### PR TITLE
updateDateInput: better handling of malformed dates. Closes #1179

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -90,6 +90,8 @@ shiny 0.13.2.9005
 * Fixed #1144: updateRadioButton and updateCheckboxGroupInput break controls
   when used in modules (thanks, @sipemu!).
 
+* Fixed #1179: updateDateInput sometimes didn't work with malformed dates.
+
 shiny 0.13.2
 --------------------------------------------------------------------------------
 

--- a/R/update-input.R
+++ b/R/update-input.R
@@ -166,11 +166,15 @@ updateActionButton <- function(session, inputId, label = NULL, icon = NULL) {
 updateDateInput <- function(session, inputId, label = NULL, value = NULL,
                             min = NULL, max = NULL) {
 
-  # If value is a date object, convert it to a string with yyyy-mm-dd format
-  # Same for min and max
-  if (inherits(value, "Date"))  value <- format(value, "%Y-%m-%d")
-  if (inherits(min, "Date"))    min   <- format(min,   "%Y-%m-%d")
-  if (inherits(max, "Date"))    max   <- format(max,   "%Y-%m-%d")
+  # Make sure values are Date objects. This is so we can ensure that they will
+  # be formatted correctly.
+  value <- as.Date(value)
+  min   <- as.Date(min)
+  max   <- as.Date(max)
+
+  value <- format(value, "%Y-%m-%d")
+  min   <- format(min,   "%Y-%m-%d")
+  max   <- format(max,   "%Y-%m-%d")
 
   message <- dropNulls(list(label=label, value=value, min=min, max=max))
   session$sendInputMessage(inputId, message)


### PR DESCRIPTION
Test app. Move the slider and check that the min and max are one day before and after the selected value.


```R
ui <- fluidPage(
  sliderInput("controller", "Controller", 1, 30, 5),
  dateInput("inDate", "Input date")
)
server <- function(input, output, session) {
  observe({
    x <- input$controller

    updateDateInput(session, "inDate",
      label = paste("Date label", x),
      value = paste("2013-04-", x, sep=""),
      min = paste("2013-04-", x-1, sep=""),
      max = paste("2013-04-", x+1, sep="")
    )
  })
}
shinyApp(ui, server)
```