### PR TITLE
Resolves #1935: Fix coordinate outputs when modifying outer margins

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@ shiny 1.1.0.9000
 
 * Addressed [#2042](https://github.com/rstudio/shiny/issues/2042): dates outside of `min`/`max` date range are now a lighter shade of grey to highlight the allowed range. [#2087](https://github.com/rstudio/shiny/pull/2087)
 
+* Resolved [#1935](https://github.com/rstudio/shiny/issues/1935): correctly returns plot coordinates when using outer margins. ([#2108](https://github.com/rstudio/shiny/pull/2108))
+
 ### Documentation Updates
 
 * Addressed [#1864](https://github.com/rstudio/shiny/issues/1864) by changing `optgroup` documentation to use `list` instead of `c`. [#2084](https://github.com/rstudio/shiny/pull/2084)

--- a/R/render-plot.R
+++ b/R/render-plot.R
@@ -425,10 +425,10 @@ getPrevPlotCoordmap <- function(width, height) {
     ),
     # The bounds of the plot area, in DOM pixels
     range = list(
-      left = graphics::grconvertX(usrBounds[1], 'user', 'nfc') * width,
-      right = graphics::grconvertX(usrBounds[2], 'user', 'nfc') * width,
-      bottom = (1-graphics::grconvertY(usrBounds[3], 'user', 'nfc')) * height - 1,
-      top = (1-graphics::grconvertY(usrBounds[4], 'user', 'nfc')) * height - 1
+      left = graphics::grconvertX(usrBounds[1], 'user', 'ndc') * width,
+      right = graphics::grconvertX(usrBounds[2], 'user', 'ndc') * width,
+      bottom = (1-graphics::grconvertY(usrBounds[3], 'user', 'ndc')) * height - 1,
+      top = (1-graphics::grconvertY(usrBounds[4], 'user', 'ndc')) * height - 1
     ),
     log = list(
       x = if (graphics::par('xlog')) 10 else NULL,


### PR DESCRIPTION
#1935 

Reproducible example: https://gist.github.com/tmastny/0e32a6945cd0ac2e234575f9c3beef2b
For a minimal example, see the issue.

The Gist is non-minimal, but it covers the following margin settings in `par`:

**Outer margins**
- oma
- omi
- omd

**Normal Margins**
- mar
- mai

Master currently fails on any outer margin change in `par`, but works for normal margins. 