### PR TITLE
Fix updateDateRangeInput when only one of start/end updated

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,9 @@ shiny 0.13.2.9005
 * `updateDateInput()` and `updateDateRangeInput()` can now clear the date
   input fields. (#1299, #896)
 
+* Fix `updateDateRangeInput()` when only one of `start` and `end` are
+  updated. (#1315)
+
 * Added support for the `pool` package (use Shiny's timer/scheduler)
 
 * `Display: Showcase` now displays the .js, .html and .css files in the `www`

--- a/R/update-input.R
+++ b/R/update-input.R
@@ -274,7 +274,7 @@ updateDateRangeInput <- function(session, inputId, label = NULL,
 
   message <- dropNulls(list(
     label = label,
-    value = c(start, end),
+    value = list(start, end),
     min = min,
     max = max
   ))


### PR DESCRIPTION
App to test:

```r
shinyApp(
  ui = fluidPage(
    div(
      dateRangeInput("daterange", "Date range:",
                     start = "2001-01-01",
                     end   = "2010-12-31")
    ),
    actionButton("btn1", "leave start & end alone"),
    actionButton("btn2", "set date range start"),
    actionButton("btn3", "set date range end"),
    actionButton("btn4", "set date range start and end")
  ),
  server = function(input, output, session) {
    observeEvent(input$btn1, updateDateRangeInput(session, "daterange"))
    observeEvent(input$btn2, updateDateRangeInput(session, "daterange", start = "2005-01-01"))    
    observeEvent(input$btn3, updateDateRangeInput(session, "daterange", end = "2006-01-01"))
    observeEvent(input$btn4, updateDateRangeInput(session, "daterange", start = "2007-01-01", end = "2008-01-01"))
  }
)
```