### PR TITLE
Fix #1581

### DIFF
--- a/R/input-action.R
+++ b/R/input-action.R
@@ -54,7 +54,7 @@ actionButton <- function(inputId, label, icon = NULL, width = NULL, ...) {
 
 #' @rdname actionButton
 #' @export
-actionLink <- function(inputId, label, icon = NULL, ...) {
+actionLink <- function(inputId, label, ..., icon = NULL) {
   value <- restoreInput(id = inputId, default = NULL)
 
   tags$a(id=inputId,


### PR DESCRIPTION
Change the order of `...` and `icon = NULL` in `actionLink()` to avoid pass non-icon contents into `validateIcon` when `icon` is not specified. 