### PR TITLE
Revert back the relative position of the icon and title in tabPanel's and navbarMenu's

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,8 @@ shiny 1.0.5.9000
 
 * The internal `URLdecode()` function previously was a copy of `httpuv::decodeURIComponent()`, assigned at build time; now it invokes the httpuv function at run time.
 
+* Fixed [#1840](https://github.com/rstudio/shiny/issues/1840): with the release of Shiny 1.0.5, we accidently changed the relative positioning of the icon and the title text in `navbarMenu`s and `tabPanel`s. This fix reverts this behavior back (i.e. the icon should be to the left of the text and/or the downward arrow in case of `navbarMenu`s). ([#1848](https://github.com/rstudio/shiny/pull/1848))
+
 ### Library updates
 
 

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -883,8 +883,8 @@ buildTabItem <- function(index, tabsetId, foundSelected, tabs = NULL,
       tags$a(href = "#",
         class = "dropdown-toggle", `data-toggle` = "dropdown",
         `data-value` = divTag$menuName,
-        divTag$title, tags$b(class = "caret"),
-        getIcon(iconClass = divTag$iconClass)
+        getIcon(iconClass = divTag$iconClass),
+        divTag$title, tags$b(class = "caret")
       ),
       tabset$navList   # inner tabPanels items
     )
@@ -899,8 +899,8 @@ buildTabItem <- function(index, tabsetId, foundSelected, tabs = NULL,
                  href = paste("#", tabId, sep = ""),
                  `data-toggle` = "tab",
                  `data-value` = divTag$attribs$`data-value`,
-                 divTag$attribs$title,
-                 getIcon(iconClass = divTag$attribs$`data-icon-class`)
+                 getIcon(iconClass = divTag$attribs$`data-icon-class`),
+                 divTag$attribs$title
                )
     )
     # if this tabPanel is selected item, mark it active


### PR DESCRIPTION
Fixes #1840.

Ready for review and merging.