### PR TITLE
Fix #1989: Allow outputs to be removed by assigning NULL to them

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,8 @@ This is a significant release for Shiny, with a major new feature that was nearl
 
 * Addressed [#1859](https://github.com/rstudio/shiny/issues/1859): Server-side selectize is now significantly faster. (Thanks to @dselivanov [#1861](https://github.com/rstudio/shiny/pull/1861))
 
+* [#1989](https://github.com/rstudio/shiny/issues/1989): The server side of outputs can now be removed (e.g. `output$plot <- NULL`). This is not usually necessary but it does allow some objects to be garbage collected, which might matter if you are dynamically creating and destroying many outputs. (Thanks, @mmuurr! [#2011](https://github.com/rstudio/shiny/pull/2011))
+
 ### Bug fixes
 
 * Fixed [#1006](https://github.com/rstudio/shiny/issues/1006): Slider inputs sometimes showed too many digits. ([#1956](https://github.com/rstudio/shiny/pull/1956))

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -1024,9 +1024,16 @@ ShinySession <- R6Class(
       # name not working unless name was eagerly evaluated. Yikes!
       force(name)
 
-      # If overwriting an output object, suspend the previous copy of it
+      # If overwriting an output object, destroy the previous copy of it
       if (!is.null(private$.outputs[[name]])) {
-        private$.outputs[[name]]$suspend()
+        private$.outputs[[name]]$destroy()
+      }
+
+      if (is.null(func)) {
+        # If func is null, give it an "empty" output function so it can go
+        # through the logic below. If we simply returned at this point, the
+        # previous output (if any) would continue to show in the client.
+        func <- missingOutput
       }
 
       if (is.function(func)) {
@@ -2216,3 +2223,5 @@ ShinyServerTimingRecorder <- R6Class("ShinyServerTimingRecorder",
     }
   )
 )
+
+missingOutput <- function(...) req(FALSE)


### PR DESCRIPTION
Testing notes: Use repro case https://github.com/rstudio/shiny-examples/blob/master/130-output-null/app.R. It errors/crashes without this fix, works correctly with it.