### PR TITLE
Fix #2061: Tests failing on Windows due to rounding errors

### DIFF
--- a/R/input-slider.R
+++ b/R/input-slider.R
@@ -250,7 +250,13 @@ findStepSize <- function(min, max, step) {
     # values to calculate the step size.
     pretty_steps <- pretty(c(min, max), n = 100)
     n_steps <- length(pretty_steps) - 1
-    (max(pretty_steps) - min(pretty_steps)) / n_steps
+    
+    # Fix for #2061: Windows has low-significance digits (like 17 digits out)
+    # even at the boundaries of pretty()'s output. Use signif(digits = 10),
+    # which should be way way less significant than any data we'd want to keep.
+    # It might make sense to use signif(steps[2] - steps[1], 10) instead, but
+    # for now trying to make the minimal change.
+    signif(digits = 10, (max(pretty_steps) - min(pretty_steps)) / n_steps)
 
   } else {
     1


### PR DESCRIPTION
### Testing notes

To repro, you have to be on Windows. I repro'd it on R 3.5.0.

1. `install.packages(c("devtools", "roxygen2", "shiny", "ggplot2", "testthat"))` as necessary
2. Clone the Shiny repo locally
3. In the Shiny repo, launch R (or open the project in RStudio) and run `devtools::test()`. You will get lots of stack traces printed, don't worry about that, it's just part of the tests. But at the end you will get 1 failing test as well, in test-ui.R.

With this fix, the tests should all pass.