### PR TITLE
Make it possible to have multiple bookmark buttons

### DIFF
--- a/R/bookmark-state.R
+++ b/R/bookmark-state.R
@@ -470,18 +470,60 @@ updateQueryString <- function(queryString, session = getDefaultReactiveDomain())
 #' that consists of a link icon and the text "Bookmark...". It is meant to be
 #' used for bookmarking state.
 #'
+#' @inheritParams actionButton
 #' @param title A tooltip that is shown when the mouse cursor hovers over the
 #'   button.
+#' @param id An ID for the bookmark button. The only time it is necessary to set
+#'   the ID unless you have more than one bookmark button in your application.
+#'   If you specify an input ID, it should be excluded from bookmarking with
+#'   \code{\link{setBookmarkExclude}}, and you must create an observer that
+#'   does the bookmarking when the button is pressed. See the examples below.
 #'
-#' @seealso enableBookmarking
-#' @inheritParams actionButton
+#' @seealso \code{\link{enableBookmarking}} for more examples.
+#'
+#' @examples
+#' ## Only run these examples in interactive sessions
+#' if (interactive()) {
+#'
+#' # This example shows how to use multiple bookmark buttons. If you only need
+#' # a single bookmark button, see examples in ?enableBookmarking.
+#' ui <- function(request) {
+#'   fluidPage(
+#'     tabsetPanel(id = "tabs",
+#'       tabPanel("One",
+#'         checkboxInput("chk1", "Checkbox 1"),
+#'         bookmarkButton(id = "bookmark1")
+#'       ),
+#'       tabPanel("Two",
+#'         checkboxInput("chk2", "Checkbox 2"),
+#'         bookmarkButton(id = "bookmark2")
+#'       )
+#'     )
+#'   )
+#' }
+#' server <- function(input, output, session) {
+#'   # Need to exclude the buttons from themselves being bookmarked
+#'   setBookmarkExclude(c("bookmark1", "bookmark2"))
+#'
+#'   # Trigger bookmarking with either button
+#'   observeEvent(input$bookmark1, {
+#'     session$doBookmark()
+#'   })
+#'   observeEvent(input$bookmark2, {
+#'     session$doBookmark()
+#'   })
+#' }
+#' enableBookmarking(store = "url")
+#' shinyApp(ui, server)
+#' }
 #' @export
 bookmarkButton <- function(label = "Bookmark...",
   icon = shiny::icon("link", lib = "glyphicon"),
   title = "Bookmark this application's state and get a URL for sharing.",
-  ...)
+  ...,
+  id = "._bookmark_")
 {
-  actionButton("._bookmark_", label, icon, title = title, ...)
+  actionButton(id, label, icon, title = title, ...)
 }
 
 

--- a/man/bookmarkButton.Rd
+++ b/man/bookmarkButton.Rd
@@ -6,7 +6,8 @@
 \usage{
 bookmarkButton(label = "Bookmark...", icon = shiny::icon("link", lib =
   "glyphicon"),
-  title = "Bookmark this application's state and get a URL for sharing.", ...)
+  title = "Bookmark this application's state and get a URL for sharing.", ...,
+  id = "._bookmark_")
 }
 \arguments{
 \item{label}{The contents of the button or link--usually a text label, but
@@ -18,13 +19,55 @@ you could also use any other HTML, like an image.}
 button.}
 
 \item{...}{Named attributes to be applied to the button or link.}
+
+\item{id}{An ID for the bookmark button. The only time it is necessary to set
+the ID unless you have more than one bookmark button in your application.
+If you specify an input ID, it should be excluded from bookmarking with
+\code{\link{setBookmarkExclude}}, and you must create an observer that
+does the bookmarking when the button is pressed. See the examples below.}
 }
 \description{
 A \code{bookmarkButton} is a \code{\link{actionButton}} with a default label
 that consists of a link icon and the text "Bookmark...". It is meant to be
 used for bookmarking state.
 }
+\examples{
+## Only run these examples in interactive sessions
+if (interactive()) {
+
+# This example shows how to use multiple bookmark buttons. If you only need
+# a single bookmark button, see examples in ?enableBookmarking.
+ui <- function(request) {
+  fluidPage(
+    tabsetPanel(id = "tabs",
+      tabPanel("One",
+        checkboxInput("chk1", "Checkbox 1"),
+        bookmarkButton(id = "bookmark1")
+      ),
+      tabPanel("Two",
+        checkboxInput("chk2", "Checkbox 2"),
+        bookmarkButton(id = "bookmark2")
+      )
+    )
+  )
+}
+server <- function(input, output, session) {
+  # Need to exclude the buttons from themselves being bookmarked
+  setBookmarkExclude(c("bookmark1", "bookmark2"))
+
+  # Trigger bookmarking with either button
+  observeEvent(input$bookmark1, {
+    session$doBookmark()
+  })
+  observeEvent(input$bookmark2, {
+    session$doBookmark()
+  })
+}
+enableBookmarking(store = "url")
+shinyApp(ui, server)
+}
+}
 \seealso{
-enableBookmarking
+\code{\link{enableBookmarking}} for more examples.
 }
 

--- a/man/session.Rd
+++ b/man/session.Rd
@@ -146,6 +146,9 @@
   Registers a function that will be called when a session is restored, after
   all other reactives, observers, and render functions are run.
 }
+\item{doBookmark()}{
+  Do bookmarking and invoke the onBookmark and onBookmarked callback functions.
+}
 }
 \description{
 Shiny server functions can optionally include \code{session} as a parameter


### PR DESCRIPTION
Closes #1305. This makes it possible to do things like the following:

```R
ui <- function(request) {
  fluidPage(
    tabsetPanel(id = "tabs",
      tabPanel("One",
        checkboxInput("chk1", "Checkbox 1"),
        bookmarkButton(id = "bookmark1")
      ),
      tabPanel("Two",
        checkboxInput("chk2", "Checkbox 2"),
        bookmarkButton(id = "bookmark2")
      )
    )
  )
}
server <- function(input, output, session) {
  # Need to exclude the buttons from themselves being bookmarked
  setBookmarkExclude(c("bookmark1", "bookmark2"))

  # Trigger bookmarking with either button
  observeEvent(input$bookmark1, {
    session$doBookmark()
  })
  observeEvent(input$bookmark2, {
    session$doBookmark()
  })
}
enableBookmarking(store = "url")
shinyApp(ui, server)
```