### PR TITLE
Let modules get at the root scope (undocumented for now)

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -610,6 +610,9 @@ ShinySession <- R6Class(
         )
       )
     },
+    rootScope = function() {
+      self
+    },
     makeScope = function(namespace) {
       ns <- NS(namespace)
 


### PR DESCRIPTION
This is needed for plotly. I really hope people are not tempted to abuse this to do inter-module communication.