### PR TITLE
Add binding and el fields to shiny:inputchanged event

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,8 @@ in shiny apps. For more info, see the documentation (`?updateQueryString` and `?
 
 * Fixed [#1577](https://github.com/rstudio/shiny/issues/1577): Improved `escapeHTML` (util.js) in terms of the order dependency of replacing, XSS risk attack and performance. ([#1579](https://github.com/rstudio/shiny/pull/1579))
 
+* The `shiny:inputchanged` JavaScript event now includes two new fields, `binding` and `el`, which contain the input binding and DOM element, respectively. Additionally, `Shiny.onInputChange()` now accepts an optional argument, `opts`, which can contain the same fields. ([#1596](https://github.com/rstudio/shiny/pull/1596))
+
 ### Bug fixes
 
 * Fixed [#1511](https://github.com/rstudio/shiny/issues/1511): `fileInput`s did not trigger the `shiny:inputchanged` event on the client. Also removed `shiny:fileuploaded` JavaScript event, because it is no longer needed after this fix. ([#1541](https://github.com/rstudio/shiny/pull/1541), [#1570](https://github.com/rstudio/shiny/pull/1570))

--- a/srcjs/init_shiny.js
+++ b/srcjs/init_shiny.js
@@ -93,8 +93,14 @@ function initShiny() {
     });
   });
 
-  exports.onInputChange = function(name, value) {
-    inputs.setInput(name, value);
+  exports.onInputChange = function(name, value, opts) {
+    opts = Object.assign({
+      immediate: false,
+      binding: null,
+      el: null
+    }, opts);
+
+    inputs.setInput(name, value, opts);
   };
 
   var boundInputs = {};
@@ -106,7 +112,9 @@ function initShiny() {
       var type = binding.getType(el);
       if (type)
         id = id + ":" + type;
-      inputs.setInput(id, value, !allowDeferred);
+
+      let opts = { immediate: !allowDeferred, binding: binding, el: el };
+      inputs.setInput(id, value, opts);
     }
   }
 

--- a/srcjs/init_shiny.js
+++ b/srcjs/init_shiny.js
@@ -224,9 +224,9 @@ function initShiny() {
   exports.bindAll = function(scope) {
     // _bindAll returns input values; it doesn't send them to the server.
     // export.bindAll needs to send the values to the server.
-    var currentValues = _bindAll(scope);
-    $.each(currentValues, function(name, val) {
-      inputs.setInput(name, val.value, val.opts);
+    var currentInputItems = _bindAll(scope);
+    $.each(currentInputItems, function(name, item) {
+      inputs.setInput(name, item.value, item.opts);
     });
 
     // Not sure if the iframe stuff is an intrinsic part of bindAll, but bindAll

--- a/srcjs/init_shiny.js
+++ b/srcjs/init_shiny.js
@@ -82,16 +82,24 @@ function initShiny() {
   var inputsRate = new InputRateDecorator(inputsEvent);
   var inputsDefer = new InputDeferDecorator(inputsEvent);
 
-  // By default, use rate decorator
-  var inputs = inputsRate;
-  $('input[type="submit"], button[type="submit"]').each(function() {
+  var inputsValidate;
+  if ($('input[type="submit"], button[type="submit"]').length > 0) {
     // If there is a submit button on the page, use defer decorator
-    inputs = inputsDefer;
-    $(this).click(function(event) {
-      event.preventDefault();
-      inputsDefer.submit();
+    inputsValidate = new InputValidateDecorator(inputsDefer);
+
+    $('input[type="submit"], button[type="submit"]').each(function() {
+      $(this).click(function(event) {
+        event.preventDefault();
+        inputsDefer.submit();
+      });
     });
-  });
+
+  } else {
+    // By default, use rate decorator
+    inputsValidate = new InputValidateDecorator(inputsRate);
+  }
+
+  var inputs = inputsValidate;
 
   exports.onInputChange = function(name, value, opts) {
     opts = Object.assign({

--- a/srcjs/init_shiny.js
+++ b/srcjs/init_shiny.js
@@ -467,6 +467,9 @@ function initShiny() {
     }
   });
 
+  // IE8 and IE9 have some limitations with data URIs
+  initialValues['.clientdata_allowDataUriScheme'] = typeof WebSocket !== 'undefined';
+
   // We've collected all the initial values--start the server process!
   inputsNoResend.reset(initialValues);
   shinyapp.connect(initialValues);

--- a/srcjs/init_shiny.js
+++ b/srcjs/init_shiny.js
@@ -82,10 +82,10 @@ function initShiny() {
   var inputsRate = new InputRateDecorator(inputsEvent);
   var inputsDefer = new InputDeferDecorator(inputsEvent);
 
-  var inputsValidate;
+  var inputs;
   if ($('input[type="submit"], button[type="submit"]').length > 0) {
     // If there is a submit button on the page, use defer decorator
-    inputsValidate = new InputValidateDecorator(inputsDefer);
+    inputs = inputsDefer;
 
     $('input[type="submit"], button[type="submit"]').each(function() {
       $(this).click(function(event) {
@@ -96,10 +96,10 @@ function initShiny() {
 
   } else {
     // By default, use rate decorator
-    inputsValidate = new InputValidateDecorator(inputsRate);
+    inputs = inputsRate;
   }
 
-  var inputs = inputsValidate;
+  inputs = new InputValidateDecorator(inputs);
 
   exports.onInputChange = function(name, value, opts) {
     opts = addDefaultInputOpts(opts);

--- a/srcjs/init_shiny.js
+++ b/srcjs/init_shiny.js
@@ -121,7 +121,7 @@ function initShiny() {
   function bindInputs(scope = document) {
     var bindings = inputBindings.getBindings();
 
-    var currentValues = {};
+    var inputItems = {};
 
     for (var i = 0; i < bindings.length; i++) {
       var binding = bindings[i].binding;
@@ -136,7 +136,13 @@ function initShiny() {
 
         var type = binding.getType(el);
         var effectiveId = type ? id + ":" + type : id;
-        currentValues[effectiveId] = binding.getValue(el);
+        inputItems[effectiveId] = {
+          value: binding.getValue(el),
+          opts: {
+            binding: binding,
+            el: el
+          }
+        };
 
         /*jshint loopfunc:true*/
         var thisCallback = (function() {
@@ -171,7 +177,7 @@ function initShiny() {
       }
     }
 
-    return currentValues;
+    return inputItems;
   }
 
   function unbindInputs(scope = document, includeSelf = false) {

--- a/srcjs/init_shiny.js
+++ b/srcjs/init_shiny.js
@@ -264,20 +264,15 @@ function initShiny() {
   initializeInputs(document);
 
   var initialValues = _bindAll(document);
-  // Each entry in initialValues has the structure { value: 123, opts: {} },
-  // where opts is an empty object, to be consistent with the (non-initial)
-  // input values.
-  function addInitialValue(name, value) {
-    initialValues[name] = { value, opts: {} };
-  }
+
 
   // The server needs to know the size of each image and plot output element,
   // in case it is auto-sizing
   $('.shiny-image-output, .shiny-plot-output').each(function() {
     var id = getIdFromEl(this);
     if (this.offsetWidth !== 0 || this.offsetHeight !== 0) {
-      addInitialValue('.clientdata_output_' + id + '_width', this.offsetWidth);
-      addInitialValue('.clientdata_output_' + id + '_height', this.offsetHeight);
+      initialValues['.clientdata_output_' + id + '_width'] = this.offsetWidth;
+      initialValues['.clientdata_output_' + id + '_height'] = this.offsetHeight;
     }
   });
   function doSendImageSize() {
@@ -327,10 +322,10 @@ function initShiny() {
   $('.shiny-bound-output').each(function() {
     var id = getIdFromEl(this);
     if (isHidden(this)) {
-      addInitialValue('.clientdata_output_' + id + '_hidden', true);
+      initialValues['.clientdata_output_' + id + '_hidden'] = true;
     } else {
       lastKnownVisibleOutputs[id] = true;
-      addInitialValue('.clientdata_output_' + id + '_hidden', false);
+      initialValues['.clientdata_output_' + id + '_hidden'] = false;
     }
   });
   // Send update when hidden state changes
@@ -419,19 +414,19 @@ function initShiny() {
                sendOutputHiddenState);
 
   // Send initial pixel ratio, and update it if it changes
-  addInitialValue('.clientdata_pixelratio', pixelRatio());
+  initialValues['.clientdata_pixelratio'] = pixelRatio();
   $(window).resize(function() {
     inputs.setInput('.clientdata_pixelratio', pixelRatio());
   });
 
   // Send initial URL
-  addInitialValue('.clientdata_url_protocol', window.location.protocol);
-  addInitialValue('.clientdata_url_hostname', window.location.hostname);
-  addInitialValue('.clientdata_url_port',     window.location.port);
-  addInitialValue('.clientdata_url_pathname', window.location.pathname);
+  initialValues['.clientdata_url_protocol'] = window.location.protocol;
+  initialValues['.clientdata_url_hostname'] = window.location.hostname;
+  initialValues['.clientdata_url_port']     = window.location.port;
+  initialValues['.clientdata_url_pathname'] = window.location.pathname;
 
   // Send initial URL search (query string) and update it if it changes
-  addInitialValue('.clientdata_url_search',   window.location.search);
+  initialValues['.clientdata_url_search']   = window.location.search;
 
   $(window).on('pushstate', function(e) {
     inputs.setInput('.clientdata_url_search', window.location.search);
@@ -445,8 +440,8 @@ function initShiny() {
   // a reactive version of this isn't sent because watching for changes can
   // require polling on some browsers. The JQuery hashchange plugin can be
   // used if this capability is important.
-  addInitialValue('.clientdata_url_hash_initial', window.location.hash);
-  addInitialValue('.clientdata_url_hash', window.location.hash);
+  initialValues['.clientdata_url_hash_initial'] = window.location.hash;
+  initialValues['.clientdata_url_hash'] = window.location.hash;
 
   $(window).on('hashchange', function(e) {
     inputs.setInput('.clientdata_url_hash', location.hash);
@@ -454,8 +449,8 @@ function initShiny() {
 
   // The server needs to know what singletons were rendered as part of
   // the page loading
-  var singletonText = $('script[type="application/shiny-singletons"]').text();
-  addInitialValue('.clientdata_singletons', singletonText);
+  var singletonText = initialValues['.clientdata_singletons'] =
+      $('script[type="application/shiny-singletons"]').text();
   singletons.registerNames(singletonText.split(/,/));
 
   var dependencyText = $('script[type="application/html-dependencies"]').text();

--- a/srcjs/init_shiny.js
+++ b/srcjs/init_shiny.js
@@ -102,12 +102,7 @@ function initShiny() {
   var inputs = inputsValidate;
 
   exports.onInputChange = function(name, value, opts) {
-    opts = Object.assign({
-      immediate: false,
-      binding: null,
-      el: null
-    }, opts);
-
+    opts = addDefaultInputOpts(opts);
     inputs.setInput(name, value, opts);
   };
 

--- a/srcjs/init_shiny.js
+++ b/srcjs/init_shiny.js
@@ -264,15 +264,20 @@ function initShiny() {
   initializeInputs(document);
 
   var initialValues = _bindAll(document);
-
+  // Each entry in initialValues has the structure { value: 123, opts: {} },
+  // where opts is an empty object, to be consistent with the (non-initial)
+  // input values.
+  function addInitialValue(name, value) {
+    initialValues[name] = { value, opts: {} };
+  }
 
   // The server needs to know the size of each image and plot output element,
   // in case it is auto-sizing
   $('.shiny-image-output, .shiny-plot-output').each(function() {
     var id = getIdFromEl(this);
     if (this.offsetWidth !== 0 || this.offsetHeight !== 0) {
-      initialValues['.clientdata_output_' + id + '_width'] = this.offsetWidth;
-      initialValues['.clientdata_output_' + id + '_height'] = this.offsetHeight;
+      addInitialValue('.clientdata_output_' + id + '_width', this.offsetWidth);
+      addInitialValue('.clientdata_output_' + id + '_height', this.offsetHeight);
     }
   });
   function doSendImageSize() {
@@ -322,10 +327,10 @@ function initShiny() {
   $('.shiny-bound-output').each(function() {
     var id = getIdFromEl(this);
     if (isHidden(this)) {
-      initialValues['.clientdata_output_' + id + '_hidden'] = true;
+      addInitialValue('.clientdata_output_' + id + '_hidden', true);
     } else {
       lastKnownVisibleOutputs[id] = true;
-      initialValues['.clientdata_output_' + id + '_hidden'] = false;
+      addInitialValue('.clientdata_output_' + id + '_hidden', false);
     }
   });
   // Send update when hidden state changes
@@ -414,19 +419,19 @@ function initShiny() {
                sendOutputHiddenState);
 
   // Send initial pixel ratio, and update it if it changes
-  initialValues['.clientdata_pixelratio'] = pixelRatio();
+  addInitialValue('.clientdata_pixelratio', pixelRatio());
   $(window).resize(function() {
     inputs.setInput('.clientdata_pixelratio', pixelRatio());
   });
 
   // Send initial URL
-  initialValues['.clientdata_url_protocol'] = window.location.protocol;
-  initialValues['.clientdata_url_hostname'] = window.location.hostname;
-  initialValues['.clientdata_url_port']     = window.location.port;
-  initialValues['.clientdata_url_pathname'] = window.location.pathname;
+  addInitialValue('.clientdata_url_protocol', window.location.protocol);
+  addInitialValue('.clientdata_url_hostname', window.location.hostname);
+  addInitialValue('.clientdata_url_port',     window.location.port);
+  addInitialValue('.clientdata_url_pathname', window.location.pathname);
 
   // Send initial URL search (query string) and update it if it changes
-  initialValues['.clientdata_url_search']   = window.location.search;
+  addInitialValue('.clientdata_url_search',   window.location.search);
 
   $(window).on('pushstate', function(e) {
     inputs.setInput('.clientdata_url_search', window.location.search);
@@ -440,8 +445,8 @@ function initShiny() {
   // a reactive version of this isn't sent because watching for changes can
   // require polling on some browsers. The JQuery hashchange plugin can be
   // used if this capability is important.
-  initialValues['.clientdata_url_hash_initial'] = window.location.hash;
-  initialValues['.clientdata_url_hash'] = window.location.hash;
+  addInitialValue('.clientdata_url_hash_initial', window.location.hash);
+  addInitialValue('.clientdata_url_hash', window.location.hash);
 
   $(window).on('hashchange', function(e) {
     inputs.setInput('.clientdata_url_hash', location.hash);
@@ -449,8 +454,8 @@ function initShiny() {
 
   // The server needs to know what singletons were rendered as part of
   // the page loading
-  var singletonText = initialValues['.clientdata_singletons'] =
-      $('script[type="application/shiny-singletons"]').text();
+  var singletonText = $('script[type="application/shiny-singletons"]').text();
+  addInitialValue('.clientdata_singletons', singletonText);
   singletons.registerNames(singletonText.split(/,/));
 
   var dependencyText = $('script[type="application/html-dependencies"]').text();

--- a/srcjs/init_shiny.js
+++ b/srcjs/init_shiny.js
@@ -139,6 +139,7 @@ function initShiny() {
         inputItems[effectiveId] = {
           value: binding.getValue(el),
           opts: {
+            immediate: true,
             binding: binding,
             el: el
           }

--- a/srcjs/input_binding_fileinput.js
+++ b/srcjs/input_binding_fileinput.js
@@ -38,9 +38,10 @@ var IE8FileUploader = function(shinyapp, id, fileEl) {
   };
 }).call(IE8FileUploader.prototype);
 
-var FileUploader = function(shinyapp, id, files) {
+var FileUploader = function(shinyapp, id, files, el) {
   this.shinyapp = shinyapp;
   this.id = id;
+  this.el = el;
   FileProcessor.call(this, files);
 };
 $.extend(FileUploader.prototype, FileProcessor.prototype);
@@ -130,6 +131,8 @@ $.extend(FileUploader.prototype, FileProcessor.prototype);
     var evt = jQuery.Event("shiny:inputchanged");
     evt.name = this.id;
     evt.value = fileInfo;
+    evt.binding = fileInputBinding;
+    evt.el = this.el;
     evt.inputType = 'shiny.fileupload';
     $(document).trigger(evt);
 
@@ -213,7 +216,8 @@ function uploadFiles(evt) {
     /*jshint nonew:false */
     new IE8FileUploader(exports.shinyapp, id, evt.target);
   } else {
-    $el.data('currentUploader', new FileUploader(exports.shinyapp, id, files));
+    $el.data('currentUploader',
+      new FileUploader(exports.shinyapp, id, files, evt.target));
   }
 }
 

--- a/srcjs/input_rate.js
+++ b/srcjs/input_rate.js
@@ -224,7 +224,6 @@ var InputNoResendDecorator = function(target, initialValues) {
     // decorator stack. If in the future this setInput keeps track of opts, it
     // would be best not to store the `el`, because that could prevent it from
     // being GC'd.
-
     const { name: inputName, inputType: inputType } = splitInputNameType(name);
     const jsonValue = JSON.stringify(value);
 
@@ -249,11 +248,6 @@ var InputEventDecorator = function(target) {
 };
 (function() {
   this.setInput = function(name, value, opts) {
-    opts = Object.assign({
-      binding: null,
-      el: null
-    }, opts);
-
     var evt = jQuery.Event("shiny:inputchanged");
 
     const input = splitInputNameType(name);
@@ -283,12 +277,6 @@ var InputRateDecorator = function(target) {
 };
 (function() {
   this.setInput = function(name, value, opts) {
-    opts = Object.assign({
-      immediate: false,
-      binding: null,
-      el: null
-    }, opts);
-
     this.$ensureInit(name);
 
     if (opts.immediate)
@@ -323,11 +311,6 @@ var InputDeferDecorator = function(target) {
 };
 (function() {
   this.setInput = function(name, value, opts) {
-    opts = Object.assign({
-      binding: null,
-      el: null
-    }, opts);
-
     if (/^\./.test(name))
       this.target.setInput(name, value, opts);
     else
@@ -342,6 +325,26 @@ var InputDeferDecorator = function(target) {
     }
   };
 }).call(InputDeferDecorator.prototype);
+
+
+const InputValidateDecorator = function(target) {
+  this.target = target;
+};
+(function() {
+  this.setInput = function(name, value, opts) {
+    if (!name)
+      throw "Can't set input with empty name.";
+
+    // Merge with default options
+    opts = Object.assign({
+      immediate: false,
+      binding: null,
+      el: null
+    }, opts);
+
+    this.target.setInput(name, value, opts);
+  };
+}).call(InputValidateDecorator.prototype);
 
 
 function splitInputNameType(name) {

--- a/srcjs/input_rate.js
+++ b/srcjs/input_rate.js
@@ -257,9 +257,9 @@ var InputEventDecorator = function(target) {
     var evt = jQuery.Event("shiny:inputchanged");
 
     const input = splitInputNameType(name);
-    evt.name = input.name;
+    evt.name      = input.name;
     evt.inputType = input.inputType;
-    evt.value = value;
+    evt.value     = value;
     evt.binding   = opts.binding;
     evt.el        = opts.el;
 

--- a/srcjs/input_rate.js
+++ b/srcjs/input_rate.js
@@ -335,16 +335,21 @@ const InputValidateDecorator = function(target) {
     if (!name)
       throw "Can't set input with empty name.";
 
-    // Merge with default options
-    opts = Object.assign({
-      immediate: false,
-      binding: null,
-      el: null
-    }, opts);
+    opts = addDefaultInputOpts(opts);
 
     this.target.setInput(name, value, opts);
   };
 }).call(InputValidateDecorator.prototype);
+
+
+// Merge opts with defaults, and return a new object.
+function addDefaultInputOpts(opts) {
+  return Object.assign({
+    immediate: false,
+    binding: null,
+    el: null
+  }, opts);
+}
 
 
 function splitInputNameType(name) {

--- a/srcjs/input_rate.js
+++ b/srcjs/input_rate.js
@@ -192,7 +192,8 @@ var InputBatchSender = function(shinyapp) {
   this.setInput = function(name, value, opts) {
     var self = this;
 
-    this.pendingData[name] = value;
+    this.pendingData[name] = { value, opts };
+
     if (!this.timerId && !this.reentrant) {
       this.timerId = setTimeout(function() {
         self.reentrant = true;
@@ -234,10 +235,7 @@ var InputNoResendDecorator = function(target, initialValues) {
   };
   this.reset = function(values) {
     values = values || {};
-    var strValues = {};
-    $.each(values, function(key, value) {
-      strValues[key] = JSON.stringify(value);
-    });
+    var strValues = mapValues(values, x => JSON.stringify(x.value));
     this.lastSentValues = strValues;
   };
 }).call(InputNoResendDecorator.prototype);

--- a/srcjs/input_rate.js
+++ b/srcjs/input_rate.js
@@ -262,7 +262,7 @@ var InputEventDecorator = function(target) {
   this.target = target;
 };
 (function() {
-  this.setInput = function(name, value, immediate) {
+  this.setInput = function(name, value) {
     var evt = jQuery.Event("shiny:inputchanged");
 
     const input = splitInputNameType(name);
@@ -273,7 +273,7 @@ var InputEventDecorator = function(target) {
     if (!evt.isDefaultPrevented()) {
       name = evt.name;
       if (evt.inputType !== '') name += ':' + evt.inputType;
-      this.target.setInput(name, evt.value, immediate);
+      this.target.setInput(name, evt.value);
     }
   };
 }).call(InputEventDecorator.prototype);
@@ -286,9 +286,9 @@ var InputRateDecorator = function(target) {
   this.setInput = function(name, value, immediate) {
     this.$ensureInit(name);
     if (immediate)
-      this.inputRatePolicies[name].immediateCall(name, value, immediate);
+      this.inputRatePolicies[name].immediateCall(name, value);
     else
-      this.inputRatePolicies[name].normalCall(name, value, immediate);
+      this.inputRatePolicies[name].normalCall(name, value);
   };
   this.setRatePolicy = function(name, mode, millis) {
     if (mode === 'direct') {

--- a/srcjs/input_rate.js
+++ b/srcjs/input_rate.js
@@ -241,33 +241,6 @@ var InputNoResendDecorator = function(target, initialValues) {
 }).call(InputNoResendDecorator.prototype);
 
 
-var InputDeferDecorator = function(target) {
-  this.target = target;
-  this.pendingInput = {};
-};
-(function() {
-  this.setInput = function(name, value, opts) {
-    opts = Object.assign({
-      binding: null,
-      el: null
-    }, opts);
-
-    if (/^\./.test(name))
-      this.target.setInput(name, value, opts);
-    else
-      this.pendingInput[name] = { value, opts };
-  };
-  this.submit = function() {
-    for (var name in this.pendingInput) {
-      if (this.pendingInput.hasOwnProperty(name)) {
-        let input = this.pendingInput[name];
-        this.target.setInput(name, input.value, input.opts);
-      }
-    }
-  };
-}).call(InputDeferDecorator.prototype);
-
-
 var InputEventDecorator = function(target) {
   this.target = target;
 };
@@ -336,6 +309,33 @@ var InputRateDecorator = function(target) {
     this.target.setInput(name, value, opts);
   };
 }).call(InputRateDecorator.prototype);
+
+
+var InputDeferDecorator = function(target) {
+  this.target = target;
+  this.pendingInput = {};
+};
+(function() {
+  this.setInput = function(name, value, opts) {
+    opts = Object.assign({
+      binding: null,
+      el: null
+    }, opts);
+
+    if (/^\./.test(name))
+      this.target.setInput(name, value, opts);
+    else
+      this.pendingInput[name] = { value, opts };
+  };
+  this.submit = function() {
+    for (var name in this.pendingInput) {
+      if (this.pendingInput.hasOwnProperty(name)) {
+        let input = this.pendingInput[name];
+        this.target.setInput(name, input.value, input.opts);
+      }
+    }
+  };
+}).call(InputDeferDecorator.prototype);
 
 
   function splitInputNameType(name) {

--- a/srcjs/input_rate.js
+++ b/srcjs/input_rate.js
@@ -338,10 +338,10 @@ var InputDeferDecorator = function(target) {
 }).call(InputDeferDecorator.prototype);
 
 
-  function splitInputNameType(name) {
-    const name2 = name.split(':');
-    return {
-      name:      name2[0],
-      inputType: name2.length > 1 ? name2[1] : ''
-    };
-  }
+function splitInputNameType(name) {
+  const name2 = name.split(':');
+  return {
+    name:      name2[0],
+    inputType: name2.length > 1 ? name2[1] : ''
+  };
+}

--- a/srcjs/shinyapp.js
+++ b/srcjs/shinyapp.js
@@ -4,6 +4,9 @@ var ShinyApp = function() {
   // Cached input values
   this.$inputValues = {};
 
+  // Input values at initialization (and reconnect)
+  this.$initialInput = {};
+
   // Output bindings
   this.$bindings = {};
 
@@ -97,9 +100,23 @@ var ShinyApp = function() {
 
       self.onConnected();
 
+      // self.$initialInput has a structure like this:
+      //   { x: { value: 1, opts: { binding: null, el: null } },
+      //     y: { value: 2, opts: { binding: null, el: null } } }
+      // We need to extract just the `value` so that we send just this data:
+      //   { x: 1, y: 2 }
+      const initialInputValues = mapValues(self.$initialInput, x => {
+        // TODO: Remove need for this test, by setting initial values with
+        // {values: 1} wrapper. We need to use hasOwnProperty because sometimes
+        // value is null.
+        if (x.hasOwnProperty("value"))
+          return x.value;
+        return x;
+      });
+
       socket.send(JSON.stringify({
         method: 'init',
-        data: self.$initialInput
+        data: initialInputValues
       }));
 
       while (self.$pendingMessages.length) {
@@ -131,9 +148,16 @@ var ShinyApp = function() {
   };
 
   this.sendInput = function(values) {
-    var msg = JSON.stringify({
+    // `values` will have a format like this:
+    //   { x: { value: 1, opts: { binding: null, el: null } },
+    //     y: { value: 2, opts: { binding: null, el: null } } }
+    // We need to extract just the `value` so that we send just this data:
+    //   { x: 1, y: 2 }
+    const dataValues = mapValues(values, x => x.value);
+
+    const msg = JSON.stringify({
       method: 'update',
-      data: values
+      data: dataValues
     });
 
     this.$sendMsg(msg);
@@ -389,7 +413,7 @@ var ShinyApp = function() {
     for (var name in this.$inputValues) {
       if (this.$inputValues.hasOwnProperty(name)) {
         var shortName = name.replace(/:.*/, '');
-        inputs[shortName] = this.$inputValues[name];
+        inputs[shortName] = this.$inputValues[name].value;
       }
     }
 

--- a/srcjs/shinyapp.js
+++ b/srcjs/shinyapp.js
@@ -32,7 +32,10 @@ var ShinyApp = function() {
 
     $.extend(initialInput, {
       // IE8 and IE9 have some limitations with data URIs
-      ".clientdata_allowDataUriScheme": typeof WebSocket !== 'undefined'
+      ".clientdata_allowDataUriScheme": {
+        value: typeof WebSocket !== 'undefined',
+        opts: {}
+      }
     });
 
     this.$socket = this.createSocket();
@@ -105,14 +108,7 @@ var ShinyApp = function() {
       //     y: { value: 2, opts: { binding: null, el: null } } }
       // We need to extract just the `value` so that we send just this data:
       //   { x: 1, y: 2 }
-      const initialInputValues = mapValues(self.$initialInput, x => {
-        // TODO: Remove need for this test, by setting initial values with
-        // {values: 1} wrapper. We need to use hasOwnProperty because sometimes
-        // value is null.
-        if (x.hasOwnProperty("value"))
-          return x.value;
-        return x;
-      });
+      const initialInputValues = mapValues(self.$initialInput, x => x.value);
 
       socket.send(JSON.stringify({
         method: 'init',

--- a/srcjs/shinyapp.js
+++ b/srcjs/shinyapp.js
@@ -100,23 +100,9 @@ var ShinyApp = function() {
 
       self.onConnected();
 
-      // self.$initialInput has a structure like this:
-      //   { x: { value: 1, opts: { binding: null, el: null } },
-      //     y: { value: 2, opts: { binding: null, el: null } } }
-      // We need to extract just the `value` so that we send just this data:
-      //   { x: 1, y: 2 }
-      const initialInputValues = mapValues(self.$initialInput, x => {
-        // TODO: Remove need for this test, by setting initial values with
-        // {values: 1} wrapper. We need to use hasOwnProperty because sometimes
-        // value is null.
-        if (x.hasOwnProperty("value"))
-          return x.value;
-        return x;
-      });
-
       socket.send(JSON.stringify({
         method: 'init',
-        data: initialInputValues
+        data: self.$initialInput
       }));
 
       while (self.$pendingMessages.length) {
@@ -148,16 +134,9 @@ var ShinyApp = function() {
   };
 
   this.sendInput = function(values) {
-    // `values` will have a format like this:
-    //   { x: { value: 1, opts: { binding: null, el: null } },
-    //     y: { value: 2, opts: { binding: null, el: null } } }
-    // We need to extract just the `value` so that we send just this data:
-    //   { x: 1, y: 2 }
-    const dataValues = mapValues(values, x => x.value);
-
-    const msg = JSON.stringify({
+    var msg = JSON.stringify({
       method: 'update',
-      data: dataValues
+      data: values
     });
 
     this.$sendMsg(msg);
@@ -413,7 +392,7 @@ var ShinyApp = function() {
     for (var name in this.$inputValues) {
       if (this.$inputValues.hasOwnProperty(name)) {
         var shortName = name.replace(/:.*/, '');
-        inputs[shortName] = this.$inputValues[name].value;
+        inputs[shortName] = this.$inputValues[name];
       }
     }
 

--- a/srcjs/shinyapp.js
+++ b/srcjs/shinyapp.js
@@ -30,11 +30,6 @@ var ShinyApp = function() {
     if (this.$socket)
       throw "Connect was already called on this application object";
 
-    $.extend(initialInput, {
-      // IE8 and IE9 have some limitations with data URIs
-      ".clientdata_allowDataUriScheme": typeof WebSocket !== 'undefined'
-    });
-
     this.$socket = this.createSocket();
     this.$initialInput = initialInput;
     $.extend(this.$inputValues, initialInput);

--- a/srcjs/shinyapp.js
+++ b/srcjs/shinyapp.js
@@ -32,10 +32,7 @@ var ShinyApp = function() {
 
     $.extend(initialInput, {
       // IE8 and IE9 have some limitations with data URIs
-      ".clientdata_allowDataUriScheme": {
-        value: typeof WebSocket !== 'undefined',
-        opts: {}
-      }
+      ".clientdata_allowDataUriScheme": typeof WebSocket !== 'undefined'
     });
 
     this.$socket = this.createSocket();
@@ -108,7 +105,14 @@ var ShinyApp = function() {
       //     y: { value: 2, opts: { binding: null, el: null } } }
       // We need to extract just the `value` so that we send just this data:
       //   { x: 1, y: 2 }
-      const initialInputValues = mapValues(self.$initialInput, x => x.value);
+      const initialInputValues = mapValues(self.$initialInput, x => {
+        // TODO: Remove need for this test, by setting initial values with
+        // {values: 1} wrapper. We need to use hasOwnProperty because sometimes
+        // value is null.
+        if (x.hasOwnProperty("value"))
+          return x.value;
+        return x;
+      });
 
       socket.send(JSON.stringify({
         method: 'init',

--- a/srcjs/utils.js
+++ b/srcjs/utils.js
@@ -207,3 +207,14 @@ function mergeSort(list, sortfunc) {
 var $escape = exports.$escape = function(val) {
   return val.replace(/([!"#$%&'()*+,.\/:;<=>?@\[\\\]^`{|}~])/g, '\\$1');
 };
+
+// Maps a function over an object, preserving keys. Like the mapValues
+// function from lodash.
+function mapValues(obj, f) {
+  const newObj = {};
+  for (let key in obj) {
+    if (obj.hasOwnProperty(key))
+      newObj[key] = f(obj[key]);
+  }
+  return newObj;
+}

--- a/tools/Gruntfile.js
+++ b/tools/Gruntfile.js
@@ -98,6 +98,7 @@ module.exports = function(grunt) {
           // "no-shadow": 1,
           "no-undef": 1,
           "no-unused-vars": [1, {"args": "none"}],
+          "guard-for-in": 1,
           // "no-use-before-define": [1, {"functions": false}],
           "semi": [1, "always"]
         },


### PR DESCRIPTION
With this PR, the `shiny:inputchanged` JavaScript event gets two new fields, `binding` and `el`, which contain the input binding and DOM element, respectively. Additionally, `Shiny.onInputChange()` now accepts an optional argument, `opts`, which can contain the same fields.