### PR TITLE
Improve error handling when `addResourcePath()` fails (especially for `runtime: shiny_prerendered` documents)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@ shiny 1.0.5.9000
 
 ### Minor new features and improvements
 
+* Improved the error handling inside the `addResourcePath()` function, to give end users more informative error messages when the `directoryPath` argument cannot be normalized. This is especially useful for `runtime: shiny_prerendered` Rmd documents, like `learnr` tutorials. [#1968](https://github.com/rstudio/shiny/pull/1968)
+
 * Changed script tags in reactlog ([inst/www/reactive-graph.html](https://github.com/rstudio/shiny/blob/master/inst/www/reactive-graph.html)) from HTTP to HTTPS in order to avoid mixed content blocking by most browsers. (Thanks, [@jekriske-lilly](https://github.com/jekriske-lilly)! [#1844](https://github.com/rstudio/shiny/pull/1844))
 
 * The version of Shiny is now accessible from Javascript, with `Shiny.version`. There is also a new function for comparing version strings, `Shiny.compareVersion()`. ([#1826](https://github.com/rstudio/shiny/pull/1826), [#1830](https://github.com/rstudio/shiny/pull/1830))

--- a/R/server.R
+++ b/R/server.R
@@ -62,7 +62,7 @@ addResourcePath <- function(prefix, directoryPath) {
          "please use a different prefix")
   }
 
-  directoryPath <- normalizePath(directoryPath, mustWork=TRUE)
+  directoryPath <- normalizePath(directoryPath, mustWork=FALSE)
 
   existing <- .globals$resources[[prefix]]
 

--- a/R/server.R
+++ b/R/server.R
@@ -53,21 +53,22 @@ registerClient <- function(client) {
 #' @export
 addResourcePath <- function(prefix, directoryPath) {
   prefix <- prefix[1]
-  if (!grepl('^[a-z0-9\\-_][a-z0-9\\-_.]*$', prefix, ignore.case=TRUE, perl=TRUE)) {
+  if (!grepl('^[a-z0-9\\-_][a-z0-9\\-_.]*$', prefix, ignore.case = TRUE, perl = TRUE)) {
     stop("addResourcePath called with invalid prefix; please see documentation")
   }
-
   if (prefix %in% c('shared')) {
     stop("addResourcePath called with the reserved prefix '", prefix, "'; ",
          "please use a different prefix")
   }
-
-  directoryPath <- normalizePath(directoryPath, mustWork=FALSE)
-
-  existing <- .globals$resources[[prefix]]
-
-  .globals$resources[[prefix]] <- list(directoryPath=directoryPath,
-                                       func=staticHandler(directoryPath))
+  tryCatch({
+    normalizedPath <- normalizePath(directoryPath, mustWork = TRUE)
+    .globals$resources[[prefix]] <- list(
+      directoryPath = normalizedPath,
+      func = staticHandler(normalizedPath)
+    )
+  },  error = function(e) {
+    stop("Couldn't normalize path ", directoryPath)
+  })
 }
 
 resourcePathHandler <- function(req) {

--- a/R/server.R
+++ b/R/server.R
@@ -60,15 +60,16 @@ addResourcePath <- function(prefix, directoryPath) {
     stop("addResourcePath called with the reserved prefix '", prefix, "'; ",
          "please use a different prefix")
   }
-  tryCatch({
-    normalizedPath <- normalizePath(directoryPath, mustWork = TRUE)
-    .globals$resources[[prefix]] <- list(
-      directoryPath = normalizedPath,
-      func = staticHandler(normalizedPath)
-    )
-  },  error = function(e) {
-    stop("Couldn't normalize path ", directoryPath)
-  })
+  normalizedPath <- tryCatch(normalizePath(directoryPath, mustWork = TRUE),
+    error = function(e) {
+      stop("Couldn't normalize path in `addResourcePath`, with arguments: ",
+        "`prefix` = '", prefix, "'; `directoryPath` = '" , directoryPath, "'")
+    }
+  )
+  .globals$resources[[prefix]] <- list(
+    directoryPath = normalizedPath,
+    func = staticHandler(normalizedPath)
+  )
 }
 
 resourcePathHandler <- function(req) {


### PR DESCRIPTION
A copy of Yihui's PR for rmarkdown (https://github.com/rstudio/rmarkdown/pull/1171/) to avoid the error `"Error in normalizePath: path[1]="": No such file or directory"` when running any tutorial.

In order the repro of the issue *and* the solution, you should have the latest CRAN versions of the following:

```r
install.packages("rmarkdown")
install.packages("learnr")
```

You can repro the issue with either the latest CRAN version, or the github master version of shiny:

```r
install.packages("shiny")   # OR
remotes::install_github("rstudio/shiny")
```

Then run any `leanr` tutorial (I just used the first learnr example from the package itself). Assuming you have the package cloned to some directory `learnr`, you can do the same through this one liner:

```r
rmarkdown::run("<__your_path_to_learnr__>/learnr/examples/00-setup/00-setup.Rmd")
```

That should result in a fatal problem, that causes the tutorial not to render at all:

![repro](https://user-images.githubusercontent.com/6527540/37076197-74bc29e0-21cd-11e8-8c8e-0eeffe582825.png)

If you restart your R session and install `shiny` from my new branch, the problem disappears:

```r
remotes::install_github("rstudio/shiny@barbara/learnr-compat")
rmarkdown::run("<__your_path_to_learnr__>/learnr/examples/00-setup/00-setup.Rmd")
```

![withshinyfix](https://user-images.githubusercontent.com/6527540/37076218-8d6b15dc-21cd-11e8-933f-12af98de4675.png)

---

I don't know how this was uncaught in the great battles of Pandoc 2 last year... But here's my rough thought process from today. After using a local build of shiny, the error message is a little more helpful, pointing to file & line `/shiny/R/server.R#782`:

![reprowithlocalshiny](https://user-images.githubusercontent.com/6527540/37076544-00d87464-21cf-11e8-8ccb-7d2e7afb540f.png)

Over in shiny land, line 782 is the beginning of a call to `..stacktraceoff..`. Instead of trying to understand that, I just did CMD + F for "normalizePath" and only found one call to it in that file. So I tried the same change as Yihui's PR https://github.com/rstudio/rmarkdown/pull/1171/, and to my complete befuddlement, it worked!

However, I worry, that the `mustWork=TRUE` arg was there for a reason and that we may need to wrap it in a conditional. I mostly still don't understand the nature of this bug. Any help is super appreciated, @jcheng5 or @wch!

