### PR TITLE
Change NS() to return a vectorized function

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,8 @@ in shiny apps. For more info, see the documentation (`?updateQueryString` and `?
 
 * The `shiny:inputchanged` JavaScript event now includes two new fields, `binding` and `el`, which contain the input binding and DOM element, respectively. Additionally, `Shiny.onInputChange()` now accepts an optional argument, `opts`, which can contain the same fields. ([#1596](https://github.com/rstudio/shiny/pull/1596))
 
+* The `NS()` function now returns a vectorized function. ([#1613](https://github.com/rstudio/shiny/pull/1613))
+
 ### Bug fixes
 
 * Fixed [#1511](https://github.com/rstudio/shiny/issues/1511): `fileInput`s did not trigger the `shiny:inputchanged` event on the client. Also removed `shiny:fileuploaded` JavaScript event, because it is no longer needed after this fix. ([#1541](https://github.com/rstudio/shiny/pull/1541), [#1570](https://github.com/rstudio/shiny/pull/1570))

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -386,7 +386,7 @@ NS <- function(namespace, id = NULL) {
     if (length(ns_prefix) == 0)
       return(id)
 
-    paste(ns_prefix, id, sep = "-")
+    paste(ns_prefix, id, sep = ns.sep)
   }
 
   if (missing(id)) {

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -375,12 +375,24 @@ NULL
 #' @seealso \url{http://shiny.rstudio.com/articles/modules.html}
 #' @export
 NS <- function(namespace, id = NULL) {
+  if (length(namespace) == 0)
+    ns_prefix <- character(0)
+  else
+    ns_prefix <- paste(namespace, collapse = ns.sep)
+
+  f <- function(id) {
+    if (length(id) == 0)
+      return(ns_prefix)
+    if (length(ns_prefix) == 0)
+      return(id)
+
+    paste(ns_prefix, id, sep = "-")
+  }
+
   if (missing(id)) {
-    function(id) {
-      paste(c(namespace, id), collapse = ns.sep)
-    }
+    f
   } else {
-    paste(c(namespace, id), collapse = ns.sep)
+    f(id)
   }
 }
 

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -856,7 +856,7 @@ ShinySession <- R6Class(
           if (anyUnnamed(dots))
             stop("exportTestValues: all arguments must be named.")
 
-          names(dots) <- vapply(names(dots), ns, character(1))
+          names(dots) <- ns(names(dots))
 
           do.call(
             .subset2(self, "exportTestValues"),
@@ -973,7 +973,7 @@ ShinySession <- R6Class(
       # Returns the excluded names with the scope's ns prefix on them.
       private$registerBookmarkExclude(function() {
         excluded <- scope$getBookmarkExclude()
-        vapply(excluded, ns, character(1), USE.NAMES = FALSE)
+        ns(excluded)
       })
 
       scope

--- a/tests/testthat/test-modules.R
+++ b/tests/testthat/test-modules.R
@@ -1,11 +1,30 @@
 context("modules")
 
 test_that("Namespace qualifying", {
+  expect_equivalent(NS(NULL, "one"), "one")
+  expect_equivalent(NS(NULL)("one"), "one")
+
+  expect_equivalent(NS("one", NULL), "one")
+  expect_equivalent(NS("one")(NULL), "one")
+
   expect_equivalent(NS("one", "two"), "one-two")
+  expect_equivalent(NS("one")("two"), "one-two")
+
   expect_equivalent(NS(c("one", "two"))(NULL), "one-two")
-  expect_equivalent(NS(NULL)(c("one", "two")), "one-two")
-  expect_equivalent(NS(c("one", "two"), c("three", "four")), "one-two-three-four")
-  expect_equivalent(NS(c("one", "two"))(c("three", "four")), "one-two-three-four")
+  expect_equivalent(NS(c("one", "two"), NULL), "one-two")
+
+  expect_equivalent(NS(NULL)(c("one", "two")), c("one", "two"))
+  expect_equivalent(NS(NULL, c("one", "two")), c("one", "two"))
+
+  expect_equivalent(NS("one", c("two", "three")), c("one-two", "one-three"))
+  expect_equivalent(NS("one")(c("two", "three")), c("one-two", "one-three"))
+
+  expect_equivalent(NS(c("one", "two"), "three"), "one-two-three")
+  expect_equivalent(NS(c("one", "two"))("three"), "one-two-three")
+
+  expect_equivalent(NS(c("one", "two"), c("three", "four")), c("one-two-three", "one-two-four"))
+  expect_equivalent(NS(c("one", "two"))(c("three", "four")), c("one-two-three", "one-two-four"))
+
   expect_equivalent(NS(c("one", "two"))("three four"), "one-two-three four")
   expect_equivalent(NS(c("one", "two"))("three-four"), "one-two-three-four")
 })


### PR DESCRIPTION
Previously, `NS` had this behavior:

```R
ns <- NS(c("one", "two"))
ns(c("three", "four"))
# [1] "one-two-three-four"
```

But it make more sense for the `ns()` function (the one which was returned by `NS()`) to return a vector. Now it does this:

```R
ns <- NS(c("one", "two"))
ns(c("three", "four"))
# [1] "one-two-three" "one-two-four" 
```

The code ended up being more complex than I expected, but I didn't see a simpler way to do it.