### PR TITLE
Stop propagation of mouse events on slider

### DIFF
--- a/inst/www/shared/ionrangeslider/js/ion.rangeSlider.js
+++ b/inst/www/shared/ionrangeslider/js/ion.rangeSlider.js
@@ -767,6 +767,7 @@
          */
         pointerDown: function (target, e) {
             e.preventDefault();
+            e.stopPropagation();
             var x = e.pageX || e.originalEvent.touches && e.originalEvent.touches[0].pageX;
             if (e.button === 2) {
                 return;
@@ -810,6 +811,7 @@
          */
         pointerClick: function (target, e) {
             e.preventDefault();
+            e.stopPropagation();
             var x = e.pageX || e.originalEvent.touches && e.originalEvent.touches[0].pageX;
             if (e.button === 2) {
                 return;

--- a/tools/updateIonRangeSlider.R
+++ b/tools/updateIonRangeSlider.R
@@ -1,8 +1,14 @@
 #!/usr/bin/env Rscript
 
 # This script copies resources from ion.RangeSlider to shiny's inst
-# directory. The ion.RangeSlider/ project directory should be on the same level
+# directory. The ion.rangeSlider/ project directory should be on the same level
 # as the shiny/ project directory.
+
+# The version of ion.rangeSlider that we use is modified from the base version
+# in two ways:
+# * In our version, mouse events on the slider are not propagated to lower
+#   layers (#711, #1630).
+# * We include a custom skin for Shiny.
 
 # This script can be sourced from RStudio, or run with Rscript.
 


### PR DESCRIPTION
This fixes #1630.

It gets ion.rangeSlider from: https://github.com/rstudio/ion.rangeSlider/tree/shiny-mods-2.1.6

I forgot to apply one of our old patches to fix the mouse event propagation issue when I updated to 2.1.6.