### PR TITLE
Fix #1632: Showcase mode comes up almost blank in IE9 & 11

### DIFF
--- a/inst/www/shared/shiny-showcase.js
+++ b/inst/www/shared/shiny-showcase.js
@@ -217,7 +217,7 @@
     var app = document.getElementById("showcase-app-container");
     $(app).animate({
         width: appWidth + "px",
-        zoom: zoom
+        zoom: (zoom*100) + "%"
       }, animate ? animateMs : 0);
   };
 


### PR DESCRIPTION
If the width is made very wide in showcase mode with side-by-side
arrangement, the app shrinks to almost nothing. For some reason the
zoom CSS property (which we set using jQuery.animate) is set to
"1%" instead of "1".

Numbers and percentages are equally valid here, and the issue goes
away if we use percentage.