### PR TITLE
Check whether hosting environment supports bookmarking

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -597,7 +597,7 @@ runApp <- function(appDir=getwd(),
 
   workerId(workerId)
 
-  if (nzchar(Sys.getenv('SHINY_PORT'))) {
+  if (inShinyServer()) {
     # If SHINY_PORT is set, we're running under Shiny Server. Check the version
     # to make sure it is compatible. Older versions of Shiny Server don't set
     # SHINY_SERVER_VERSION, those will return "" which is considered less than
@@ -982,4 +982,10 @@ browserViewer <- function(browser = getOption("browser")) {
   function(url) {
     utils::browseURL(url, browser = browser)
   }
+}
+
+# Returns TRUE if we're running in Shiny Server or other hosting environment,
+# otherwise returns FALSE.
+inShinyServer <- function() {
+  nzchar(Sys.getenv('SHINY_PORT'))
 }

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -470,6 +470,18 @@ ShinySession <- R6Class(
       if (store == "disable")
         return()
 
+      # Warn if trying to enable save-to-server bookmarking on a version of SS,
+      # SSP, or Connect that doesn't support it.
+      if (store == "server" && inShinyServer() &&
+          is.null(getShinyOption("save.interface")))
+      {
+        showNotification(
+          "This app tried to enable saved-to-server bookmarking, but it is not supported by the hosting environment.",
+          duration = NULL, type = "warning", session = self
+        )
+        return()
+      }
+
       withReactiveDomain(self, {
         # This observer fires when the bookmark button is clicked.
         observeEvent(self$input[["._bookmark_"]], {


### PR DESCRIPTION
This adds a check for whether the hosting environment supports saved-to-server bookmarking. If not, then, when the user tries to bookmark state, it shows an error in a notification.

I've tested this with:
* the latest version of Shiny Server (1.4.4.804)
* an older version of Shiny Server (1.4.4.801)
* [shinyapps.io](https://winston.shinyapps.io/bookmark-server/)
* [connect](https://beta.rstudioconnect.com/content/1701/)
* Shiny Server Pro

Bookmarking works with the new version of Shiny Server. With all the others, the error message comes up as expected.