### PR TITLE
Set default reactive domain when executing flushedCallbacks. Fixes #1975

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -1173,8 +1173,10 @@ ShinySession <- R6Class(
 
         # Schedule execution of onFlushed callbacks
         on.exit({
-          # ..stacktraceon matches with the top-level ..stacktraceoff..
-          private$flushedCallbacks$invoke(..stacktraceon = TRUE)
+          withReactiveDomain(self, {
+            # ..stacktraceon matches with the top-level ..stacktraceoff..
+            private$flushedCallbacks$invoke(..stacktraceon = TRUE)
+          })
         }, add = TRUE)
 
         if (!hasPendingUpdates()) {


### PR DESCRIPTION
This fixes #1975.