### PR TITLE
Add list2env wrapper, for R <3.2.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,8 @@ shiny 0.14.1.9002
 
 * `sliderInputBinding.setValue()` now sends a slider's value immediately, instead of waiting for the usual 250ms debounce delay. ([#1429](https://github.com/rstudio/shiny/pull/1429))
 
+* Fixed a bug where, in versions of R before 3.2, Shiny applications could crash due to a bug in R's implementation of `list2env()`. ([#1446](https://github.com/rstudio/shiny/pull/1446))
+
 shiny 0.14.1
 ============
 

--- a/R/bookmark-state.R
+++ b/R/bookmark-state.R
@@ -362,7 +362,7 @@ RestoreContext <- R6Class("RestoreContext",
       self$input <- RestoreInputSet$new(inputs)
 
       values <- valuesFromJSON(values)
-      self$values <- list2env(values, self$values)
+      self$values <- list2env2(values, self$values)
     }
   )
 )
@@ -385,7 +385,7 @@ RestoreInputSet <- R6Class("RestoreInputSet",
 
   public = list(
     initialize = function(values) {
-      private$values <- list2env(values, parent = emptyenv())
+      private$values <- list2env2(values, parent = emptyenv())
     },
 
     exists = function(name) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -196,6 +196,16 @@ mergeVectors <- function(a, b) {
   x[!drop_idx]
 }
 
+# Wrapper around list2env with a NULL check. In R <3.2.0, if an empty unnamed
+# list is passed to list2env(), it errors. But an empty named list is OK. For
+# R >=3.2.0, this wrapper is not necessary.
+list2env2 <- function(x, ...) {
+  # Ensure that zero-length lists have a name attribute
+   if (length(x) == 0)
+    attr(x, "names") <- character(0)
+
+  list2env(x, ...)
+}
 
 # Combine dir and (file)name into a file path. If a file already exists with a
 # name differing only by case, then use it instead.


### PR DESCRIPTION
This fixes a problem where Shiny applications would crash in R < 3.2.0. See rstudio/shiny-server-pro#560.