### PR TITLE
Fix #2008: Allow eventReactive and observeEvent eventExprs to be async

### DIFF
--- a/R/conditions.R
+++ b/R/conditions.R
@@ -191,7 +191,7 @@ createStackTracePromiseDomain <- function() {
 }
 
 deepStacksEnabled <- function() {
-  getOption("shiny.deepstacktrace", FALSE)
+  getOption("shiny.deepstacktrace", TRUE)
 }
 
 doCaptureStack <- function(e) {


### PR DESCRIPTION
This makes it possible to monitor e.g. async reactive expressions.

In the process of fixing this, also discovered that observers don't
filter out shiny.silent.error (i.e. req(FALSE)) when they come back
from async operations. For example, this will kill the current
Shiny session instead of being ignored:

    observe({
      promise_resolve(TRUE) %...>%
        {req(FALSE)}
    })

This issue is also fixed in this commit.

### Testing notes

Test app at https://github.com/rstudio/shiny-examples/blob/master/132-async-events/app.R