### PR TITLE
Avoid rounding errors in sliderInput

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,8 @@ shiny 1.0.5.9000
 
 * Addressed [#1859](https://github.com/rstudio/shiny/issues/1859): Server-side selectize is now significantly faster. (Thanks to @dselivanov [#1861](https://github.com/rstudio/shiny/pull/1861))
 
+* Fixed [#1006](https://github.com/rstudio/shiny/issues/1006): Slider inputs sometimes showed too many digits. ([#1956](https://github.com/rstudio/shiny/pull/1956))
+
 ### Bug fixes
 
 * The internal `URLdecode()` function previously was a copy of `httpuv::decodeURIComponent()`, assigned at build time; now it invokes the httpuv function at run time.

--- a/R/input-slider.R
+++ b/R/input-slider.R
@@ -88,20 +88,6 @@ sliderInput <- function(inputId, label, min, max, value, step = NULL,
 
   value <- restoreInput(id = inputId, default = value)
 
-  # If step is NULL, use heuristic to set the step size.
-  findStepSize <- function(min, max, step) {
-    if (!is.null(step)) return(step)
-
-    range <- max - min
-    # If short range or decimals, use continuous decimal with ~100 points
-    if (range < 2 || hasDecimals(min) || hasDecimals(max)) {
-      step <- pretty(c(min, max), n = 100)
-      step[2] - step[1]
-    } else {
-      1
-    }
-  }
-
   if (inherits(min, "Date")) {
     if (!inherits(max, "Date") || !inherits(value, "Date"))
       stop("`min`, `max`, and `value must all be Date or non-Date objects")
@@ -237,6 +223,28 @@ hasDecimals <- function(value) {
   truncatedValue <- round(value)
   return (!identical(value, truncatedValue))
 }
+
+
+# If step is NULL, use heuristic to set the step size.
+findStepSize <- function(min, max, step) {
+  if (!is.null(step)) return(step)
+
+  range <- max - min
+  # If short range or decimals, use continuous decimal with ~100 points
+  if (range < 2 || hasDecimals(min) || hasDecimals(max)) {
+    # Workaround for rounding errors (#1006): the intervals between the items
+    # returned by pretty() can have rounding errors. To avoid this, we'll use
+    # pretty() to find the min, max, and number of steps, and then use those
+    # values to calculate the step size.
+    pretty_steps <- pretty(c(min, max), n = 100)
+    n_steps <- length(pretty_steps) - 1
+    (max(pretty_steps) - min(pretty_steps)) / n_steps
+
+  } else {
+    1
+  }
+}
+
 
 #' @rdname sliderInput
 #'

--- a/tests/testthat/test-ui.R
+++ b/tests/testthat/test-ui.R
@@ -14,3 +14,10 @@ test_that("selectInput options are properly escaped", {
   expect_true(any(grepl("<option value=\"&#39;\">", si_str, fixed = TRUE)))
   expect_true(any(grepl("<optgroup label=\"&quot;Separators&quot;\">", si_str, fixed = TRUE)))
 })
+
+
+# For issue #1006
+test_that("sliderInput steps don't have rounding errors", {
+  # Need to use expect_identical; expect_equal is too forgiving of rounding error
+  expect_identical(findStepSize(-5.5, 4, NULL), 0.1)
+})


### PR DESCRIPTION
This fixes #1006.

Before:


```R
sliderInput("slider2", "Slider", min = -4.36, max = 3.6, value = c(-4.36, 3.6))
# <div class="form-group shiny-input-container">
#   <label class="control-label" for="slider2">Slider</label>
#   <input class="js-range-slider" id="slider2" data-type="double" data-min="-4.36" 
# data-max="3.6" data-from="-4.36" data-to="3.6" data-step="0.0999999999999996" 
# data-grid="true" data-grid-num="9.95000000000004" data-grid-snap="false" 
# data-prettify-separator="," data-prettify-enabled="true" data-keyboard="true" 
# data-keyboard-step="1.25628140703517"  data-drag-interval="true" data-data-type="number"/>
# </div>
```

After:

```R
sliderInput("slider2", "Slider", min = -4.36, max = 3.6, value = c(-4.36, 3.6))
# <div class="form-group shiny-input-container">
#   <label class="control-label" for="slider2">Slider</label>
#   <input class="js-range-slider" id="slider2" data-type="double" data-min="-4.36" 
# data-max="3.6" data-from="-4.36" data-to="3.6" data-step="0.1" 
# data-grid="true" data-grid-num="9.95" data-grid-snap="false" 
# data-prettify-separator="," data-prettify-enabled="true" data-keyboard="true"
# data-keyboard-step="1.25628140703518" data-drag-interval="true" data-data-type="number"/>
```
