### PR TITLE
Fix #2037: With enableBookmarking="url", clientData is not available …

### DIFF
--- a/R/reactives.R
+++ b/R/reactives.R
@@ -1401,12 +1401,15 @@ reactiveTimer <- function(intervalMs=1000, session = getDefaultReactiveDomain())
     }
 
     timerHandle <<- scheduleTask(intervalMs, sys.function())
-    lapply(
-      dependents$values(),
-      function(dep.ctx) {
-        dep.ctx$invalidate()
-        NULL
-      })
+
+    session$cycleStartAction(function() {
+      lapply(
+        dependents$values(),
+        function(dep.ctx) {
+          dep.ctx$invalidate()
+          NULL
+        })
+    })
   })
 
   if (!is.null(session)) {

--- a/R/server.R
+++ b/R/server.R
@@ -279,7 +279,19 @@ createAppHandlers <- function(httpHandlers, serverFuncSource) {
                   shinysession$setShowcase(mode)
               }
 
-              shinysession$manageInputs(msg$data)
+              # In shinysession$createBookmarkObservers() above, observers may be
+              # created, which puts the shiny session in busyCount > 0 state. That
+              # prevents the manageInputs here from taking immediate effect, by
+              # default. The manageInputs here needs to take effect though, because
+              # otherwise the bookmark observers won't find the clientData they are
+              # looking for. So use `now = TRUE` to force the changes to be
+              # immediate.
+              #
+              # FIXME: break createBookmarkObservers into two separate steps, one
+              # before and one after manageInputs, and put the observer creation
+              # in the latter. Then add an assertion that busyCount == 0L when
+              # this manageInputs is called.
+              shinysession$manageInputs(msg$data, now = TRUE)
 
               # The client tells us what singletons were rendered into
               # the initial page


### PR DESCRIPTION
…when observers are first run

Also fixed reactiveTimer firing even while async tasks are active

**Testing notes:**

Please try these relevant apps from shiny-examples:

115-bookmarking-updatequerystring
133-async-hold-inputs (new!)
134-async-hold-timers (new!)