### PR TITLE
Reactlog scripting fix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,8 @@ shiny 1.0.5.9000
 
 ### Bug fixes
 
+* Changed script links for reactlog to use protocol relative URLs in order to avoid mixed content blocking by modern browsers.
+
 ### Library updates
 
 

--- a/inst/www/reactive-graph.html
+++ b/inst/www/reactive-graph.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js"></script>
-<script src="http://d3js.org/d3.v3.min.js" charset="utf-8"></script>
-<link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:200,400,600' rel='stylesheet' type='text/css'>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js"></script>
+<script src="//d3js.org/d3.v3.min.js" charset="utf-8"></script>
+<link href='//fonts.googleapis.com/css?family=Source+Sans+Pro:200,400,600' rel='stylesheet' type='text/css'>
 <style type="text/css">
 html, body {
   font-family: 'Source Sans Pro', sans-serif;


### PR DESCRIPTION
Modern browsers will block mixed content by default. 
This corrects the blocking issue when using reactlog with a Shiny or Rstudio server using TLS.