### PR TITLE
Fix bookmark fileinput 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,13 @@
 shiny 0.14.0.9000
 =================
 
+## Minor new features and improvements
+
+* Restored file inputs are now copied on restore, so that the restored application can't modify the bookmarked file. ([#1370](https://github.com/rstudio/shiny/issues/1370))
+
+## Bug fixes
+
+* Fixed [#1368](https://github.com/rstudio/shiny/issues/1368): If an app with a file input was bookmarked and restored, and then the restored app was bookmarked and restored (without uploading a new file), then it would fail to restore the file the second time. ([#1370](https://github.com/rstudio/shiny/issues/1370))
 
 shiny 0.14
 ==========

--- a/R/fileupload.R
+++ b/R/fileupload.R
@@ -94,7 +94,7 @@ FileUploadContext <- R6Class(
     },
     createUploadOperation = function(fileInfos) {
       while (TRUE) {
-        id <- paste(as.raw(p_runif(12, min=0, max=0xFF)), collapse='')
+        id <- createUniqueId(12)
         private$ids <- c(private$ids, id)
         dir <- file.path(private$basedir, id)
         if (!dir.create(dir))

--- a/R/server-input-handlers.R
+++ b/R/server-input-handlers.R
@@ -148,5 +148,10 @@ registerInputHandler("shiny.file", function(val, shinysession, name) {
   # Prepend the persistent dir
   val$datapath <- file.path(getCurrentRestoreContext()$dir, val$datapath)
 
+  # Need to mark this input value with the correct serializer. When a file is
+  # uploaded the usual way (instead of being restored), this occurs in
+  # session$`@uploadEnd`.
+  .subset2(shinysession$input, "impl")$setMeta(name, "shiny.serializer", serializerFileInput)
+
   val
 })

--- a/R/server-input-handlers.R
+++ b/R/server-input-handlers.R
@@ -139,10 +139,9 @@ registerInputHandler("shiny.file", function(val, shinysession, name) {
   # The data will be a named list of lists; convert to a data frame.
   val <- as.data.frame(lapply(val, unlist), stringsAsFactors = FALSE)
 
-  # Make sure that the paths don't go up the directory tree, for security
-  # reasons.
-  if (any(grepl("..", val$datapath, fixed = TRUE))) {
-    stop("Invalid '..' found in file input path.")
+  # `val$datapath` should be a filename without a path, for security reasons.
+  if (basename(val$datapath) != val$datapath) {
+    stop("Invalid '/' found in file input path.")
   }
 
   # Prepend the persistent dir

--- a/R/server-input-handlers.R
+++ b/R/server-input-handlers.R
@@ -145,7 +145,14 @@ registerInputHandler("shiny.file", function(val, shinysession, name) {
   }
 
   # Prepend the persistent dir
-  val$datapath <- file.path(getCurrentRestoreContext()$dir, val$datapath)
+  oldfile <- file.path(getCurrentRestoreContext()$dir, val$datapath)
+
+  # Copy the original file to a new temp dir, so that a restored session can't
+  # modify the original.
+  newdir <- file.path(tempdir(), createUniqueId(12))
+  dir.create(newdir)
+  val$datapath <- file.path(newdir, val$datapath)
+  file.copy(oldfile, val$datapath)
 
   # Need to mark this input value with the correct serializer. When a file is
   # uploaded the usual way (instead of being restored), this occurs in


### PR DESCRIPTION
Fixes #1368. The problem was that a restored fileInput wasn't marked with the correct serializer because it uses a different code path from a file that was uploaded the normal way.

This PR also:
* Copies the restored file to a temp dir. Previosuly, it let the restored session access the bookmarked file directly, which could be a problem if the user's code modifies the file.
* Has a better check that the restored file doesn't contain a path, so that a malicious user can't access any other parts of the filesystem.
* Uses `createUniqueId` in the `FileUploadContext`, for consistency.