### PR TITLE
Give each ReactiveVal separate dependents

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,8 @@ shiny 1.0.3.9000
 
 Fixed [#1701](https://github.com/rstudio/shiny/issues/1701): There was a partial argument match in the `generateOptions` function. ([#1702](https://github.com/rstudio/shiny/pull/1702))
 
+Fixed [#1710](https://github.com/rstudio/shiny/issues/1710): `ReactiveVal` objects did not have separate dependents. ([#1712](https://github.com/rstudio/shiny/pull/1712))
+
 ### Library updates
 
 

--- a/R/reactives.R
+++ b/R/reactives.R
@@ -47,12 +47,13 @@ ReactiveVal <- R6Class(
     value = NULL,
     label = NULL,
     frozen = FALSE,
-    dependents = Dependents$new()
+    dependents = NULL
   ),
   public = list(
     initialize = function(value, label = NULL) {
       private$value <- value
       private$label <- label
+      private$dependents <- Dependents$new()
       .graphValueChange(private$label, value)
     },
     get = function() {

--- a/tests/testthat/test-reactivity.r
+++ b/tests/testthat/test-reactivity.r
@@ -41,6 +41,29 @@ test_that("ReactiveVal", {
   o$destroy()
 })
 
+test_that("ReactiveVals have independent dependencies", {
+  # Issue 1710
+  x <- reactiveVal(0)
+  y <- reactiveVal(0)
+
+  o <- observe({
+    y()
+  })
+
+  # The observer always fires the first time
+  x(1)
+  flushReact()
+  expect_equal(execCount(o), 1)
+
+  # Changing x again shouldn't invalidate the observer
+  x(2)
+  flushReact()
+  expect_equal(execCount(o), 1)
+
+  o$destroy()
+})
+
+
 test_that("ReactiveVal labels", {
   val <- reactiveVal()
   expect_equal(attr(val, "label", exact = TRUE), "val")


### PR DESCRIPTION
This fixes #1710. Previously, all `ReactiveVal` objects shared the same set of dependents (!!).

The `dependents <- Dependents$new()` needs to be assigned in the `initialize` method for each one to have its own set of dependents.