### PR TITLE
Fix #1824: HEAD request on static files causes app to stop

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,8 @@ shiny 1.0.4.9000
 
 * Added a safe wrapper function for internal calls to `jsonlite::fromJSON()`. ([#1822](https://github.com/rstudio/shiny/pull/1822))
 
+* Fixed [#1824](https://github.com/rstudio/shiny/issues/1824): HTTP HEAD requests on static files caused the application to stop. ([#1825](https://github.com/rstudio/shiny/pull/1825))
+
 ### Library updates
 
 

--- a/R/middleware.R
+++ b/R/middleware.R
@@ -360,7 +360,9 @@ HandlerManager <- R6Class("HandlerManager",
 
           response <- filter(req, response)
           if (head_request) {
-            headers$`Content-Length` <- nchar(response$content, type = "bytes")
+
+            headers$`Content-Length` <- getResponseContentLength(response, deleteOwnedContent = TRUE)
+
             return(list(
               status = response$status,
               body = "",
@@ -382,6 +384,30 @@ HandlerManager <- R6Class("HandlerManager",
     }
   )
 )
+
+getResponseContentLength <- function(response, deleteOwnedContent) {
+  force(deleteOwnedContent)
+
+  result <- if (is.character(response$content)) {
+    nchar(response$content, type = "bytes")
+  } else if (is.raw(response$content)) {
+    length(response$content)
+  } else if (is.list(response$content) && !is.null(response$content$file)) {
+    if (deleteOwnedContent && isTRUE(response$content$owned)) {
+      on.exit(unlink(response$content$file, recursive = FALSE, force = FALSE), add = TRUE)
+    }
+    file.info(response$content$file)$size
+  } else {
+    warning("HEAD request for unexpected content class ", class(response$content)[[1]])
+    NULL
+  }
+
+  if (is.na(result)) {
+    return(NULL)
+  } else {
+    return(result)
+  }
+}
 
 #
 # ## Next steps

--- a/R/middleware.R
+++ b/R/middleware.R
@@ -385,10 +385,14 @@ HandlerManager <- R6Class("HandlerManager",
   )
 )
 
+# Safely get the Content-Length of a Rook response, or NULL if the length cannot
+# be determined for whatever reason (probably malformed response$content).
+# If deleteOwnedContent is TRUE, then the function should delete response
+# content that is of the form list(file=..., owned=TRUE).
 getResponseContentLength <- function(response, deleteOwnedContent) {
   force(deleteOwnedContent)
 
-  result <- if (is.character(response$content)) {
+  result <- if (is.character(response$content) && length(response$content) == 1) {
     nchar(response$content, type = "bytes")
   } else if (is.raw(response$content)) {
     length(response$content)
@@ -403,6 +407,7 @@ getResponseContentLength <- function(response, deleteOwnedContent) {
   }
 
   if (is.na(result)) {
+    # Mostly for missing file case
     return(NULL)
   } else {
     return(result)


### PR DESCRIPTION
The problem was that for HEAD requests specifically, we implement
an explicit Content-Length header (normally we let httpuv figure
out the Content-Length based on the content, but for HEAD we don't
return any content but still want to include the Content-Length).

The Content-Length header was only implemented correctly for string
values, not for raw vectors or file-by-path. This change implements
the value correctly for all currently valid httpuv content.