### PR TITLE
Assign individual html ids to radiobutton and checkbox choices

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@ shiny 1.0.0.9000
 
 ### Minor new features and improvements
 
+* Added automatic ids to radiobutton and checkbox choices. Id format: `inputId_choice`
+
 * Fixed [#1565](https://github.com/rstudio/shiny/issues/1565), which meant that resources with spaces in their names return HTTP 404. ([#1566](https://github.com/rstudio/shiny/pull/1566))
 
 * Exported `session$user` (if it exists) to the client-side; it's accessible in the Shiny object: `Shiny.user`. ([#1563](https://github.com/rstudio/shiny/pull/1563))

--- a/R/input-utils.R
+++ b/R/input-utils.R
@@ -43,7 +43,7 @@ generateOptions <- function(inputId, choices, selected, inline, type = 'checkbox
     choices, names(choices),
     FUN = function(value, name) {
       inputTag <- tags$input(
-        type = type, name = inputId, value = value
+        type = type, id = paste0(inputId, "_", value), name = inputId, value = value
       )
       if (value %in% selected)
         inputTag$attribs$checked <- "checked"


### PR DESCRIPTION
This assigns an html id value to the individual options created for both radiobuttons and checkboxes. By referencing this id individual choices can be 'disabled' using shinyjs (etc.).

Here's an example:

```
library(shiny)
library(shinyjs)

b <- seq(10, 50, by = 10)

ui <- fluidPage(
  shinyjs::useShinyjs(),
  checkboxGroupInput("disable", "Disable Buttons", choices = b, inline = TRUE),
  radioButtons("bins", "Number of bins:", choices = b, inline = TRUE),
  plotOutput("distPlot")
)


server <- function(input, output, session) {

  observeEvent(input$disable, {
    lapply(b, FUN = function(x) shinyjs::toggleState(id = paste0("bins_", x), condition = !(x %in% input$disable)))
    if(input$bins %in% input$disable) updateRadioButtons(session, "bins", selected = b[!(b %in% input$disable)][1])
  })

  output$distPlot <- renderPlot({
    req(input$bins)
    x <- faithful[, 2]
    bins <- seq(min(x), max(x), length.out = as.numeric(input$bins) + 1)
    hist(x, breaks = bins, col = 'darkgray', border = 'white')
  })
}

shinyApp(ui = ui, server = server)
```