### PR TITLE
Relax naming requirements for addResourcePath

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,7 +37,7 @@ Now there's an official way to slow down reactive values and expressions that in
 
 * Implemented [#1512](https://github.com/rstudio/shiny/issues/1512): added a `userData` environment to `session`, for storing arbitrary session-related variables. Generally, session-scoped variables are created just by declaring normal variables that are local to the Shiny server function, but `session$userData` may be more convenient for some advanced scenarios. ([#1513](https://github.com/rstudio/shiny/pull/1513))
 
-* Relaxed naming requirements for `addResourcePath()` (the first character no longer needs to be a letter)
+* Relaxed naming requirements for `addResourcePath()` (the first character no longer needs to be a letter). ([#1529](https://github.com/rstudio/shiny/pull/1529))
 
 ### Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,8 @@ Now there's an official way to slow down reactive values and expressions that in
 
 * Implemented [#1512](https://github.com/rstudio/shiny/issues/1512): added a `userData` environment to `session`, for storing arbitrary session-related variables. Generally, session-scoped variables are created just by declaring normal variables that are local to the Shiny server function, but `session$userData` may be more convenient for some advanced scenarios. ([#1513](https://github.com/rstudio/shiny/pull/1513))
 
+* Relaxed naming requirements for `addResourcePath()` (the first character no longer needs to be a letter)
+
 ### Bug fixes
 
 * Fixed [#969](https://github.com/rstudio/shiny/issues/969): allow navbarPage's `fluid` param to control both containers. ([#1481](https://github.com/rstudio/shiny/pull/1481))

--- a/R/server.R
+++ b/R/server.R
@@ -52,7 +52,7 @@ registerClient <- function(client) {
 #' @export
 addResourcePath <- function(prefix, directoryPath) {
   prefix <- prefix[1]
-  if (!grepl('^[^\\.][a-z0-9\\-_.]*$', prefix, ignore.case=TRUE, perl=TRUE)) {
+  if (!grepl('^[a-z0-9\\-_][a-z0-9\\-_.]*$', prefix, ignore.case=TRUE, perl=TRUE)) {
     stop("addResourcePath called with invalid prefix; please see documentation")
   }
 

--- a/R/server.R
+++ b/R/server.R
@@ -34,7 +34,7 @@ registerClient <- function(client) {
 #' JavaScript/CSS files available to their components.
 #'
 #' @param prefix The URL prefix (without slashes). Valid characters are a-z,
-#'   A-Z, 0-9, hyphen, period, and underscore; and must begin with a-z or A-Z.
+#'   A-Z, 0-9, hyphen, period, and underscore.
 #'   For example, a value of 'foo' means that any request paths that begin with
 #'   '/foo' will be mapped to the given directory.
 #' @param directoryPath The directory that contains the static resources to be
@@ -52,7 +52,7 @@ registerClient <- function(client) {
 #' @export
 addResourcePath <- function(prefix, directoryPath) {
   prefix <- prefix[1]
-  if (!grepl('^[a-z][a-z0-9\\-_.]*$', prefix, ignore.case=TRUE, perl=TRUE)) {
+  if (!grepl('^[^\\.][a-z0-9\\-_.]*$', prefix, ignore.case=TRUE, perl=TRUE)) {
     stop("addResourcePath called with invalid prefix; please see documentation")
   }
 

--- a/man/addResourcePath.Rd
+++ b/man/addResourcePath.Rd
@@ -8,7 +8,7 @@ addResourcePath(prefix, directoryPath)
 }
 \arguments{
 \item{prefix}{The URL prefix (without slashes). Valid characters are a-z,
-A-Z, 0-9, hyphen, period, and underscore; and must begin with a-z or A-Z.
+A-Z, 0-9, hyphen, period, and underscore.
 For example, a value of 'foo' means that any request paths that begin with
 '/foo' will be mapped to the given directory.}
 


### PR DESCRIPTION
First character no longer needs to be a letter. See https://github.com/rstudio/tutor/issues/4 for discussion.