### PR TITLE
Lazily format stack traces

### DIFF
--- a/R/conditions.R
+++ b/R/conditions.R
@@ -136,7 +136,7 @@ createStackTracePromiseDomain <- function() {
       force(onFulfilled)
       # Subscription time
       if (deepStacksEnabled()) {
-        currentStack <- formatStackTrace(sys.calls())
+        currentStack <- sys.calls()
         currentDeepStack <- .globals$deepStack
       }
       function(...) {
@@ -157,7 +157,7 @@ createStackTracePromiseDomain <- function() {
       force(onRejected)
       # Subscription time
       if (deepStacksEnabled()) {
-        currentStack <- formatStackTrace(sys.calls())
+        currentStack <- sys.calls()
         currentDeepStack <- .globals$deepStack
       }
       function(...) {
@@ -265,7 +265,7 @@ printError <- function(cond,
     message(
       paste0(
         "From earlier call:\n",
-        paste0(st, collapse = "\n"),
+        paste0(formatStackTrace(st), collapse = "\n"),
         "\n"
       )
     )


### PR DESCRIPTION
With deep stack traces enabled, whenever then() is called, we need
to grab the current stack, just in case a downstream callback throws
an error and we need to form a deep stack trace.

Previously, we were calling formatStackTrace at the time that we
grab the current stack (i.e. no error has happened yet) because I
wasn't sure whether holding a reference to sys.calls() for a long
time was a good idea from a garbage collection perspective; would it
prevent the stack frame environments from being collected? But the
answer is no, sys.calls() is just calls, which can be confirmed with
.Internal(inspect(sys.calls()).

By deferring the formatStackTrace call to when we actually need to
print the stack trace, we save ourselves a ton of work--it turns out
it's quite expensive to format the stack traces, much more expensive
than sys.calls() alone.