### PR TITLE
Add ... arg to downloadButton

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@ shiny 0.14.2.9000
 
 * Added support for injecting JavaScript code when the `shiny.testmode` option is set to `TRUE`. This makes it possible to record test events interactively. ([#1464]https://github.com/rstudio/shiny/pull/1464))
 
+* Added ability through arguments to the `a` tag function called inside `downloadButton()` and `downloadLink()`. Closes [#986](https://github.com/rstudio/shiny/issues/986). ([#1492](https://github.com/rstudio/shiny/pulls/1492))
+
 ### Bug fixes
 
 * Fix [#1438](https://github.com/rstudio/shiny/issue/1438): `unbindAll()` should not be called when inserting content with `insertUI()` ([#1449](https://github.com/rstudio/shiny/pull/1449))

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -1421,6 +1421,7 @@ uiOutput <- htmlOutput
 #'   is assigned to.
 #' @param label The label that should appear on the button.
 #' @param class Additional CSS classes to apply to the tag, if any.
+#' @param ... Other arguments to pass to the container tag function.
 #'
 #' @examples
 #' \dontrun{
@@ -1443,25 +1444,25 @@ uiOutput <- htmlOutput
 #' @export
 downloadButton <- function(outputId,
                            label="Download",
-                           class=NULL) {
+                           class=NULL, ...) {
   aTag <- tags$a(id=outputId,
                  class=paste('btn btn-default shiny-download-link', class),
                  href='',
                  target='_blank',
                  download=NA,
                  icon("download"),
-                 label)
+                 label, ...)
 }
 
 #' @rdname downloadButton
 #' @export
-downloadLink <- function(outputId, label="Download", class=NULL) {
+downloadLink <- function(outputId, label="Download", class=NULL, ...) {
   tags$a(id=outputId,
          class=paste(c('shiny-download-link', class), collapse=" "),
          href='',
          target='_blank',
          download=NA,
-         label)
+         label, ...)
 }
 
 

--- a/man/downloadButton.Rd
+++ b/man/downloadButton.Rd
@@ -5,9 +5,9 @@
 \alias{downloadLink}
 \title{Create a download button or link}
 \usage{
-downloadButton(outputId, label = "Download", class = NULL)
+downloadButton(outputId, label = "Download", class = NULL, ...)
 
-downloadLink(outputId, label = "Download", class = NULL)
+downloadLink(outputId, label = "Download", class = NULL, ...)
 }
 \arguments{
 \item{outputId}{The name of the output slot that the \code{downloadHandler}
@@ -16,6 +16,8 @@ is assigned to.}
 \item{label}{The label that should appear on the button.}
 
 \item{class}{Additional CSS classes to apply to the tag, if any.}
+
+\item{...}{Other arguments to pass to the container tag function.}
 }
 \description{
 Use these functions to create a download button or link; when clicked, it


### PR DESCRIPTION
Added ability to pass arguments to the `a` tag function called inside `downloadButton()` and `downloadLink()`. Closes #986.

After seeing this referenced in another issue, this seemed like a very reasonable request that is not hard or risky to implement and doesn't break backward compatibility. Do you agree @wch, @jcheng5 ?

Demo app:
```r
ui <- fluidPage( downloadButton("download", style = "background-color:#C9DD03"))
server <- function(input, output, session) {}
shinyApp(ui, server)
```