### PR TITLE
Bookmark/restore actionButtons

### DIFF
--- a/R/bookmark-state.R
+++ b/R/bookmark-state.R
@@ -65,7 +65,8 @@ saveShinySaveState <- function(state) {
       isolate(state$onSave(state))
 
     # Serialize values, possibly saving some extra data to stateDir
-    inputValues <- serializeReactiveValues(state$input, state$exclude, state$dir)
+    exclude <- c(state$exclude, "._bookmark_")
+    inputValues <- serializeReactiveValues(state$input, exclude, state$dir)
     saveRDS(inputValues, file.path(stateDir, "input.rds"))
 
     # If values were added, save them also.
@@ -83,7 +84,8 @@ saveShinySaveState <- function(state) {
 
 # Encode the state to a URL. This does not save to disk.
 encodeShinySaveState <- function(state) {
-  inputVals <- serializeReactiveValues(state$input, state$exclude, stateDir = NULL)
+  exclude <- c(state$exclude, "._bookmark_")
+  inputVals <- serializeReactiveValues(state$input, exclude, stateDir = NULL)
 
   # Allow user-supplied onSave function to do things like add state$values.
   if (!is.null(state$onSave))
@@ -586,8 +588,8 @@ showBookmarkUrlModal <- function(url) {
 #' \code{function(request) \{ fluidPage(....) \}}.
 #'
 #' By default, all input values will be bookmarked, except for the values of
-#' actionButtons and passwordInputs. fileInputs will be saved if the state is
-#' saved on a server, but not if the state is encoded in a URL.
+#' passwordInputs. fileInputs will be saved if the state is saved on a server,
+#' but not if the state is encoded in a URL.
 #'
 #' When bookmarking state, arbitrary values can be stored, by passing a function
 #' as the \code{onBookmark} argument. That function will be passed a

--- a/R/input-action.R
+++ b/R/input-action.R
@@ -39,10 +39,14 @@
 #' @seealso \code{\link{observeEvent}} and \code{\link{eventReactive}}
 #' @export
 actionButton <- function(inputId, label, icon = NULL, width = NULL, ...) {
+
+  value <- restoreInput(id = inputId, default = NULL)
+
   tags$button(id=inputId,
     style = if (!is.null(width)) paste0("width: ", validateCssUnit(width), ";"),
     type="button",
     class="btn btn-default action-button",
+    `data-val` = value,
     list(validateIcon(icon), label),
     ...
   )
@@ -51,9 +55,12 @@ actionButton <- function(inputId, label, icon = NULL, width = NULL, ...) {
 #' @rdname actionButton
 #' @export
 actionLink <- function(inputId, label, icon = NULL, ...) {
+  value <- restoreInput(id = inputId, default = NULL)
+
   tags$a(id=inputId,
     href="#",
     class="action-button",
+    `data-val` = value,
     list(validateIcon(icon), label),
     ...
   )

--- a/R/server-input-handlers.R
+++ b/R/server-input-handlers.R
@@ -124,9 +124,6 @@ registerInputHandler("shiny.datetime", function(val, ...){
 })
 
 registerInputHandler("shiny.action", function(val, shinysession, name) {
-  # Mark as not serializable
-  .subset2(shinysession$input, "impl")$setMeta(name, "shiny.serializer", serializerUnserializable)
-
   # mark up the action button value with a special class so we can recognize it later
   class(val) <- c(class(val), "shinyActionButtonValue")
   val

--- a/man/enableBookmarking.Rd
+++ b/man/enableBookmarking.Rd
@@ -34,8 +34,8 @@ function is as simple as wrapping it in a function, as in
 \code{function(request) \{ fluidPage(....) \}}.
 
 By default, all input values will be bookmarked, except for the values of
-actionButtons and passwordInputs. fileInputs will be saved if the state is
-saved on a server, but not if the state is encoded in a URL.
+passwordInputs. fileInputs will be saved if the state is saved on a server,
+but not if the state is encoded in a URL.
 
 When bookmarking state, arbitrary values can be stored, by passing a function
 as the \code{onBookmark} argument. That function will be passed a


### PR DESCRIPTION
This implements bookmarking and restoring of actionButtons. In this example, clicking the "plot" button makes a plot appear. Without this fix, when the app is restored, the plot doesn't show and needs the button to be clicked again. With the fix, the state of the plot (shown/not shown) in the restored session will be the same as when it was bookmarked.

```R
ui <- function(request) {
  fluidPage(
    plotOutput("plot"),
    actionButton("plot", "Plot"),
    bookmarkButton("Bookmark")
  )
}
server <- function(input, output, session) {
  output$plot <- renderPlot({
    req(input$plot)
    hist(rnorm(20))
  })
}
enableBookmarking("url")
shinyApp(ui, server)
```