### PR TITLE
runApp: add support for IPv6 addresses

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -65,7 +65,7 @@ Depends:
 Imports:
     utils,
     grDevices,
-    httpuv (>= 1.4.3),
+    httpuv (>= 1.4.3.9001),
     mime (>= 0.3),
     jsonlite (>= 0.9.16),
     xtable,
@@ -89,6 +89,8 @@ Suggests:
     magrittr
 URL: http://shiny.rstudio.com
 BugReports: https://github.com/rstudio/shiny/issues
+Remotes:
+    rstudio/httpuv
 Collate: 
     'app.R'
     'bookmark-state-local.R'


### PR DESCRIPTION
This fixes #2074. rstudio/httpuv#142 must be merged before this one.


This is what it looks like now when listening on the IPv6 address `::`:

![image](https://user-images.githubusercontent.com/86978/40504861-1fb5523c-5f58-11e8-9b5d-d5039bf32685.png)
