### PR TITLE
Wrap dir.create in dir.exists

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -901,9 +901,11 @@ ShinySession <- R6Class(
         # Create subdir for this scope
         if (!is.null(state$dir)) {
           scopeState$dir <- file.path(state$dir, namespace)
-          res <- dir.create(scopeState$dir)
-          if (res == FALSE) {
-            stop("Error creating subdirectory for scope ", namespace)
+          if(!dir.exists(scopeState$dir)){
+            res <- dir.create(scopeState$dir)
+            if (res == FALSE) {
+              stop("Error creating subdirectory for scope ", namespace)
+            }
           }
         }
 


### PR DESCRIPTION
Wrap dir.create in dir.exists to fix unwanted stop if directory already exists
Fixes #2093