### PR TITLE
Fix #2021: Memory leak with reactiveTimer and invalidateLater

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -51,6 +51,8 @@ This is a significant release for Shiny, with a major new feature that was nearl
 
 * Fixed [#2000](https://github.com/rstudio/shiny/issues/2000): Implicit calls to xxxOutput not working inside modules. (Thanks, @GregorDeCillia! [#2010](https://github.com/rstudio/shiny/pull/2010))
 
+* Fixed [#2021](https://github.com/rstudio/shiny/issues/2021): Memory leak with reactiveTimer and invalidateLater ([#2022](https://github.com/rstudio/shiny/pull/2022))
+
 ### Library updates
 
 * Updated to ion.rangeSlider 2.2.0. ([#1955](https://github.com/rstudio/shiny/pull/1955))

--- a/tests/testthat/test-timer.R
+++ b/tests/testthat/test-timer.R
@@ -37,3 +37,12 @@ test_that("Unscheduling works", {
   expect_identical(timerCallbacks$.times, origTimes)
   expect_identical(timerCallbacks$.funcs$keys(), origFuncKeys)
 })
+
+test_that("Vectorized unscheduling works", {
+  key1 <- timerCallbacks$schedule(1000, function() {})
+  key2 <- timerCallbacks$schedule(1000, function() {})
+  key3 <- timerCallbacks$schedule(1000, function() {})
+  
+  expect_identical(timerCallbacks$unschedule(key2), TRUE)
+  expect_identical(timerCallbacks$unschedule(c(key1, key2, key3)), c(TRUE, FALSE, TRUE))
+})

--- a/tests/testthat/test-timer.R
+++ b/tests/testthat/test-timer.R
@@ -23,3 +23,17 @@ test_that("Scheduling works", {
   expect_false(timerCallbacks$executeElapsed())
   expect_equal(0, nrow(timerCallbacks$takeElapsed()))
 })
+
+test_that("Unscheduling works", {
+  origTimes <- timerCallbacks$.times
+  origFuncKeys <- timerCallbacks$.funcs$keys()
+  
+  taskHandle <- scheduleTask(1000, function() {
+    message("Whatever")
+  })
+  # Unregister
+  taskHandle()
+  
+  expect_identical(timerCallbacks$.times, origTimes)
+  expect_identical(timerCallbacks$.funcs$keys(), origFuncKeys)
+})


### PR DESCRIPTION
`reactiveTimer` and `invalidateLater` had mechanisms to ensure they wouldn't have any effect once their owning sessions ended. But they didn't have anything in place to ensure that their closures could be garbage collected. This is because the underlying TimerCallbacks class I implemented way way back in the day, did not provide any way to truly unregister something that was scheduled for execution. This PR corrects that oversight and modifies `reactiveTimer` and `invalidateLater` to take advantage of that.

### Testing notes

See #2021 for repro apps.