### PR TITLE
Fix #2000: Implicit calls to xxxOutput not working inside modules

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -43,11 +43,11 @@ This is a significant release for Shiny, with a major new feature that was nearl
 
 * Improved the error handling inside the `addResourcePath()` function, to give end users more informative error messages when the `directoryPath` argument cannot be normalized. This is especially useful for `runtime: shiny_prerendered` Rmd documents, like `learnr` tutorials. ([#1968](https://github.com/rstudio/shiny/pull/1968))
 
-* Changed script tags in reactlog ([inst/www/reactive-graph.html](https://github.com/rstudio/shiny/blob/master/inst/www/reactive-graph.html)) from HTTP to HTTPS in order to avoid mixed content blocking by most browsers. (Thanks, [@jekriske-lilly](https://github.com/jekriske-lilly)! [#1844](https://github.com/rstudio/shiny/pull/1844))
+* Changed script tags in reactlog ([inst/www/reactive-graph.html](https://github.com/rstudio/shiny/blob/master/inst/www/reactive-graph.html)) from HTTP to HTTPS in order to avoid mixed content blocking by most browsers. (Thanks, @jekriske-lilly! [#1844](https://github.com/rstudio/shiny/pull/1844))
 
 * Addressed [#1784](https://github.com/rstudio/shiny/issues/1784): `runApp()` will avoid port 6697, which is considered unsafe by Chrome
 
-* Fixed [#2000](https://github.com/rstudio/shiny/issues/2000): Implicit calls to xxxOutput not working inside modules. ([#2010](https://github.com/rstudio/shiny/pull/2010))
+* Fixed [#2000](https://github.com/rstudio/shiny/issues/2000): Implicit calls to xxxOutput not working inside modules. (Thanks, @GregorDeCillia! [#2010](https://github.com/rstudio/shiny/pull/2010))
 
 ### Library updates
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -47,6 +47,8 @@ This is a significant release for Shiny, with a major new feature that was nearl
 
 * Addressed [#1784](https://github.com/rstudio/shiny/issues/1784): `runApp()` will avoid port 6697, which is considered unsafe by Chrome
 
+* Fixed [#2000](https://github.com/rstudio/shiny/issues/2000): Implicit calls to xxxOutput not working inside modules.
+
 ### Library updates
 
 * Updated to ion.rangeSlider 2.2.0. ([#1955](https://github.com/rstudio/shiny/pull/1955))

--- a/NEWS.md
+++ b/NEWS.md
@@ -47,7 +47,7 @@ This is a significant release for Shiny, with a major new feature that was nearl
 
 * Addressed [#1784](https://github.com/rstudio/shiny/issues/1784): `runApp()` will avoid port 6697, which is considered unsafe by Chrome
 
-* Fixed [#2000](https://github.com/rstudio/shiny/issues/2000): Implicit calls to xxxOutput not working inside modules.
+* Fixed [#2000](https://github.com/rstudio/shiny/issues/2000): Implicit calls to xxxOutput not working inside modules. ([#2010](https://github.com/rstudio/shiny/pull/2010))
 
 ### Library updates
 

--- a/R/shinywrappers.R
+++ b/R/shinywrappers.R
@@ -111,12 +111,15 @@ useRenderFunction <- function(renderFunc, inline = FALSE) {
   }
 
   id <- createUniqueId(8, "out")
-  # Make the id the first positional argument
-  outputArgs <- c(list(id), outputArgs)
 
   o <- getDefaultReactiveDomain()$output
-  if (!is.null(o))
+  if (!is.null(o)) {
     o[[id]] <- renderFunc
+    id <- getDefaultReactiveDomain()$ns(id)
+  }
+  
+  # Make the id the first positional argument
+  outputArgs <- c(list(id), outputArgs)
 
   if (is.logical(formals(outputFunction)[["inline"]]) && !("inline" %in% names(outputArgs))) {
     outputArgs[["inline"]] <- inline

--- a/R/shinywrappers.R
+++ b/R/shinywrappers.R
@@ -115,6 +115,7 @@ useRenderFunction <- function(renderFunc, inline = FALSE) {
   o <- getDefaultReactiveDomain()$output
   if (!is.null(o)) {
     o[[id]] <- renderFunc
+    # If there's a namespace, we must respect it
     id <- getDefaultReactiveDomain()$ns(id)
   }
   

--- a/tests/testthat/test-modules.R
+++ b/tests/testthat/test-modules.R
@@ -56,3 +56,14 @@ test_that("reactiveValues with namespace", {
   expect_equivalent(isolate(names(rv1)), c("baz", "qux-quux"))
   expect_equivalent(isolate(names(rv2)), c("quux"))
 })
+
+test_that("implicit output respects module namespace", {
+  output <- new.env(parent = emptyenv())
+  ns <- NS("test")
+  result <- withReactiveDomain(list(output = output, ns = ns),
+    as.tags(renderText("hi"))
+  )
+  # Does the automatically-generated output id include the correct namespace qualifier?
+  # (See issue #2000)
+  expect_equivalent(result$attribs$id, ns(ls(output)))
+})


### PR DESCRIPTION
I just forgot to have the implicit xxxOutput call respect namespaces.

See #2000 for the repro case. That code sample should be pasted into a new .Rmd file and run. With this patch applied, both buttons produce the same effect.