### PR TITLE
Avoid jQuery using eval() for dependency JS

### DIFF
--- a/srcjs/output_binding_html.js
+++ b/srcjs/output_binding_html.js
@@ -103,7 +103,10 @@ function renderDependency(dep) {
     var scripts = $.map(asArray(dep.script), function(scriptName) {
       return $("<script>").attr("src", href + "/" + encodeURI(scriptName));
     });
-    $head.append(scripts);
+    // avoid jQuery’s magic eval()
+    scripts.forEach(function(e) {
+      document.head.appendChild(e[0]);
+    });
   }
 
   if (dep.attachment) {


### PR DESCRIPTION
This allows to use debuggers for dependency code.