### PR TITLE
Pressing Esc in a modal in a gadget only closes the modal. Closes #1453

### DIFF
--- a/srcjs/modal.js
+++ b/srcjs/modal.js
@@ -27,12 +27,29 @@ exports.modal = {
       });
     }
 
+    $modal.on('keydown.shinymodal', function(e) {
+      // If we're listening for Esc, don't let the event propagate. See
+      // https://github.com/rstudio/shiny/issues/1453. The value of
+      // data("keyboard") needs to be checked inside the handler, because at
+      // the time that $modal.on() is called, the $("#shiny-modal") div doesn't
+      // yet exist.
+      if ($("#shiny-modal").data("keyboard") === false)
+        return;
+
+      if (e.keyCode === 27) {
+        e.stopPropagation();
+        e.preventDefault();
+      }
+    });
+
     // Set/replace contents of wrapper with html.
     exports.renderContent($modal, { html: html, deps: deps });
   },
 
   remove: function() {
     const $modal = $('#shiny-modal-wrapper');
+
+    $modal.off('keydown.shinymodal');
 
     // Look for a Bootstrap modal and if present, trigger hide event. This will
     // trigger the hidden.bs.modal callback that we set in show(), which unbinds


### PR DESCRIPTION
Pressing Esc in a modal in a gadget only closes the modal, not the gadget. Closes #1453.

With this gadget test app, pressing Esc only closes the modal:

```R
ui <- miniUI::miniPage(
    miniUI::gadgetTitleBar("test"),
    actionButton("showmodal", "Show modal")
)

server <- function(input, output, session) {
    observeEvent(input$showmodal, {
        showModal(modalDialog(
            "Press ESC",
            easyClose = T
        ))
    })
}
runGadget(ui, server)
```


When `easyClose=FALSE`, the Esc is not intercepted by the modal, and so it does close the gadget:

```R
ui <- miniUI::miniPage(
    miniUI::gadgetTitleBar("test"),
    actionButton("showmodal", "Show modal")
)

server <- function(input, output, session) {
    observeEvent(input$showmodal, {
        showModal(modalDialog(
            "Press ESC",
            easyClose = F
        ))
    })
}
runGadget(ui, server)
```
