### PR TITLE
Closes #1357: verbatimTextOutput should optionally be hidden if no content

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@ shiny 0.14.2.9000
 
 ## Full changelog
 
+### Breaking changes
+
+* Added a new `placeholder` argument to `verbatimTextOutput()`. The default is `FALSE`, which means that, if there is no content for this output, no representation of this slot will be made in the UI. Previsouly, even if there was no content, you'd see an empty rectangle in the UI that served as a placeholder. You can set `placeholder = TRUE` to revert back to that look. ([#1480](https://github.com/rstudio/shiny/pull/1480))
+
 ### Minor new features and improvements
 
 * Added support for injecting JavaScript code when the `shiny.testmode` option is set to `TRUE`. This makes it possible to record test events interactively. ([#1464]https://github.com/rstudio/shiny/pull/1464))

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -935,21 +935,34 @@ textOutput <- function(outputId, container = if (inline) span else div, inline =
 #' Render a reactive output variable as verbatim text within an
 #' application page. The text will be included within an HTML \code{pre} tag.
 #' @param outputId output variable to read the value from
+#' @param placeholder if the output is empty or \code{NULL}, should an empty
+#'   rectangle be displayed to serve as a placeholder? (does not affect
+#'   behavior when the the output in nonempty)
 #' @return A verbatim text output element that can be included in a panel
 #' @details Text is HTML-escaped prior to rendering. This element is often used
-#' with the \link{renderPrint} function to preserve fixed-width formatting
-#' of printed objects.
+#'   with the \link{renderPrint} function to preserve fixed-width formatting
+#'   of printed objects.
 #' @examples
-#' mainPanel(
-#'   h4("Summary"),
-#'   verbatimTextOutput("summary"),
-#'
-#'   h4("Observations"),
-#'   tableOutput("view")
-#' )
+#' ## Only run this example in interactive R sessions
+#' if (interactive()) {
+#'   shinyApp(
+#'     ui = basicPage(
+#'       textInput("txt", "Enter the text to display below:"),
+#'       verbatimTextOutput("default"),
+#'       verbatimTextOutput("placeholder", placeholder = TRUE)
+#'     ),
+#'     server = function(input, output) {
+#'       output$default <- renderText({ input$txt })
+#'       output$placeholder <- renderText({ input$txt })
+#'     }
+#'   )
+#' }
 #' @export
-verbatimTextOutput <- function(outputId) {
-  textOutput(outputId, container = pre)
+verbatimTextOutput <- function(outputId, placeholder = FALSE) {
+  pre(id = outputId,
+      class = paste(c("shiny-text-output", if (!placeholder) "noplaceholder"),
+                    collapse = " ")
+      )
 }
 
 

--- a/inst/www/shared/shiny.css
+++ b/inst/www/shared/shiny.css
@@ -1,3 +1,17 @@
+/* This is necessary so that an empty verbatimTextOutput slot
+is the same height as a non-empty one (only important when
+* placeholder = TRUE) */
+pre.shiny-text-output:empty::before {
+  content: " ";
+}
+
+pre.shiny-text-output.noplaceholder:empty {
+  margin: 0;
+  padding: 0;
+  border-width: 0;
+  height: 0;
+}
+
 #shiny-disconnected-overlay {
   position: fixed;
   top: 0;

--- a/man/verbatimTextOutput.Rd
+++ b/man/verbatimTextOutput.Rd
@@ -4,10 +4,14 @@
 \alias{verbatimTextOutput}
 \title{Create a verbatim text output element}
 \usage{
-verbatimTextOutput(outputId)
+verbatimTextOutput(outputId, placeholder = FALSE)
 }
 \arguments{
 \item{outputId}{output variable to read the value from}
+
+\item{placeholder}{if the output is empty or \code{NULL}, should an empty
+rectangle be displayed to serve as a placeholder? (does not affect
+behavior when the the output in nonempty)}
 }
 \value{
 A verbatim text output element that can be included in a panel
@@ -18,16 +22,23 @@ application page. The text will be included within an HTML \code{pre} tag.
 }
 \details{
 Text is HTML-escaped prior to rendering. This element is often used
-with the \link{renderPrint} function to preserve fixed-width formatting
-of printed objects.
+  with the \link{renderPrint} function to preserve fixed-width formatting
+  of printed objects.
 }
 \examples{
-mainPanel(
-  h4("Summary"),
-  verbatimTextOutput("summary"),
-
-  h4("Observations"),
-  tableOutput("view")
-)
+## Only run this example in interactive R sessions
+if (interactive()) {
+  shinyApp(
+    ui = basicPage(
+      textInput("txt", "Enter the text to display below:"),
+      verbatimTextOutput("default"),
+      verbatimTextOutput("placeholder", placeholder = TRUE)
+    ),
+    server = function(input, output) {
+      output$default <- renderText({ input$txt })
+      output$placeholder <- renderText({ input$txt })
+    }
+  )
+}
 }
 


### PR DESCRIPTION
Can be done with only:

* a new parameter to `verbatimTextOutput` (called `placeholder`, and defaulting to TRUE -- which means no old apps will look different from before);

* a new parameter to `textOutput` (`...` so that we can send through the new class we add in `verbatimTextOutput`);

* a little CSS.

No JS needed!

Example app (one with the default, another with `placeholder = FALSE`):

```r
library(shiny)

ui <- basicPage(
  textInput("txt", "Enter the text to display below:"),
  verbatimTextOutput("default"),
  verbatimTextOutput("new", placeholder = FALSE),
  p("Dummy text to show there is no extra spacing when", 
    "the second output is empty")
)

server <- function(input, output, session) {
  output$default <- renderText({ input$txt })
  output$new <- renderText({ input$txt })
}

shinyApp(ui, server)

```