### PR TITLE
Don't crash on malformed date input values. Closes #803

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -94,7 +94,10 @@ shiny 0.13.2.9005
   means a more-expensive no-op than necessary).
 
 * Fixed #1179: updateDateInput sometimes didn't work with malformed dates.
+
 * Added inputTextArea. (Thanks to @nuno-agostinho)
+
+* Fixed #803: Malformed date input values crashed app.
 
 shiny 0.13.2
 --------------------------------------------------------------------------------

--- a/R/server-input-handlers.R
+++ b/R/server-input-handlers.R
@@ -98,7 +98,20 @@ registerInputHandler("shiny.password", function(val, shinysession, name) {
 registerInputHandler("shiny.date", function(val, ...){
   # First replace NULLs with NA, then convert to Date vector
   datelist <- ifelse(lapply(val, is.null), NA, val)
-  as.Date(unlist(datelist))
+
+  res <- NULL
+  tryCatch({
+      res <- as.Date(unlist(datelist))
+    },
+    error = function(e) {
+      # It's possible for client to send a string like "99999-01-01", which
+      # as.Date can't handle.
+      warning(e$message)
+      res <<- as.Date(rep(NA, length(datelist)))
+    }
+  )
+
+  res
 })
 
 registerInputHandler("shiny.datetime", function(val, ...){


### PR DESCRIPTION
Test app. Entering very large numbers for the year (like 99999) previously would crash the app.

```R
app <- shinyApp(
  ui = bootstrapPage(
    dateRangeInput('dateRange', 'Date Range Input'),
    dateInput('date', 'Date Input')
    
  ),
  server = function(input, output, session) {
    observe({
      print(input$dateRange)
      print(input$date)
    })
  }
)
runApp(app)
```

