### PR TITLE
Fix unqualified links to other packages

### DIFF
--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -1136,7 +1136,7 @@ imageOutput <- function(outputId, width = "100%", height="400px",
 #'   same \code{id} to disappear.
 #' @inheritParams textOutput
 #' @note The arguments \code{clickId} and \code{hoverId} only work for R base
-#'   graphics (see the \pkg{\link{graphics}} package). They do not work for
+#'   graphics (see the \pkg{\link[graphics:graphics-package]{graphics}} package). They do not work for
 #'   \pkg{\link[grid:grid-package]{grid}}-based graphics, such as \pkg{ggplot2},
 #'   \pkg{lattice}, and so on.
 #'

--- a/R/imageutils.R
+++ b/R/imageutils.R
@@ -21,7 +21,7 @@
 #' @param width Width in pixels.
 #' @param height Height in pixels.
 #' @param res Resolution in pixels per inch. This value is passed to
-#'   \code{\link{png}}. Note that this affects the resolution of PNG rendering in
+#'   \code{\link[grDevices]{png}}. Note that this affects the resolution of PNG rendering in
 #'   R; it won't change the actual ppi of the browser.
 #' @param ... Arguments to be passed through to \code{\link[grDevices]{png}}.
 #'   These can be used to set the width, height, background color, etc.

--- a/R/input-select.R
+++ b/R/input-select.R
@@ -155,7 +155,7 @@ needOptgroup <- function(choices) {
 #' @rdname selectInput
 #' @param ... Arguments passed to \code{selectInput()}.
 #' @param options A list of options. See the documentation of \pkg{selectize.js}
-#'   for possible options (character option values inside \code{\link{I}()} will
+#'   for possible options (character option values inside \code{\link[base]{I}()} will
 #'   be treated as literal JavaScript code; see \code{\link{renderDataTable}()}
 #'   for details).
 #' @param width The width of the input, e.g. \code{'400px'}, or \code{'100\%'};

--- a/R/input-slider.R
+++ b/R/input-slider.R
@@ -36,7 +36,7 @@
 #'   format string, to be passed to the Javascript strftime library. See
 #'   \url{https://github.com/samsonjs/strftime} for more details. The allowed
 #'   format specifications are very similar, but not identical, to those for R's
-#'   \code{\link{strftime}} function. For Dates, the default is \code{"\%F"}
+#'   \code{\link[base]{strftime}} function. For Dates, the default is \code{"\%F"}
 #'   (like \code{"2015-07-01"}), and for POSIXt, the default is \code{"\%F \%T"}
 #'   (like \code{"2015-07-01 15:32:10"}).
 #' @param timezone Only used if the values are POSIXt objects. A string

--- a/R/reactives.R
+++ b/R/reactives.R
@@ -344,7 +344,7 @@ as.list.reactivevalues <- function(x, all.names=FALSE, ...) {
 
 #' Convert a reactivevalues object to a list
 #'
-#' This function does something similar to what you might \code{\link{as.list}}
+#' This function does something similar to what you might \code{\link[base]{as.list}}
 #' to do. The difference is that the calling context will take dependencies on
 #' every object in the reactivevalues object. To avoid taking dependencies on
 #' all the objects, you can wrap the call with \code{\link{isolate}()}.
@@ -1109,7 +1109,7 @@ setAutoflush <- local({
 #' @return A no-parameter function that can be called from a reactive context,
 #'   in order to cause that context to be invalidated the next time the timer
 #'   interval elapses. Calling the returned function also happens to yield the
-#'   current time (as in \code{\link{Sys.time}}).
+#'   current time (as in \code{\link[base]{Sys.time}}).
 #' @seealso \code{\link{invalidateLater}}
 #'
 #' @examples
@@ -1417,7 +1417,7 @@ reactiveFileReader <- function(intervalMillis, session, filePath, readFunc, ...)
 #' The expression given to \code{isolate()} is evaluated in the calling
 #' environment. This means that if you assign a variable inside the
 #' \code{isolate()}, its value will be visible outside of the \code{isolate()}.
-#' If you want to avoid this, you can use \code{\link{local}()} inside the
+#' If you want to avoid this, you can use \code{\link[base]{local}()} inside the
 #' \code{isolate()}.
 #'
 #' This function can also be useful for calling reactive expression at the

--- a/R/render-plot.R
+++ b/R/render-plot.R
@@ -28,7 +28,7 @@
 #'   inline plot, you must provide numeric values (in pixels) to both
 #'   \code{width} and \code{height}.
 #' @param res Resolution of resulting plot, in pixels per inch. This value is
-#'   passed to \code{\link{png}}. Note that this affects the resolution of PNG
+#'   passed to \code{\link[grDevices]{png}}. Note that this affects the resolution of PNG
 #'   rendering in R; it won't change the actual ppi of the browser.
 #' @param ... Arguments to be passed through to \code{\link[grDevices]{png}}.
 #'   These can be used to set the width, height, background color, etc.

--- a/R/shinywrappers.R
+++ b/R/shinywrappers.R
@@ -220,7 +220,7 @@ renderImage <- function(expr, env=parent.frame(), quoted=FALSE,
 #'
 #' Makes a reactive version of the given function that captures any printed
 #' output, and also captures its printable result (unless
-#' \code{\link{invisible}}), into a string. The resulting function is suitable
+#' \code{\link[base]{invisible}}), into a string. The resulting function is suitable
 #' for assigning to an  \code{output} slot.
 #'
 #' The corresponding HTML output tag can be anything (though \code{pre} is
@@ -232,14 +232,14 @@ renderImage <- function(expr, env=parent.frame(), quoted=FALSE,
 #'
 #' Note that unlike most other Shiny output functions, if the given function
 #' returns \code{NULL} then \code{NULL} will actually be visible in the output.
-#' To display nothing, make your function return \code{\link{invisible}()}.
+#' To display nothing, make your function return \code{\link[base]{invisible}()}.
 #'
 #' @param expr An expression that may print output and/or return a printable R
 #'   object.
 #' @param env The environment in which to evaluate \code{expr}.
 #' @param quoted Is \code{expr} a quoted expression (with \code{quote()})? This
 #'   is useful if you want to save an expression in a variable.
-#' @param width The value for \code{\link{options}('width')}.
+#' @param width The value for \code{\link[base]{options}('width')}.
 #' @param outputArgs A list of arguments to be passed through to the implicit
 #'   call to \code{\link{verbatimTextOutput}} when \code{renderPrint} is used
 #'   in an interactive R Markdown document.
@@ -420,7 +420,7 @@ downloadHandler <- function(filename, content, contentType=NA, outputArgs=list()
 #' the server infrastructure.
 #'
 #' For the \code{options} argument, the character elements that have the class
-#' \code{"AsIs"} (usually returned from \code{\link{I}()}) will be evaluated in
+#' \code{"AsIs"} (usually returned from \code{\link[base]{I}()}) will be evaluated in
 #' JavaScript. This is useful when the type of the option value is not supported
 #' in JSON, e.g., a JavaScript function, which can be obtained by evaluating a
 #' character string. Note this only applies to the root-level elements of the

--- a/R/utils.R
+++ b/R/utils.R
@@ -1230,7 +1230,7 @@ need <- function(expr, message = paste(label, "must be provided"), label) {
 #' \strong{Truthy and falsy values}
 #'
 #' The terms "truthy" and "falsy" generally indicate whether a value, when
-#' coerced to a \code{\link{logical}}, is \code{TRUE} or \code{FALSE}. We use
+#' coerced to a \code{\link[base]{logical}}, is \code{TRUE} or \code{FALSE}. We use
 #' the term a little loosely here; our usage tries to match the intuitive
 #' notions of "Is this value missing or available?", or "Has the user provided
 #' an answer?", or in the case of action buttons, "Has the button been

--- a/man/builder.Rd
+++ b/man/builder.Rd
@@ -75,7 +75,7 @@ Dedicated functions are available for the most common HTML tags that do not
 conflict with common R functions.
 
 The result from these functions is a tag object, which can be converted using
-\code{\link{as.character}()}.
+\code{\link[base]{as.character}()}.
 }
 \examples{
 doc <- tags$html(

--- a/man/isolate.Rd
+++ b/man/isolate.Rd
@@ -25,7 +25,7 @@ relationship.
 The expression given to \code{isolate()} is evaluated in the calling
 environment. This means that if you assign a variable inside the
 \code{isolate()}, its value will be visible outside of the \code{isolate()}.
-If you want to avoid this, you can use \code{\link{local}()} inside the
+If you want to avoid this, you can use \code{\link[base]{local}()} inside the
 \code{isolate()}.
 
 This function can also be useful for calling reactive expression at the

--- a/man/plotOutput.Rd
+++ b/man/plotOutput.Rd
@@ -86,7 +86,7 @@ application page.
 }
 \note{
 The arguments \code{clickId} and \code{hoverId} only work for R base
-  graphics (see the \pkg{\link{graphics}} package). They do not work for
+  graphics (see the \pkg{\link[graphics:graphics-package]{graphics}} package). They do not work for
   \pkg{\link[grid:grid-package]{grid}}-based graphics, such as \pkg{ggplot2},
   \pkg{lattice}, and so on.
 }

--- a/man/plotPNG.Rd
+++ b/man/plotPNG.Rd
@@ -18,7 +18,7 @@ extension \code{.png}.}
 \item{height}{Height in pixels.}
 
 \item{res}{Resolution in pixels per inch. This value is passed to
-\code{\link{png}}. Note that this affects the resolution of PNG rendering in
+\code{\link[grDevices]{png}}. Note that this affects the resolution of PNG rendering in
 R; it won't change the actual ppi of the browser.}
 
 \item{...}{Arguments to be passed through to \code{\link[grDevices]{png}}.

--- a/man/reactiveTimer.Rd
+++ b/man/reactiveTimer.Rd
@@ -18,7 +18,7 @@ occur.}
 A no-parameter function that can be called from a reactive context,
   in order to cause that context to be invalidated the next time the timer
   interval elapses. Calling the returned function also happens to yield the
-  current time (as in \code{\link{Sys.time}}).
+  current time (as in \code{\link[base]{Sys.time}}).
 }
 \description{
 Creates a reactive timer with the given interval. A reactive timer is like a

--- a/man/reactiveValuesToList.Rd
+++ b/man/reactiveValuesToList.Rd
@@ -13,7 +13,7 @@ reactiveValuesToList(x, all.names = FALSE)
 \code{FALSE} (the default) don't include those objects.}
 }
 \description{
-This function does something similar to what you might \code{\link{as.list}}
+This function does something similar to what you might \code{\link[base]{as.list}}
 to do. The difference is that the calling context will take dependencies on
 every object in the reactivevalues object. To avoid taking dependencies on
 all the objects, you can wrap the call with \code{\link{isolate}()}.

--- a/man/renderDataTable.Rd
+++ b/man/renderDataTable.Rd
@@ -45,7 +45,7 @@ the server infrastructure.
 }
 \details{
 For the \code{options} argument, the character elements that have the class
-\code{"AsIs"} (usually returned from \code{\link{I}()}) will be evaluated in
+\code{"AsIs"} (usually returned from \code{\link[base]{I}()}) will be evaluated in
 JavaScript. This is useful when the type of the option value is not supported
 in JSON, e.g., a JavaScript function, which can be obtained by evaluating a
 character string. Note this only applies to the root-level elements of the

--- a/man/renderPlot.Rd
+++ b/man/renderPlot.Rd
@@ -20,7 +20,7 @@ inline plot, you must provide numeric values (in pixels) to both
 \code{width} and \code{height}.}
 
 \item{res}{Resolution of resulting plot, in pixels per inch. This value is
-passed to \code{\link{png}}. Note that this affects the resolution of PNG
+passed to \code{\link[grDevices]{png}}. Note that this affects the resolution of PNG
 rendering in R; it won't change the actual ppi of the browser.}
 
 \item{...}{Arguments to be passed through to \code{\link[grDevices]{png}}.

--- a/man/renderPrint.Rd
+++ b/man/renderPrint.Rd
@@ -16,7 +16,7 @@ object.}
 \item{quoted}{Is \code{expr} a quoted expression (with \code{quote()})? This
 is useful if you want to save an expression in a variable.}
 
-\item{width}{The value for \code{\link{options}('width')}.}
+\item{width}{The value for \code{\link[base]{options}('width')}.}
 
 \item{outputArgs}{A list of arguments to be passed through to the implicit
 call to \code{\link{verbatimTextOutput}} when \code{renderPrint} is used
@@ -25,7 +25,7 @@ in an interactive R Markdown document.}
 \description{
 Makes a reactive version of the given function that captures any printed
 output, and also captures its printable result (unless
-\code{\link{invisible}}), into a string. The resulting function is suitable
+\code{\link[base]{invisible}}), into a string. The resulting function is suitable
 for assigning to an  \code{output} slot.
 }
 \details{
@@ -38,7 +38,7 @@ The result of executing \code{func} will be printed inside a
 
 Note that unlike most other Shiny output functions, if the given function
 returns \code{NULL} then \code{NULL} will actually be visible in the output.
-To display nothing, make your function return \code{\link{invisible}()}.
+To display nothing, make your function return \code{\link[base]{invisible}()}.
 }
 \examples{
 isolate({

--- a/man/req.Rd
+++ b/man/req.Rd
@@ -60,7 +60,7 @@ way to check for a value "inline" with its first use.
 \strong{Truthy and falsy values}
 
 The terms "truthy" and "falsy" generally indicate whether a value, when
-coerced to a \code{\link{logical}}, is \code{TRUE} or \code{FALSE}. We use
+coerced to a \code{\link[base]{logical}}, is \code{TRUE} or \code{FALSE}. We use
 the term a little loosely here; our usage tries to match the intuitive
 notions of "Is this value missing or available?", or "Has the user provided
 an answer?", or in the case of action buttons, "Has the button been

--- a/man/selectInput.Rd
+++ b/man/selectInput.Rd
@@ -42,7 +42,7 @@ list, but when \code{size} is set, it will be a box instead.}
 \item{...}{Arguments passed to \code{selectInput()}.}
 
 \item{options}{A list of options. See the documentation of \pkg{selectize.js}
-for possible options (character option values inside \code{\link{I}()} will
+for possible options (character option values inside \code{\link[base]{I}()} will
 be treated as literal JavaScript code; see \code{\link{renderDataTable}()}
 for details).}
 }

--- a/man/sliderInput.Rd
+++ b/man/sliderInput.Rd
@@ -62,7 +62,7 @@ see \code{\link{validateCssUnit}}.}
 format string, to be passed to the Javascript strftime library. See
 \url{https://github.com/samsonjs/strftime} for more details. The allowed
 format specifications are very similar, but not identical, to those for R's
-\code{\link{strftime}} function. For Dates, the default is \code{"\%F"}
+\code{\link[base]{strftime}} function. For Dates, the default is \code{"\%F"}
 (like \code{"2015-07-01"}), and for POSIXt, the default is \code{"\%F \%T"}
 (like \code{"2015-07-01 15:32:10"}).}
 

--- a/man/tag.Rd
+++ b/man/tag.Rd
@@ -39,7 +39,7 @@ contain tags, text nodes, and HTML.}
 }
 \value{
 An HTML tag object that can be rendered as HTML using
-  \code{\link{as.character}()}.
+  \code{\link[base]{as.character}()}.
 }
 \description{
 \code{tag()} creates an HTML tag definition. Note that all of the valid HTML5

--- a/man/updateSelectInput.Rd
+++ b/man/updateSelectInput.Rd
@@ -32,7 +32,7 @@ example section for a small demo of this feature.}
 for single-select lists and no values for multiple select lists.}
 
 \item{options}{A list of options. See the documentation of \pkg{selectize.js}
-for possible options (character option values inside \code{\link{I}()} will
+for possible options (character option values inside \code{\link[base]{I}()} will
 be treated as literal JavaScript code; see \code{\link{renderDataTable}()}
 for details).}
 


### PR DESCRIPTION
R-devel warns on this now, causes Travis to fail

```
checking Rd cross-references ... WARNING
package ‘grid’ exists but was not installed under R >= 2.10.0 so xrefs cannot be checked
package ‘grDevices’ exists but was not installed under R >= 2.10.0 so xrefs cannot be checked
package ‘utils’ exists but was not installed under R >= 2.10.0 so xrefs cannot be checked
package ‘base’ exists but was not installed under R >= 2.10.0 so xrefs cannot be checked
Missing link or links in documentation object 'builder.Rd':
  ‘as.character’

Missing link or links in documentation object 'isolate.Rd':
  ‘local’

Missing link or links in documentation object 'plotOutput.Rd':
  ‘graphics’

Missing link or links in documentation object 'plotPNG.Rd':
  ‘png’

Missing link or links in documentation object 'reactiveTimer.Rd':
  ‘Sys.time’

Missing link or links in documentation object 'reactiveValuesToList.Rd':
  ‘as.list’

Missing link or links in documentation object 'renderDataTable.Rd':
  ‘I’

Missing link or links in documentation object 'renderPlot.Rd':
  ‘png’

Missing link or links in documentation object 'renderPrint.Rd':
  ‘invisible’ ‘options’

Missing link or links in documentation object 'req.Rd':
  ‘logical’

Missing link or links in documentation object 'selectInput.Rd':
  ‘I’

Missing link or links in documentation object 'sliderInput.Rd':
  ‘strftime’

Missing link or links in documentation object 'tag.Rd':
  ‘as.character’

Missing link or links in documentation object 'updateSelectInput.Rd':
  ‘I’

See section 'Cross-references' in the 'Writing R Extensions' manual.
```