### PR TITLE
Make sure input deduplication respects inputType. Closes #162

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,8 @@ in shiny apps. For more info, see the documentation (`?updateQueryString` and `?
 
 * Fixed [#1472](https://github.com/rstudio/shiny/issues/1472): With a Progress object, calling `set(value=NULL)` made the progress bar go to 100%. Now it does not change the value of the progress bar. The documentation also incorrectly said that setting the `value` to `NULL` would hide the progress bar. ([#1547](https://github.com/rstudio/shiny/pull/1547))
 
+* Fixed [#162](https://github.com/rstudio/shiny/issues/162): When a dynamically-generated input changed to a different `inputType`, it might be incorrectly deduplicated.  ([#1594](https://github.com/rstudio/shiny/pull/1594))
+
 ### Library updates
 
 * Closed [#1500](https://github.com/rstudio/shiny/issues/1500): Updated ion.rangeSlider to 2.1.6. ([#1540](https://github.com/rstudio/shiny/pull/1540))

--- a/srcjs/input_rate.js
+++ b/srcjs/input_rate.js
@@ -217,10 +217,16 @@ var InputNoResendDecorator = function(target, initialValues) {
 };
 (function() {
   this.setInput = function(name, value) {
-    var jsonValue = JSON.stringify(value);
-    if (this.lastSentValues[name] === jsonValue)
+    const { name: inputName, inputType: inputType } = splitInputNameType(name);
+    const jsonValue = JSON.stringify(value);
+
+    // Resend if either json value or the input type has changed.
+    if (this.lastSentValues[inputName] &&
+        this.lastSentValues[inputName].jsonValue === jsonValue &&
+        this.lastSentValues[inputName].inputType === inputType) {
       return;
-    this.lastSentValues[name] = jsonValue;
+    }
+    this.lastSentValues[inputName] = { jsonValue, inputType };
     this.target.setInput(name, value);
   };
   this.reset = function(values) {
@@ -258,9 +264,10 @@ var InputEventDecorator = function(target) {
 (function() {
   this.setInput = function(name, value, immediate) {
     var evt = jQuery.Event("shiny:inputchanged");
-    var name2 = name.split(':');
-    evt.name = name2[0];
-    evt.inputType = name2.length > 1 ? name2[1] : '';
+
+    const input = splitInputNameType(name);
+    evt.name = input.name;
+    evt.inputType = input.inputType;
     evt.value = value;
     $(document).trigger(evt);
     if (!evt.isDefaultPrevented()) {
@@ -302,3 +309,12 @@ var InputRateDecorator = function(target) {
     this.target.setInput(name, value);
   };
 }).call(InputRateDecorator.prototype);
+
+
+  function splitInputNameType(name) {
+    const name2 = name.split(':');
+    return {
+      name:      name2[0],
+      inputType: name2.length > 1 ? name2[1] : ''
+    };
+  }


### PR DESCRIPTION
Closes #162. The `inputNoResendDecorator` used the `name` to check for duplicated values. However, `name` included the input type, so the previous value of `x:shiny.number` would be stored separately from `x:shiny.date`, or `x` (with no input type).

With this change, the if the value or input type changes, the value will be sent.

In this test application, switch back and forth between "numeric" and "checkbox":

```R
shinyApp(
  ui = pageWithSidebar(
    headerPanel(""),
    sidebarPanel(
      radioButtons("input_type", "Input type", c("numeric", "checkbox")),
      uiOutput("ui")
    ),

    mainPanel(
      tags$p("Input type:"),
      verbatimTextOutput("input_type_text"),
      tags$p("Dynamic input value:"),
      verbatimTextOutput("dynamic_value")
    )
  ),

  server = function(input, output) {
    output$ui <- renderUI({
      if (is.null(input$input_type))
        return()

      if (input$input_type == "numeric") {
        numericInput("dynamic",  "Dynamic", value=12)
      } else if (input$input_type == "checkbox") {
        checkboxInput("dynamic",  "Dynamic", value=TRUE)
      }
    })

    output$input_type_text <- renderText({
      input$input_type
    })

    output$dynamic_value <- renderPrint({
      str(input$dynamic)
    })
  }
)
```