### PR TITLE
give host param to `runGitHub`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,7 @@ shiny 1.0.5.9000
 
 * Fixed [#1958](https://github.com/rstudio/shiny/issues/1958): Slider inputs previously displayed commas after a decimal point. ([#1960](https://github.com/rstudio/shiny/pull/1960))
 
+* Changed `runGitHub` to have a host param that defaults to the public host (https://github.com/)
 
 ### Bug fixes
 

--- a/R/run-url.R
+++ b/R/run-url.R
@@ -120,11 +120,11 @@ runGist <- function(gist, destdir = NULL, ...) {
 #' @param repo Name of the repository.
 #' @param username GitHub username. If \code{repo} is of the form
 #'   \code{"username/repo"}, \code{username} will be taken from \code{repo}.
+#' @param ref Desired git reference. Could be a commit, tag, or branch name.
+#'   Defaults to \code{"master"}.
 #' @param host GitHub host. Desired GitHub host should you want to use a
 #'   a GitHub Enterprise host. Defaults to public GitHub host
 #'   \code{"https://github.com/"}.
-#' @param ref Desired git reference. Could be a commit, tag, or branch name.
-#'   Defaults to \code{"master"}.
 #' @export
 #' @examples
 #' ## Only run this example in interactive R sessions
@@ -136,8 +136,8 @@ runGist <- function(gist, destdir = NULL, ...) {
 #'   runGitHub("shiny_example", "rstudio", subdir = "inst/shinyapp/")
 #' }
 runGitHub <- function(repo, username = getOption("github.user"),
-                      host = "https://github.com/", ref = "master",
-                      subdir = NULL, destdir = NULL, ...) {
+                      ref = "master", subdir = NULL, destdir = NULL,
+                      host = NULL, ...) {
 
   if (grepl('/', repo)) {
     res <- strsplit(repo, '/')[[1]]
@@ -145,6 +145,22 @@ runGitHub <- function(repo, username = getOption("github.user"),
     username <- res[1]
     repo     <- res[2]
   }
+
+  if (is.null(host)) {
+    host = "https://github.com/"
+  } else {
+
+    # ensure host ends with /
+    if (!grepl(".*/$", host)) {
+      host = paste(host, "/", sep = "")
+    }
+
+    # ensure host contains http protocol
+    if (!grepl("^https?://", host)) {
+      host = paste("https://", host, sep = "")
+    }
+  }
+
 
   url <- paste(host, username, "/", repo, "/archive/",
                ref, ".tar.gz", sep = "")

--- a/R/run-url.R
+++ b/R/run-url.R
@@ -120,6 +120,9 @@ runGist <- function(gist, destdir = NULL, ...) {
 #' @param repo Name of the repository.
 #' @param username GitHub username. If \code{repo} is of the form
 #'   \code{"username/repo"}, \code{username} will be taken from \code{repo}.
+#' @param host GitHub host. Desired GitHub host should you want to use a
+#'   a GitHub Enterprise host. Defaults to public GitHub host
+#'   \code{"https://github.com/"}.
 #' @param ref Desired git reference. Could be a commit, tag, or branch name.
 #'   Defaults to \code{"master"}.
 #' @export
@@ -133,7 +136,8 @@ runGist <- function(gist, destdir = NULL, ...) {
 #'   runGitHub("shiny_example", "rstudio", subdir = "inst/shinyapp/")
 #' }
 runGitHub <- function(repo, username = getOption("github.user"),
-                      ref = "master", subdir = NULL, destdir = NULL, ...) {
+                      host = "https://github.com/", ref = "master",
+                      subdir = NULL, destdir = NULL, ...) {
 
   if (grepl('/', repo)) {
     res <- strsplit(repo, '/')[[1]]
@@ -142,7 +146,7 @@ runGitHub <- function(repo, username = getOption("github.user"),
     repo     <- res[2]
   }
 
-  url <- paste("https://github.com/", username, "/", repo, "/archive/",
+  url <- paste(host, username, "/", repo, "/archive/",
                ref, ".tar.gz", sep = "")
 
   runUrl(url, subdir = subdir, destdir = destdir, ...)

--- a/man/runUrl.Rd
+++ b/man/runUrl.Rd
@@ -10,8 +10,9 @@ runUrl(url, filetype = NULL, subdir = NULL, destdir = NULL, ...)
 
 runGist(gist, destdir = NULL, ...)
 
-runGitHub(repo, username = getOption("github.user"), ref = "master",
-  subdir = NULL, destdir = NULL, ...)
+runGitHub(repo, username = getOption("github.user"),
+  host = "https://github.com/", ref = "master", subdir = NULL,
+  destdir = NULL, ...)
 }
 \arguments{
 \item{url}{URL of the application.}
@@ -39,6 +40,10 @@ all valid values.}
 
 \item{username}{GitHub username. If \code{repo} is of the form
 \code{"username/repo"}, \code{username} will be taken from \code{repo}.}
+
+\item{host}{GitHub host. Desired GitHub host should you want to use a
+a GitHub Enterprise host. Defaults to public GitHub host
+\code{"https://github.com/"}.}
 
 \item{ref}{Desired git reference. Could be a commit, tag, or branch name.
 Defaults to \code{"master"}.}

--- a/man/runUrl.Rd
+++ b/man/runUrl.Rd
@@ -10,9 +10,8 @@ runUrl(url, filetype = NULL, subdir = NULL, destdir = NULL, ...)
 
 runGist(gist, destdir = NULL, ...)
 
-runGitHub(repo, username = getOption("github.user"),
-  host = "https://github.com/", ref = "master", subdir = NULL,
-  destdir = NULL, ...)
+runGitHub(repo, username = getOption("github.user"), ref = "master",
+  subdir = NULL, destdir = NULL, host = NULL, ...)
 }
 \arguments{
 \item{url}{URL of the application.}
@@ -41,12 +40,12 @@ all valid values.}
 \item{username}{GitHub username. If \code{repo} is of the form
 \code{"username/repo"}, \code{username} will be taken from \code{repo}.}
 
+\item{ref}{Desired git reference. Could be a commit, tag, or branch name.
+Defaults to \code{"master"}.}
+
 \item{host}{GitHub host. Desired GitHub host should you want to use a
 a GitHub Enterprise host. Defaults to public GitHub host
 \code{"https://github.com/"}.}
-
-\item{ref}{Desired git reference. Could be a commit, tag, or branch name.
-Defaults to \code{"master"}.}
 }
 \description{
 \code{runUrl()} downloads and launches a Shiny application that is hosted at


### PR DESCRIPTION
This will allow users that have shiny apps in github enterprise repos to be able to easily specify their enterprise host and use `runGitHub`