### PR TITLE
Add new `autoclose = TRUE` param to dateInput() and dateRangeInput

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,8 @@ shiny 1.0.5.9000
 
 ### Minor new features and improvements
 
+* Added a new `autoclose = TRUE` parameter to `dateInput()` and `dateRangeInput()`. This closed [#1969](https://github.com/rstudio/shiny/issues/1969) which was a duplicate of much older issue, [#173](https://github.com/rstudio/shiny/issues/173). The default value is `TRUE` since that seems to be the common use case. However, this will cause existing apps with date inputs (that update to this version of Shiny) to have the datepicker be immediately closed once a date is selected. For most apps, this is actually desired behavior; if you wish to keep the datepicker open until the user clicks out of it use `autoclose = FALSE`. ([#1987](https://github.com/rstudio/shiny/pull/1987))
+
 * Improved the error handling inside the `addResourcePath()` function, to give end users more informative error messages when the `directoryPath` argument cannot be normalized. This is especially useful for `runtime: shiny_prerendered` Rmd documents, like `learnr` tutorials. ([#1968](https://github.com/rstudio/shiny/pull/1968))
 
 * Changed script tags in reactlog ([inst/www/reactive-graph.html](https://github.com/rstudio/shiny/blob/master/inst/www/reactive-graph.html)) from HTTP to HTTPS in order to avoid mixed content blocking by most browsers. (Thanks, [@jekriske-lilly](https://github.com/jekriske-lilly)! [#1844](https://github.com/rstudio/shiny/pull/1844))

--- a/R/input-date.R
+++ b/R/input-date.R
@@ -41,6 +41,8 @@
 #'   "nb", "nl-BE", "nl", "no", "pl", "pt-BR", "pt", "ro", "rs-latin", "rs",
 #'   "ru", "sk", "sl", "sq", "sr-latin", "sr", "sv", "sw", "th", "tr", "uk",
 #'   "vi", "zh-CN", and "zh-TW".
+#' @param autoclose Whether or not to close the datepicker immediately when a
+#'   date is selected.
 #'
 #' @family input elements
 #' @seealso \code{\link{dateRangeInput}}, \code{\link{updateDateInput}}
@@ -76,7 +78,7 @@
 #' @export
 dateInput <- function(inputId, label, value = NULL, min = NULL, max = NULL,
   format = "yyyy-mm-dd", startview = "month", weekstart = 0, language = "en",
-  width = NULL) {
+  width = NULL, autoclose = TRUE) {
 
   # If value is a date object, convert it to a string with yyyy-mm-dd format
   # Same for min and max
@@ -99,7 +101,8 @@ dateInput <- function(inputId, label, value = NULL, min = NULL, max = NULL,
                `data-date-start-view` = startview,
                `data-min-date` = min,
                `data-max-date` = max,
-               `data-initial-date` = value
+               `data-initial-date` = value,
+               `data-date-autoclose` = if (autoclose) "true" else "false"
     ),
     datePickerDependency
   )

--- a/R/input-daterange.R
+++ b/R/input-daterange.R
@@ -73,7 +73,8 @@
 #' @export
 dateRangeInput <- function(inputId, label, start = NULL, end = NULL,
     min = NULL, max = NULL, format = "yyyy-mm-dd", startview = "month",
-    weekstart = 0, language = "en", separator = " to ", width = NULL) {
+    weekstart = 0, language = "en", separator = " to ", width = NULL,
+    autoclose = TRUE) {
 
   # If start and end are date objects, convert to a string with yyyy-mm-dd format
   # Same for min and max
@@ -103,7 +104,8 @@ dateRangeInput <- function(inputId, label, start = NULL, end = NULL,
           `data-date-start-view` = startview,
           `data-min-date` = min,
           `data-max-date` = max,
-          `data-initial-date` = start
+          `data-initial-date` = start,
+          `data-date-autoclose` = if (autoclose) "true" else "false"
         ),
         span(class = "input-group-addon", separator),
         tags$input(
@@ -115,7 +117,8 @@ dateRangeInput <- function(inputId, label, start = NULL, end = NULL,
           `data-date-start-view` = startview,
           `data-min-date` = min,
           `data-max-date` = max,
-          `data-initial-date` = end
+          `data-initial-date` = end,
+          `data-date-autoclose` = if (autoclose) "true" else "false"
         )
       )
     ),

--- a/man/dateInput.Rd
+++ b/man/dateInput.Rd
@@ -6,7 +6,7 @@
 \usage{
 dateInput(inputId, label, value = NULL, min = NULL, max = NULL,
   format = "yyyy-mm-dd", startview = "month", weekstart = 0,
-  language = "en", width = NULL)
+  language = "en", width = NULL, autoclose = TRUE)
 }
 \arguments{
 \item{inputId}{The \code{input} slot that will be used to access the value.}
@@ -43,6 +43,9 @@ Other valid values include "ar", "az", "bg", "bs", "ca", "cs", "cy", "da",
 
 \item{width}{The width of the input, e.g. \code{'400px'}, or \code{'100\%'};
 see \code{\link{validateCssUnit}}.}
+
+\item{autoclose}{Whether or not to close the datepicker immediately when a
+date is selected.}
 }
 \description{
 Creates a text input which, when clicked on, brings up a calendar that

--- a/man/dateRangeInput.Rd
+++ b/man/dateRangeInput.Rd
@@ -6,7 +6,7 @@
 \usage{
 dateRangeInput(inputId, label, start = NULL, end = NULL, min = NULL,
   max = NULL, format = "yyyy-mm-dd", startview = "month", weekstart = 0,
-  language = "en", separator = " to ", width = NULL)
+  language = "en", separator = " to ", width = NULL, autoclose = TRUE)
 }
 \arguments{
 \item{inputId}{The \code{input} slot that will be used to access the value.}
@@ -49,6 +49,9 @@ Other valid values include "ar", "az", "bg", "bs", "ca", "cs", "cy", "da",
 
 \item{width}{The width of the input, e.g. \code{'400px'}, or \code{'100\%'};
 see \code{\link{validateCssUnit}}.}
+
+\item{autoclose}{Whether or not to close the datepicker immediately when a
+date is selected.}
 }
 \description{
 Creates a pair of text inputs which, when clicked on, bring up calendars that


### PR DESCRIPTION
Closes #1969 and its much older duplicate, closes #173. I also made this option the default, since that seems to be the common use case. Here's a demo app:

```r
library('shiny')

shinyApp(
  ui = fluidPage(
    dateInput("date1", label = "Autoclosing"), # new default
    dateInput("date2", label = "Manual closing", autoclose = FALSE),
    dateRangeInput("date3", label = "Autoclosing"), # new default
    dateRangeInput("date4", label = "Manual closing", autoclose = FALSE)
  ), 
  server = function(input, output, session) {}
)
```