### PR TITLE
work around RStudio debugger issue (closes #1474)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -49,6 +49,8 @@ shiny 1.0.3.9001
 
 * Fixed [#1680](https://github.com/rstudio/shiny/issues/1680): `options(warn=2)` was not respected when running an app. ([#1790](https://github.com/rstudio/shiny/pull/1790))
 
+* Fixed [#1474](https://github.com/rstudio/shiny/issues/1474): A `browser()` call in an observer could cause an error in the RStudio IDE on Windows. ([#1802](https://github.com/rstudio/shiny/pull/1802))
+
 ### Library updates
 
 

--- a/R/server.R
+++ b/R/server.R
@@ -1027,6 +1027,8 @@ inShinyServer <- function() {
   nzchar(Sys.getenv('SHINY_PORT'))
 }
 
+# This check was moved out of the main function body because of an issue with
+# the RStudio debugger. (#1474)
 isEmptyMessage <- function(msg) {
   identical(charToRaw("\003\xe9"), msg)
 }

--- a/R/server.R
+++ b/R/server.R
@@ -226,7 +226,7 @@ createAppHandlers <- function(httpHandlers, serverFuncSource) {
               message("RECV ", rawToChar(msg))
           }
 
-          if (identical(charToRaw("\003\xe9"), msg))
+          if (isEmptyMessage(msg))
             return()
 
           msg <- decodeMessage(msg)
@@ -1025,4 +1025,8 @@ browserViewer <- function(browser = getOption("browser")) {
 # otherwise returns FALSE.
 inShinyServer <- function() {
   nzchar(Sys.getenv('SHINY_PORT'))
+}
+
+isEmptyMessage <- function(msg) {
+  identical(charToRaw("\003\xe9"), msg)
 }


### PR DESCRIPTION
This PR works around an issue in the RStudio debugger, where our attempts to perform some function introspection can fail with certain byte sequences in the function body.

The underlying issue is similar to this:

```R
text <- "\003\xe9"
Encoding(text) <- "UTF-8"
gregexpr(text, "", fixed = TRUE)
```

In other words, RStudio is calling `gregexpr()` with this function's body as part of the debugger work, and that's failing.