### PR TITLE
Fix URL-encoded bookmarking with date/date-time sliders

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,8 @@ shiny 1.0.5.9000
 
 * Fixed [#1840](https://github.com/rstudio/shiny/issues/1840): with the release of Shiny 1.0.5, we accidently changed the relative positioning of the icon and the title text in `navbarMenu`s and `tabPanel`s. This fix reverts this behavior back (i.e. the icon should be to the left of the text and/or the downward arrow in case of `navbarMenu`s). ([#1848](https://github.com/rstudio/shiny/pull/1848))
 
+* Fixed [#1600](https://github.com/rstudio/shiny/issues/1600): URL-encoded bookmarking did not work with sliders that had dates or date-times. ([#1961](https://github.com/rstudio/shiny/pull/1961))
+
 ### Library updates
 
 * Updated to ion.rangeSlider 2.2.0. ([#1955](https://github.com/rstudio/shiny/pull/1955))

--- a/R/input-slider.R
+++ b/R/input-slider.R
@@ -86,8 +86,6 @@ sliderInput <- function(inputId, label, min, max, value, step = NULL,
                     version = "0.10.2.2")
   }
 
-  value <- restoreInput(id = inputId, default = value)
-
   if (inherits(min, "Date")) {
     if (!inherits(max, "Date") || !inherits(value, "Date"))
       stop("`min`, `max`, and `value must all be Date or non-Date objects")
@@ -106,6 +104,21 @@ sliderInput <- function(inputId, label, min, max, value, step = NULL,
 
   } else {
     dataType <- "number"
+  }
+
+  # Restore bookmarked values here, after doing the type checking, because the
+  # restored value will be a character vector instead of Date or POSIXct, and we can do
+  # the conversion to correct type next.
+  value <- restoreInput(id = inputId, default = value)
+
+  if (is.character(value)) {
+    # If we got here, the value was restored from a URL-encoded bookmark.
+    if (dataType == "date") {
+      value <- as.Date(value, format = "%Y-%m-%d")
+    } else if (dataType == "datetime") {
+      # Date-times will have a format like "2018-02-28T03:46:26Z"
+      value <- as.POSIXct(value, format = "%Y-%m-%dT%H:%M:%SZ", tz = "UTC")
+    }
   }
 
   step <- findStepSize(min, max, step)


### PR DESCRIPTION
This fixes #1600.

Test app:

```R
library(shiny)

now <- Sys.time()
today <- Sys.Date()

ui <- function(request) {fluidPage(
  sliderInput("datetime", "Date-time",
    min = now, max = now + 10*3600, value = now + c(3, 4)*3600
  ),
  sliderInput("date", "Date",
    min = today, max = today + 10, value = today + 5
  ),
  verbatimTextOutput("values"),
  bookmarkButton()
)}

server <- function(input, output, server) {
  output$values <- renderText({
    paste(
      paste(input$datetime, collapse = ", "),
      input$date,
      sep = "\n"
    )
  })
}

shinyApp(ui, server, enableBookmarking = "url")
```