### PR TITLE
Make sure displaylist is on for recording/replaying plots

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -97,6 +97,9 @@ shiny 0.13.2.9005
 
 ## Bug fixes
 
+* Fixed #1331: `renderPlot()` now correctly records and replays plots when
+  `execOnResize=FALSE`. (#1337)
+
 * `updateDateInput()` and `updateDateRangeInput()` can now clear the date
   input fields. (#1299, #896, #1315)
 

--- a/R/render-plot.R
+++ b/R/render-plot.R
@@ -185,6 +185,9 @@ renderPlot <- function(expr, width='auto', height='auto', res=72, ...,
       success <-FALSE
       tryCatch(
         {
+          # This is necessary to enable displaylist recording
+          dev.control(displaylist = "enable")
+
           # Actually perform the plotting
           result <- withVisible(func())
           success <- TRUE


### PR DESCRIPTION
This fixes #1331,  where recordPlot/replayPlot didn't work properly. The bug was made visible by c4cc5b6.

Test app:

```R
shinyApp(
  ui = fluidPage(
    numericInput("n", "n", 1),
    plotOutput("plot")
  ),
  server = function(input, output) {
    output$plot <- renderPlot({
      print("render")
      plot(head(cars, input$n))
    })
  }
)
```
