### PR TITLE
decode URLs in staticHandler func (fixes #1565)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@ shiny 1.0.0.9000
 
 ### Minor new features and improvements
 
+* Fixed [#1565](https://github.com/rstudio/shiny/issues/1565), which meant that resources with spaces in their names return HTTP 404 .[#1566](https://github.com/rstudio/shiny/pull/1566)
+
 * Exported `session$user` (if it exists) to the client-side; it's accessible in the Shiny object: `Shiny.user`. ([#1563](https://github.com/rstudio/shiny/pull/1563))
 
 * Added support for HTML5's `pushState` which allows for pseudo-navigation

--- a/R/middleware.R
+++ b/R/middleware.R
@@ -191,7 +191,7 @@ staticHandler <- function(root) {
     if (!identical(req$REQUEST_METHOD, 'GET'))
       return(NULL)
 
-    path <- req$PATH_INFO
+    path <- URLdecode(req$PATH_INFO)
 
     if (is.null(path))
       return(httpResponse(400, content="<h1>Bad Request</h1>"))


### PR DESCRIPTION
@jcheng5 is it this simple to fix the URL problem in #1565? I tested the example app and all three ways work now:

```r
library(shiny)

addResourcePath("foo", "foo")

ui <- fluidPage(
  img(src="foo/foo.png"),
  img(src="foo/b a r.png"),
  img(src=URLencode("foo/b a r.png")),
  img(src="foo/b%20a%20r.png")
)

shinyApp(ui = ui, server = function(input, output) {})
```

given that these is a `foo` folder with a `foo.png` image and a `b a r.png` image.