### PR TITLE
allow for Radio Buttons to have choice names using HTML

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@ shiny 0.14.1.9001
 
 ### Minor new features and improvements
 
+* HTML markup can now be used in the choices' names for radio buttons. ([#1439](https://github.com/rstudio/shiny/pull/1439))
+
 * Added a `fade` argument to `modalDialog()` -- setting it to `FALSE` will remove the usual fade-in animation for that modal window. ([#1414](https://github.com/rstudio/shiny/pull/1414))
 
 * Exported function to apply input handlers to input values. This can be used for testing Shiny applications. ([#1421](https://github.com/rstudio/shiny/pull/1421))

--- a/R/input-utils.R
+++ b/R/input-utils.R
@@ -51,10 +51,10 @@ generateOptions <- function(inputId, choices, selected, inline, type = 'checkbox
       # If inline, there's no wrapper div, and the label needs a class like
       # checkbox-inline.
       if (inline) {
-        tags$label(class = paste0(type, "-inline"), inputTag, tags$span(name))
+        tags$label(class = paste0(type, "-inline"), inputTag, tags$span(HTML(name)))
       } else {
         tags$div(class = type,
-          tags$label(inputTag, tags$span(name))
+          tags$label(inputTag, tags$span(HTML(name)))
         )
       }
     },

--- a/tests/testthat/test-bootstrap.r
+++ b/tests/testthat/test-bootstrap.r
@@ -33,15 +33,15 @@ test_that("Repeated names for selectInput and radioButtons choices", {
   x <- radioButtons('id','label', choices = c(a='x1', a='x2', b='x3'))
   choices <- x$children
 
-  expect_equal(choices[[2]]$children[[1]][[1]]$children[[1]]$children[[2]]$children[[1]], 'a')
+  expect_equal(choices[[2]]$children[[1]][[1]]$children[[1]]$children[[2]]$children[[1]], HTML('a'))
   expect_equal(choices[[2]]$children[[1]][[1]]$children[[1]]$children[[1]]$attribs$value, 'x1')
   expect_equal(choices[[2]]$children[[1]][[1]]$children[[1]]$children[[1]]$attribs$checked, 'checked')
 
-  expect_equal(choices[[2]]$children[[1]][[2]]$children[[1]]$children[[2]]$children[[1]], 'a')
+  expect_equal(choices[[2]]$children[[1]][[2]]$children[[1]]$children[[2]]$children[[1]], HTML('a'))
   expect_equal(choices[[2]]$children[[1]][[2]]$children[[1]]$children[[1]]$attribs$value, 'x2')
   expect_equal(choices[[2]]$children[[1]][[2]]$children[[1]]$children[[1]]$attribs$checked, NULL)
 
-  expect_equal(choices[[2]]$children[[1]][[3]]$children[[1]]$children[[2]]$children[[1]], 'b')
+  expect_equal(choices[[2]]$children[[1]][[3]]$children[[1]]$children[[2]]$children[[1]], HTML('b'))
   expect_equal(choices[[2]]$children[[1]][[3]]$children[[1]]$children[[1]]$attribs$value, 'x3')
   expect_equal(choices[[2]]$children[[1]][[3]]$children[[1]]$children[[1]]$attribs$checked, NULL)
 })


### PR DESCRIPTION
This is a native (and pretty simple) solution to #1437. I feel bad that this was such an easy fix and it has been suggested/requested over an year ago :( ([here](http://stackoverflow.com/questions/32169748/how-can-i-have-html-elements-as-labels-for-radio-buttons)). Still, better late than never...

Sample code:
```r
library(shiny)
ui <- radioButtons("dist", "d",
                   c("Normal &mu;<sub>1</sub>" = "norm1",
                     "Normal &amp;mu;&lt;sub&gt;1&lt;&#47;sub&gt;" = "norm2"))
server <- function(input, output, session) {}
shinyApp(ui = ui, server = server)
```

Before this PR:
![screen shot 2016-10-25 at 2 04 03 pm](https://cloud.githubusercontent.com/assets/6527540/19687080/fae7c74e-9abb-11e6-9d28-ee4ff2e922fe.png)

With with PR:
![screen shot 2016-10-25 at 2 04 18 pm](https://cloud.githubusercontent.com/assets/6527540/19687087/053b2632-9abc-11e6-99bc-d11294664e67.png)

This example also illustrates the only downside with this approach (at least the only one I could find): it may break previous apps that were purposefully using unescaped HTML (i.e. you can see that if you actually want the option name to be `Normal &mu;<sub>1</sub>"` previously you just typed that verbatim, but now you have to type `Normal &amp;mu;&lt;sub&gt;1&lt;&#47;sub&gt;`).

I feel like this would be a non-existent to negligible problem, but if you think otherwise, we could make this 100% back-compatible by having an additional arg to `radioButtons` that would be something like `choicesAsHTML = FALSE`.
