### PR TITLE
Don't reduce warn level when running app

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -45,6 +45,8 @@ shiny 1.0.3.9001
 
 * Fixed [#1763](https://github.com/rstudio/shiny/issues/1763): Shiny's private random stream leaked out into the main random stream. ([#1768](https://github.com/rstudio/shiny/pull/1768))
 
+* Fixed [#1680](https://github.com/rstudio/shiny/issues/1680): `options(warn=2)` was not respected when running an app. ([#1790](https://github.com/rstudio/shiny/pull/1790))
+
 ### Library updates
 
 

--- a/R/server.R
+++ b/R/server.R
@@ -577,7 +577,11 @@ runApp <- function(appDir=getwd(),
 
   # Make warnings print immediately
   # Set pool.scheduler to support pool package
-  ops <- options(warn = 1, pool.scheduler = scheduleTask)
+  ops <- options(
+    # Raise warn level to 1, but don't lower it
+    warn = max(1, getOption("warn", default = 1)),
+    pool.scheduler = scheduleTask
+  )
   on.exit(options(ops), add = TRUE)
 
   appParts <- as.shiny.appobj(appDir)


### PR DESCRIPTION
This fixes #1680.

Prior to this change, this app would print out a warning and keep running. After the change, it stops and gives the call stack frame selector:

```R
library(shiny)
options(shiny.error = recover, warn = 2)
shinyApp(
  fluidPage(),
  function(input, output) {
    observe({
      warning("foo")
    })
  }
)
```