### PR TITLE
Fix withPrivateSeed

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -82,8 +82,6 @@ Suggests:
     rmarkdown,
     ggplot2,
     magrittr
-Remotes:
-    rstudio/httpuv
 URL: http://shiny.rstudio.com
 BugReports: https://github.com/rstudio/shiny/issues
 Collate: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -83,7 +83,7 @@ Suggests:
     ggplot2,
     magrittr
 Remotes:
-    rstudio/httpuv@wch-getrngstate
+    rstudio/httpuv
 URL: http://shiny.rstudio.com
 BugReports: https://github.com/rstudio/shiny/issues
 Collate: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -64,7 +64,7 @@ Depends:
     methods
 Imports:
     utils,
-    httpuv (>= 1.3.3),
+    httpuv (>= 1.3.5),
     mime (>= 0.3),
     jsonlite (>= 0.9.16),
     xtable,
@@ -82,6 +82,8 @@ Suggests:
     rmarkdown,
     ggplot2,
     magrittr
+Remotes:
+    rstudio/httpuv@wch-getrngstate
 URL: http://shiny.rstudio.com
 BugReports: https://github.com/rstudio/shiny/issues
 Collate: 

--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,8 @@ shiny 1.0.3.9001
 
 * Fixed [#1755](https://github.com/rstudio/shiny/issues/1755): dynamic htmlwidgets sent the path of the package on the server to the client. ([#1756](https://github.com/rstudio/shiny/pull/1756))
 
+* Fixed [#1763](https://github.com/rstudio/shiny/issues/1763): Shiny's private random stream leaked out into the main random stream. ([#1768](https://github.com/rstudio/shiny/pull/1768))
+
 ### Library updates
 
 

--- a/R/globals.R
+++ b/R/globals.R
@@ -5,7 +5,7 @@
   # R's lazy-loading package scheme causes the private seed to be cached in the
   # package itself, making our PRNG completely deterministic. This line resets
   # the private seed during load.
-  withPrivateSeed(reinitializeSeed())
+  withPrivateSeed(set.seed(NULL))
 }
 
 .onAttach <- function(libname, pkgname) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -74,6 +74,9 @@ withPrivateSeed <- function(expr) {
     } else {
       rm(.Random.seed, envir = .GlobalEnv, inherits = FALSE)
     }
+    # Need to call this to make sure that the value of .Random.seed gets put
+    # into R's internal RNG state. (Issue #1763)
+    httpuv::getRNGState()
   })
 
   expr

--- a/R/utils.R
+++ b/R/utils.R
@@ -82,15 +82,6 @@ withPrivateSeed <- function(expr) {
   expr
 }
 
-# a homemade version of set.seed(NULL) for backward compatibility with R 2.15.x
-reinitializeSeed <- if (getRversion() >= '3.0.0') {
-  function() set.seed(NULL)
-} else function() {
-  if (exists('.Random.seed', globalenv()))
-    rm(list = '.Random.seed', pos = globalenv())
-  stats::runif(1)  # generate any random numbers so R can reinitialize the seed
-}
-
 # Version of runif that runs with private seed
 p_runif <- function(...) {
   withPrivateSeed(stats::runif(...))

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -52,6 +52,27 @@ test_that("Setting the private seed explicitly results in identical values", {
   expect_identical(id7, id8)
 })
 
+test_that("Private and 'public' random streams are independent and work the same", {
+  set.seed(0)
+  public <- c(runif(1), runif(1), runif(1))
+  withPrivateSeed(set.seed(0))
+  private <- c(withPrivateSeed(runif(1)), withPrivateSeed(runif(1)), withPrivateSeed(runif(1)))
+  expect_identical(public, private)
+
+  # Interleaved calls to runif() with private and public streams
+  set.seed(0)
+  withPrivateSeed(set.seed(0))
+  public  <- numeric()
+  private <- numeric()
+  public[1]  <- runif(1)
+  private[1] <- withPrivateSeed(runif(1))
+  private[2] <- withPrivateSeed(runif(1))
+  public[2]  <- runif(1)
+  public[3]  <- runif(1)
+  private[3] <- withPrivateSeed(runif(1))
+  expect_identical(public, private)
+})
+
 test_that("need() works as expected", {
 
   # These are all falsy


### PR DESCRIPTION
This prevents Shiny's private random seed from leaking out. It fixes #1763.

Some notes:
* I refactored `withPrivateSeed`, for two reasons:
  * The logic is more straightforward now. (sorry, @jcheng5)
  * The previous version called `withTemporary()`, and it only worked if the `httpuv::getRNGState()` call was moved into `withTemporary()` -- it did not work if `getRNGState()` was called from the `on.exit()` in `withPrivateSeed()`! But it didn't make sense to put that function in `withTemporary`, because that function shouldn't know about the RNG in particular.
* I bumped the httpuv version to one that isn't on CRAN yet. I added the repo and branch to the `Remotes` field. The branch name should be removed after rstudio/httpuv#73 is merged, and the `Remotes` field should be removed after httpuv is released to CRAN.
* The tests aren't exactly related this fix, but I thought it would be good to add them.
* I don't think it's possible to add tests for this fix without adding some Rcpp code to Shiny.