### PR TITLE
Don't send local package path to client when using htmlwidgets

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,8 @@ shiny 1.0.3.9000
 
 * Fixed [#1438](https://github.com/rstudio/shiny/issues/1438): `unbindAll()` should not be called when inserting content with `insertUI()`. A previous fix ([#1449](https://github.com/rstudio/shiny/pull/1449)) did not work correctly. ([#1736](https://github.com/rstudio/shiny/pull/1736))
 
+* Fixed [#1755](https://github.com/rstudio/shiny/issues/1755): dynamic htmlwidgets sent the path of the package on the server to the client. ([#1756](https://github.com/rstudio/shiny/pull/1756))
+
 ### Library updates
 
 

--- a/R/html-deps.R
+++ b/R/html-deps.R
@@ -25,6 +25,9 @@ createWebDependency <- function(dependency) {
     dependency$src$href <- prefix
   }
 
+  # Don't leak local file path to client
+  dependency$src$file <- NULL
+
   return(dependency)
 }
 

--- a/R/html-deps.R
+++ b/R/html-deps.R
@@ -6,13 +6,18 @@
 #' URL.
 #'
 #' @param dependency A single HTML dependency object, created using
-#'   \code{\link[htmltools]{htmlDependency}}. If the \code{src} value is named, then
-#'   \code{href} and/or \code{file} names must be present.
+#'   \code{\link[htmltools]{htmlDependency}}. If the \code{src} value is named,
+#'   then \code{href} and/or \code{file} names must be present.
+#' @param scrubFile If TRUE (the default), remove \code{src$file} for the
+#'   dependency. This prevents the local file path from being sent to the client
+#'   when dynamic web dependencies are used. If FALSE, don't remove
+#'   \code{src$file}. Setting it to FALSE should be needed only in very unusual
+#'   cases.
 #'
 #' @return A single HTML dependency object that has an \code{href}-named element
 #'   in its \code{src}.
 #' @export
-createWebDependency <- function(dependency) {
+createWebDependency <- function(dependency, scrubFile = TRUE) {
   if (is.null(dependency))
     return(NULL)
 
@@ -26,7 +31,8 @@ createWebDependency <- function(dependency) {
   }
 
   # Don't leak local file path to client
-  dependency$src$file <- NULL
+  if (scrubFile)
+    dependency$src$file <- NULL
 
   return(dependency)
 }

--- a/man/createWebDependency.Rd
+++ b/man/createWebDependency.Rd
@@ -4,12 +4,18 @@
 \alias{createWebDependency}
 \title{Create a web dependency}
 \usage{
-createWebDependency(dependency)
+createWebDependency(dependency, scrubFile = TRUE)
 }
 \arguments{
 \item{dependency}{A single HTML dependency object, created using
-\code{\link[htmltools]{htmlDependency}}. If the \code{src} value is named, then
-\code{href} and/or \code{file} names must be present.}
+\code{\link[htmltools]{htmlDependency}}. If the \code{src} value is named,
+then \code{href} and/or \code{file} names must be present.}
+
+\item{scrubFile}{If TRUE (the default), remove \code{src$file} for the
+dependency. This prevents the local file path from being sent to the client
+when dynamic web dependencies are used. If FALSE, don't remove
+\code{src$file}. Setting it to FALSE should be needed only in very unusual
+cases.}
 }
 \value{
 A single HTML dependency object that has an \code{href}-named element


### PR DESCRIPTION
This fixes #1755. I've tested this with a basic DT app and leaflet app. Both work fine, and don't send the local path name anymore.