### PR TITLE
Fixes #1358: more informative error message when calling runApp inside of an app's app.R

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@ shiny 0.14.2.9000
 
 ### Minor new features and improvements
 
+* Addressed [#1358](https://github.com/rstudio/shiny/issues/1358): more informative error message when calling `runApp()` inside of an app's app.R (or inside ui.R or server.R). ([#1482](https://github.com/rstudio/shiny/pull/1482))
+
 * Added a more descriptive JS warning for `insertUI()` when the selector argument does not match anything in DOM. ([#1488](https://github.com/rstudio/shiny/pull/1488))
 
 * Added support for injecting JavaScript code when the `shiny.testmode` option is set to `TRUE`. This makes it possible to record test events interactively. ([#1464]https://github.com/rstudio/shiny/pull/1464))

--- a/R/server.R
+++ b/R/server.R
@@ -462,6 +462,9 @@ serviceApp <- function() {
 
 .shinyServerMinVersion <- '0.3.4'
 
+# Global flag that's TRUE whenever we're inside of the scope of a call to runApp
+.globals$running <- FALSE
+
 #' Run Shiny Application
 #'
 #' Runs a Shiny application. This function normally does not return; interrupt R
@@ -553,6 +556,15 @@ runApp <- function(appDir=getwd(),
                    test.mode=getOption('shiny.testmode', FALSE)) {
   on.exit({
     handlerManager$clear()
+  }, add = TRUE)
+
+  if (.globals$running) {
+    stop("Can't call `runApp()` from within `runApp()`. If your ,",
+         "application code contains `runApp()`, please remove it.")
+  }
+  .globals$running <- TRUE
+  on.exit({
+    .globals$running <- FALSE
   }, add = TRUE)
 
   # Enable per-app Shiny options


### PR DESCRIPTION
Fixes #1358: more informative error message when calling runApp inside of an app's app.R (or inside ui.R or server.R).

This used to be: `stop("Key ", key, " already in use")`

Now it is: `stop("Please remove any calls to runApp from inside your source code. (Details: Key ", key, " already in use)")`.

The only way I see this may be problematic is if this error is raised in another context (that isn't calling `runApp` from the app's source code). But I don't think that ever happens (?)

Again, I don't think this merits a NEWS entry... Let me know if you disagree