### PR TITLE
allow the `choices` argument in `checkboxGroupInput()` to be `NULL`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,18 @@
+shiny 1.0.1.9000
+================
+
+## Full changelog
+
+### Breaking changes
+### New features
+### Minor new features and improvements
+
+* Fixed [#1649](https://github.com/rstudio/shiny/issues/1649): allow the `choices` argument in `checkboxGroupInput()` to be `NULL` (or `c()`) to keep backward compatibility with Shiny < 1.0.1. This will result in the same thing as providing `choices = character(0)`. ([#1652](https://github.com/rstudio/shiny/pull/1652))
+
+### Bug fixes
+### Library updates
+
+
 shiny 1.0.1
 ================
 

--- a/R/input-checkboxgroup.R
+++ b/R/input-checkboxgroup.R
@@ -70,6 +70,9 @@
 checkboxGroupInput <- function(inputId, label, choices = NULL, selected = NULL,
   inline = FALSE, width = NULL, choiceNames = NULL, choiceValues = NULL) {
 
+  # keep backward compatibility with Shiny < 1.0.1 (see #1649)
+  if (all(is.null(c(choices, choiceNames, choiceValues)))) choices <- character(0)
+
   args <- normalizeChoicesArgs(choices, choiceNames, choiceValues)
 
   selected <- restoreInput(id = inputId, default = selected)

--- a/R/input-checkboxgroup.R
+++ b/R/input-checkboxgroup.R
@@ -71,7 +71,9 @@ checkboxGroupInput <- function(inputId, label, choices = NULL, selected = NULL,
   inline = FALSE, width = NULL, choiceNames = NULL, choiceValues = NULL) {
 
   # keep backward compatibility with Shiny < 1.0.1 (see #1649)
-  if (all(is.null(c(choices, choiceNames, choiceValues)))) choices <- character(0)
+  if (all(vapply(list(choices, choiceNames, choiceValues), is.null, logical(1)))) {
+    choices <- character(0)
+  }
 
   args <- normalizeChoicesArgs(choices, choiceNames, choiceValues)
 

--- a/R/input-checkboxgroup.R
+++ b/R/input-checkboxgroup.R
@@ -71,7 +71,7 @@ checkboxGroupInput <- function(inputId, label, choices = NULL, selected = NULL,
   inline = FALSE, width = NULL, choiceNames = NULL, choiceValues = NULL) {
 
   # keep backward compatibility with Shiny < 1.0.1 (see #1649)
-  if (all(vapply(list(choices, choiceNames, choiceValues), is.null, logical(1)))) {
+  if (is.null(choices) && is.null(choiceNames) && is.null(choiceValues)) {
     choices <- character(0)
   }
 

--- a/tests/testthat/test-bootstrap.r
+++ b/tests/testthat/test-bootstrap.r
@@ -247,3 +247,19 @@ test_that("normalizeChoicesArgs does its job", {
   expected <- list(choiceNames = NULL, choiceValues = NULL)
   expect_equal(normalizeChoicesArgs(NULL, NULL, NULL, FALSE), expected)
 })
+
+test_that("Choices need not be provided, can be NULL or c()", {
+
+  expected <- "<div id=\"cb\" class=\"form-group shiny-input-checkboxgroup shiny-input-container\">\n  <label class=\"control-label\" for=\"cb\">Choose:</label>\n  <div class=\"shiny-options-group\"></div>\n</div>"
+  noChoices <- checkboxGroupInput("cb", "Choose:")
+  choicesNull <- checkboxGroupInput("cb", "Choose:", choices = NULL)
+  choicesC <- checkboxGroupInput("cb", "Choose:", choices = c())
+  allChoicesNull <- checkboxGroupInput("cb", "Choose:", choices = NULL,
+    choiceNames = NULL, choiceValues = NULL)
+
+  expect_identical(noChoices, choicesNull)
+  expect_identical(noChoices, choicesC)
+  expect_identical(noChoices, allChoicesNull)
+
+  expect_true(grepl(fixed = TRUE, expected, format(noChoices)))
+})

--- a/tests/testthat/test-bootstrap.r
+++ b/tests/testthat/test-bootstrap.r
@@ -253,12 +253,14 @@ test_that("Choices need not be provided, can be NULL or c()", {
   expected <- "<div id=\"cb\" class=\"form-group shiny-input-checkboxgroup shiny-input-container\">\n  <label class=\"control-label\" for=\"cb\">Choose:</label>\n  <div class=\"shiny-options-group\"></div>\n</div>"
   noChoices <- checkboxGroupInput("cb", "Choose:")
   choicesNull <- checkboxGroupInput("cb", "Choose:", choices = NULL)
-  choicesC <- checkboxGroupInput("cb", "Choose:", choices = c())
+  choicesCharacter <- checkboxGroupInput("cb", "Choose:", choices = c())
+  choicesCharacter0 <- checkboxGroupInput("cb", "Choose:", choices = character(0))
   allChoicesNull <- checkboxGroupInput("cb", "Choose:", choices = NULL,
     choiceNames = NULL, choiceValues = NULL)
 
   expect_identical(noChoices, choicesNull)
-  expect_identical(noChoices, choicesC)
+  expect_identical(noChoices, choicesCharacter)
+  expect_identical(noChoices, choicesCharacter0)
   expect_identical(noChoices, allChoicesNull)
 
   expect_true(grepl(fixed = TRUE, expected, format(noChoices)))


### PR DESCRIPTION
So that we keep backward compatibility with Shiny < 1.0.1 

Fixes #1649.