### PR TITLE
Fix #1359: shinyApp options argument ignored when passed to runApp

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@ shiny 0.14.2.9000
 
 * Fixed bug causing `<meta>` tags associated with HTML dependencies of Shiny R Markdown files to be rendered incorrectly. ([#1463](https://github.com/rstudio/shiny/pull/1463))
 
+* Fix [#1359](https://github.com/rstudio/shiny/issue/1359): `shinyApp()` options argument ignored when passed to `runApp()`. ([#1483](https://github.com/rstudio/shiny/pull/1483))
 
 shiny 0.14.2
 ============

--- a/R/app.R
+++ b/R/app.R
@@ -20,9 +20,11 @@
 #' @param onStart A function that will be called before the app is actually run.
 #'   This is only needed for \code{shinyAppObj}, since in the \code{shinyAppDir}
 #'   case, a \code{global.R} file can be used for this purpose.
-#' @param options Named options that should be passed to the `runApp` call. You
-#'   can also specify \code{width} and \code{height} parameters which provide a
-#'   hint to the embedding environment about the ideal height/width for the app.
+#' @param options Named options that should be passed to the \code{runApp} call
+#'   (these can be any of the following: "port", "launch.browser", "host", "quiet",
+#'   "display.mode" and "test.mode"). You can also specify \code{width} and
+#'   \code{height} parameters which provide a hint to the embedding environment
+#'   about the ideal height/width for the app.
 #' @param uiPattern A regular expression that will be applied to each \code{GET}
 #'   request to determine whether the \code{ui} should be used to handle the
 #'   request. Note that the entire request path must match the regular
@@ -373,7 +375,8 @@ is.shiny.appobj <- function(x) {
 print.shiny.appobj <- function(x, ...) {
   opts <- x$options %OR% list()
   opts <- opts[names(opts) %in%
-      c("port", "launch.browser", "host", "quiet", "display.mode")]
+      c("port", "launch.browser", "host", "quiet",
+        "display.mode", "test.mode")]
 
   args <- c(list(x), opts)
 

--- a/R/server.R
+++ b/R/server.R
@@ -588,30 +588,22 @@ runApp <- function(appDir=getwd(),
   # I tried to make this as compact and intuitive as possible,
   # given that there are four distinct possibilities to check
   runOpts <- appParts$options
-  passedArgs <- as.list(match.call())[-1]
-  thisEnv <- environment()
-
-  # Figure out which value to use for an option
-  priorityAssign <- function(arg) {
-    # if it was passed directly to `runApp`, use that value
-    if (arg %in% names(passedArgs)) val <- passedArgs[[arg]]
-
-    # else if it was passed directly to `shinyApp`, use that value
-    else if (arg %in% names(runOpts)) val <- runOpts[[arg]]
-
-    # else, just use the default value specified in `runApp`
-    else val <- thisEnv[[arg]]
-
-    # make sure that Ts and Fs are kept as logicals
-    if (is.name(val) && val == "T") val <- TRUE
-    if (is.name(val) && val == "F") val <- FALSE
-
-    assign(arg, val, envir = thisEnv)
+  assignVal <- function(arg, default) {
+    if (arg %in% names(runOpts)) runOpts[[arg]] else default
   }
 
-  lapply(list("port", "launch.browser", "host",
-              "quiet", "display.mode", "test.mode"),
-         priorityAssign)
+  if (missing(port))
+    port <- assignVal("port", port)
+  if (missing(launch.browser))
+    launch.browser <- assignVal("launch.browser", launch.browser)
+  if (missing(host))
+    host <- assignVal("host", host)
+  if (missing(quiet))
+    quiet <- assignVal("quiet", quiet)
+  if (missing(display.mode))
+    display.mode <- assignVal("display.mode", display.mode)
+  if (missing(test.mode))
+    test.mode <- assignVal("test.mode", test.mode)
 
   if (is.null(host) || is.na(host)) host <- '0.0.0.0'
 

--- a/R/server.R
+++ b/R/server.R
@@ -587,23 +587,23 @@ runApp <- function(appDir=getwd(),
   #
   # I tried to make this as compact and intuitive as possible,
   # given that there are four distinct possibilities to check
-  runOpts <- appParts$options
-  assignVal <- function(arg, default) {
-    if (arg %in% names(runOpts)) runOpts[[arg]] else default
+  appOps <- appParts$options
+  findVal <- function(arg, default) {
+    if (arg %in% names(appOps)) appOps[[arg]] else default
   }
 
   if (missing(port))
-    port <- assignVal("port", port)
+    port <- findVal("port", port)
   if (missing(launch.browser))
-    launch.browser <- assignVal("launch.browser", launch.browser)
+    launch.browser <- findVal("launch.browser", launch.browser)
   if (missing(host))
-    host <- assignVal("host", host)
+    host <- findVal("host", host)
   if (missing(quiet))
-    quiet <- assignVal("quiet", quiet)
+    quiet <- findVal("quiet", quiet)
   if (missing(display.mode))
-    display.mode <- assignVal("display.mode", display.mode)
+    display.mode <- findVal("display.mode", display.mode)
   if (missing(test.mode))
-    test.mode <- assignVal("test.mode", test.mode)
+    test.mode <- findVal("test.mode", test.mode)
 
   if (is.null(host) || is.na(host)) host <- '0.0.0.0'
 

--- a/man/shinyApp.Rd
+++ b/man/shinyApp.Rd
@@ -44,9 +44,11 @@ is.shiny.appobj(x)
 This is only needed for \code{shinyAppObj}, since in the \code{shinyAppDir}
 case, a \code{global.R} file can be used for this purpose.}
 
-\item{options}{Named options that should be passed to the `runApp` call. You
-can also specify \code{width} and \code{height} parameters which provide a
-hint to the embedding environment about the ideal height/width for the app.}
+\item{options}{Named options that should be passed to the \code{runApp} call
+(these can be any of the following: "port", "launch.browser", "host", "quiet",
+"display.mode" and "test.mode"). You can also specify \code{width} and
+\code{height} parameters which provide a hint to the embedding environment
+about the ideal height/width for the app.}
 
 \item{uiPattern}{A regular expression that will be applied to each \code{GET}
 request to determine whether the \code{ui} should be used to handle the


### PR DESCRIPTION
Fix #1359: shinyApp options argument ignored when passed to runApp.

The `options` arg to `shinyApp()` now works as expected, accepting the following shiny options:
* `port`
* `launch.browser`
* `host`

There are other params that `runApp()` accepts that `shinyApp()`'s `options` argument does not yet accept (these are `workerId`, `quiet`,`display.mode`). It may be worth having a discussion about whether any (or all, for consistency) of these should be promoted to a shiny option...

Here's the matrix of possibilities and the correspoding demo app:

1. no options are explicitly specified in `shinyApp()` or in `runApp()` -- defaults kick in (same behavior as before this PR):

```r
library(shiny)
app <- shinyApp(
  ui = fluidPage(
    numericInput("n", "n", 1),
    plotOutput("plot")
  ),
  server = function(input, output) {
    output$plot <- renderPlot( plot(head(cars, input$n)) )
  },
)
runApp(app)
```

2. options are only explicitly specified in `shinyApp()` -- these should be followed (this did not work before this PR):

```r
library(shiny)
app <- shinyApp(
  ui = fluidPage(
    numericInput("n", "n", 1),
    plotOutput("plot")
  ),
  server = function(input, output) {
    output$plot <- renderPlot( plot(head(cars, input$n)) )
  },
  options = list(launch.browser=rstudioapi::viewer, port=4000)
)
runApp(app)
```

3. options are only explicitly specified in `runApp()` -- these should be followed (same behavior as before this PR):

```r
library(shiny)
app <- shinyApp(
  ui = fluidPage(
    numericInput("n", "n", 1),
    plotOutput("plot")
  ),
  server = function(input, output) {
    output$plot <- renderPlot( plot(head(cars, input$n)) )
  },
)
runApp(app, launch.browser=T, port=3000)
```

4. no options are explicitly specified both in `shinyApp()` and in `runApp()` -- options from `runApp` win (same behavior as before this PR):

```r
library(shiny)
app <- shinyApp(
  ui = fluidPage(
    numericInput("n", "n", 1),
    plotOutput("plot")
  ),
  server = function(input, output) {
    output$plot <- renderPlot( plot(head(cars, input$n)) )
  },
  options = list(launch.browser=rstudioapi::viewer, port=4000)
)
runApp(app, launch.browser=T, port=3000)
```