### PR TITLE
Fix #1326: add download attribute for downloadButton

### DIFF
--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -1448,6 +1448,7 @@ downloadButton <- function(outputId,
                  class=paste('btn btn-default shiny-download-link', class),
                  href='',
                  target='_blank',
+                 download=NA,
                  icon("download"),
                  label)
 }
@@ -1459,6 +1460,7 @@ downloadLink <- function(outputId, label="Download", class=NULL) {
          class=paste(c('shiny-download-link', class), collapse=" "),
          href='',
          target='_blank',
+         download=NA,
          label)
 }
 


### PR DESCRIPTION
This works perfectly well for the browsers that support it. Unfortunately that is not the case for Safari (although, maybe soon this will change) or any IE... (http://caniuse.com/#feat=download) For these, adding the download attribute doesn't change anything. So while it's not ideal, we're at least not breaking anything...

Good to merge?