### PR TITLE
DiskCache: use mtime instead of atime, check for time resolution

### DIFF
--- a/R/cache-disk.R
+++ b/R/cache-disk.R
@@ -99,18 +99,16 @@
 #'     \item{\code{"lru"}}{
 #'       Least Recently Used. The least recently used objects will be removed.
 #'       This uses the filesystem's mtime property. When "lru" is used, each
-#'       \code{get()} is called, it will update the files mtime. Some
-#'       filesystems have poor mtime resolution. HFS+, for example has
-#'       an mtime resolution of 1 second, and FAT has a resolution of 2 seconds.
-#'       The DiskCache will check for mtime resolution the first 10 times that
-#'       \code{get()} is called, and if the filesystem has poor time
-#'       resolution, a warning will be issued. (Note: atime is not used because
-#'       support for atime is even worse than mtime.)
+#'       \code{get()} is called, it will update the file's mtime.
 #'     }
 #'     \item{\code{"fifo"}}{
 #'       First-in-first-out. The oldest objects will be removed.
 #'     }
 #'   }
+#'
+#' Both of these policies use files' mtime. Note that some filesystems (notably
+#' FAT) have poor mtime resolution. (atime is not used because support for
+#' atime is worse than mtime.)
 #'
 #'
 #' @section Sharing among multiple processes:
@@ -213,11 +211,6 @@
 #'   \code{get()} results in a cache miss.
 #' @param logfile An optional filename or connection object to where logging
 #'   information will be written. To log to the console, use \code{stdout()}.
-#' @param min_mtime_resolution The minimum desired resolution (or granularity)
-#'   of the filesystem's mtime, in seconds (default is 1). If the filesystem's
-#'   mtime resolution is worse (larger), then the DiskCache will emit a
-#'   warning while it is being used. (The resolution is checked when
-#'   \code{$get()} is called.)
 #'
 #' @export
 diskCache <- function(
@@ -229,11 +222,10 @@ diskCache <- function(
   destroy_on_finalize = FALSE,
   missing = key_missing(),
   exec_missing = FALSE,
-  logfile = NULL,
-  min_mtime_resolution = 1)
+  logfile = NULL)
 {
   DiskCache$new(dir, max_size, max_age, max_n, evict, destroy_on_finalize,
-                missing, exec_missing, logfile, min_mtime_resolution)
+                missing, exec_missing, logfile)
 }
 
 
@@ -248,8 +240,7 @@ DiskCache <- R6Class("DiskCache",
       destroy_on_finalize = FALSE,
       missing = key_missing(),
       exec_missing = FALSE,
-      logfile = NULL,
-      min_mtime_resolution = 1)
+      logfile = NULL)
     {
       if (exec_missing && (!is.function(missing) || length(formals(missing)) == 0)) {
         stop("When `exec_missing` is true, `missing` must be a function that takes one argument.")
@@ -275,10 +266,8 @@ DiskCache <- R6Class("DiskCache",
       private$missing             <- missing
       private$exec_missing        <- exec_missing
       private$logfile             <- logfile
-      private$min_mtime_resolution<- min_mtime_resolution
 
       private$prune_last_time     <- as.numeric(Sys.time())
-      private$mtime_next_check_time  <- as.numeric(Sys.time())
     },
 
     get = function(key, missing = private$missing, exec_missing = private$exec_missing) {
@@ -296,7 +285,10 @@ DiskCache <- R6Class("DiskCache",
       read_error <- FALSE
       tryCatch(
         {
-          value <- private$read_rds(filename)
+          value <- suppressWarnings(readRDS(filename))
+          if (private$evict == "lru"){
+            Sys.setFileTime(filename, Sys.time())
+          }
         },
         error = function(e) {
           read_error <<- TRUE
@@ -420,9 +412,8 @@ DiskCache <- R6Class("DiskCache",
         }
       }
 
-      # Sort objects by priority, according to eviction policy. The sorting is
-      # done in a function which can be called multiple times but only does
-      # the work the first time.
+      # Sort objects by priority. The sorting is done in a function which can be
+      # called multiple times but only does the work the first time.
       info_is_sorted <- FALSE
       ensure_info_is_sorted <- function() {
         if (info_is_sorted) return()
@@ -516,87 +507,9 @@ DiskCache <- R6Class("DiskCache",
     missing = NULL,
     exec_missing = FALSE,
     logfile = NULL,
-    min_mtime_resolution = NULL,
 
     prune_throttle_counter = 0,
     prune_last_time = NULL,
-
-    mtime_next_check_time = NULL,
-    mtime_check_counter = 0,
-    mtime_support = NULL,     # NULL means unkown; changes to TRUE or FALSE after we know.
-
-    # This reads in a cached object, and, if needed, checks if the filesystem
-    # has sufficient mtime resolution. See
-    # https://gist.github.com/wch/9bc615c70219c7ac15f7b339ddd7a30d for
-    # mtime/ctime/atime tests.
-    read_rds = function(filename) {
-
-      if (private$evict == "lru" &&
-          is.null(private$mtime_support) &&
-          as.numeric(Sys.time()) > private$mtime_next_check_time)
-      {
-        # Record some times to check for mtime resolution
-        start <- as.numeric(Sys.time())
-        value <- suppressWarnings(readRDS(filename))
-        if (private$evict == "lru"){
-          # Updates the mtime, ctime, and atime. When examining file info, we
-          # use mtime, because it (I believe) it is supported on all
-          # platforms, and it has higher resolution than atime on some
-          # filesystems (like FAT). Note that on NTFS, this only reliably
-          # updates mtime.
-          Sys.setFileTime(filename, Sys.time())
-        }
-        file_mtime <- as.numeric(file.info(filename)[["mtime"]])
-        end <- as.numeric(Sys.time())
-
-        private$log(paste(
-          "Checking mtimes: start, file, end:",
-          paste(sprintf("%.6f", c(start, file_mtime, end)), collapse = " ")
-        ))
-
-        # Check that the file's mtime is within the start and end times, but
-        # expanded by private$min_mtime_resolution seconds on each side. If it
-        # fails this test, we know that the filesystem has worse than the
-        # desired mtime resolution. If it passes the test once, we can't be
-        # sure if the, so we'll run the test 10 times before we stop checking.
-        if (file_mtime < start - private$min_mtime_resolution ||
-            file_mtime > end   + private$min_mtime_resolution)
-        {
-          private$mtime_support <- FALSE
-          private$log("mtime support is FALSE")
-          mtime_difference <- max(abs(start - file_mtime), abs(end - file_mtime))
-
-          warning("DiskCache: eviction policy \"lru\" will not work correctly because filesystem for ",
-            private$dir, " does not support mtime, or has poor mtime resolution.",
-            " (Desired resolution: ", private$min_mtime_resolution,
-            ". Found mtime error of : ", round(mtime_difference, 3)
-          )
-
-        } else {
-          # Next check is a random time between 0s and the
-          # min_mtime_resolution from now. We don't check again right away
-          # because that might not be useful -- if we did this and the first
-          # 10 get()s happen right away, there's a good chance that if the
-          # first one passes due to luck, that they'll all pass.
-          private$mtime_next_check_time <- as.numeric(Sys.time()) + runif(1, max = private$min_mtime_resolution)
-          private$mtime_check_counter <- private$mtime_check_counter + 1
-
-          # After 10 passes, assume that mtime support works
-          if (private$mtime_check_counter >= 10) {
-            private$log("mtime support is TRUE")
-            private$mtime_support <- TRUE
-          }
-        }
-
-      } else {
-        value <- suppressWarnings(readRDS(filename))
-        if (private$evict == "lru"){
-          Sys.setFileTime(filename, Sys.time())
-        }
-      }
-
-      value
-    },
 
     key_to_filename = function(key) {
       validate_key(key)

--- a/man/diskCache.Rd
+++ b/man/diskCache.Rd
@@ -6,7 +6,8 @@
 \usage{
 diskCache(dir = NULL, max_size = 10 * 1024^2, max_age = Inf,
   max_n = Inf, evict = c("lru", "fifo"), destroy_on_finalize = FALSE,
-  missing = key_missing(), exec_missing = FALSE, logfile = NULL)
+  missing = key_missing(), exec_missing = FALSE, logfile = NULL,
+  min_mtime_resolution = 1)
 }
 \arguments{
 \item{dir}{Directory to store files for the cache. If \code{NULL} (the
@@ -48,6 +49,12 @@ as a value to return when \code{get()} results in a cache miss. If
 
 \item{logfile}{An optional filename or connection object to where logging
 information will be written. To log to the console, use \code{stdout()}.}
+
+\item{min_mtime_resolution}{The minimum desired resolution (or granularity)
+of the filesystem's mtime, in seconds (default is 1). If the filesystem's
+mtime resolution is worse (larger), then the DiskCache will emit a
+warning while it is being used. (The resolution is checked when
+\code{$get()} is called.)}
 }
 \description{
 A disk cache object is a key-value store that saves the values as files in a
@@ -152,10 +159,14 @@ policies are:
   \describe{
     \item{\code{"lru"}}{
       Least Recently Used. The least recently used objects will be removed.
-      This uses the filesystem's atime property. Some filesystems do not
-      support atime, or have a very low atime resolution. The DiskCache will
-      check for atime support, and if the filesystem does not support atime,
-      a warning will be issued and the "fifo" policy will be used instead.
+      This uses the filesystem's mtime property. When "lru" is used, each
+      \code{get()} is called, it will update the files mtime. Some
+      filesystems have poor mtime resolution. HFS+, for example has
+      an mtime resolution of 1 second, and FAT has a resolution of 2 seconds.
+      The DiskCache will check for mtime resolution the first 10 times that
+      \code{get()} is called, and if the filesystem has poor time
+      resolution, a warning will be issued. (Note: atime is not used because
+      support for atime is even worse than mtime.)
     }
     \item{\code{"fifo"}}{
       First-in-first-out. The oldest objects will be removed.
@@ -171,6 +182,12 @@ do this, each R process should have a DiskCache object that uses the same
 directory. Each DiskCache will do pruning independently of the others, so if
 they have different pruning parameters, then one DiskCache may remove cached
 objects before another DiskCache would do so.
+
+Even though it is possible for multiple processes to share a DiskCache
+directory, this should not be done on networked file systems, because of
+slow performance of networked file systems can cause problems. If you need
+a high-performance shared cache, you can use one built on a database like
+Redis, SQLite, mySQL, or similar.
 
 When multiple processes share a cache directory, there are some potential
 race conditions. For example, if your code calls \code{exists(key)} to check

--- a/man/diskCache.Rd
+++ b/man/diskCache.Rd
@@ -6,8 +6,7 @@
 \usage{
 diskCache(dir = NULL, max_size = 10 * 1024^2, max_age = Inf,
   max_n = Inf, evict = c("lru", "fifo"), destroy_on_finalize = FALSE,
-  missing = key_missing(), exec_missing = FALSE, logfile = NULL,
-  min_mtime_resolution = 1)
+  missing = key_missing(), exec_missing = FALSE, logfile = NULL)
 }
 \arguments{
 \item{dir}{Directory to store files for the cache. If \code{NULL} (the
@@ -49,12 +48,6 @@ as a value to return when \code{get()} results in a cache miss. If
 
 \item{logfile}{An optional filename or connection object to where logging
 information will be written. To log to the console, use \code{stdout()}.}
-
-\item{min_mtime_resolution}{The minimum desired resolution (or granularity)
-of the filesystem's mtime, in seconds (default is 1). If the filesystem's
-mtime resolution is worse (larger), then the DiskCache will emit a
-warning while it is being used. (The resolution is checked when
-\code{$get()} is called.)}
 }
 \description{
 A disk cache object is a key-value store that saves the values as files in a
@@ -160,18 +153,16 @@ policies are:
     \item{\code{"lru"}}{
       Least Recently Used. The least recently used objects will be removed.
       This uses the filesystem's mtime property. When "lru" is used, each
-      \code{get()} is called, it will update the files mtime. Some
-      filesystems have poor mtime resolution. HFS+, for example has
-      an mtime resolution of 1 second, and FAT has a resolution of 2 seconds.
-      The DiskCache will check for mtime resolution the first 10 times that
-      \code{get()} is called, and if the filesystem has poor time
-      resolution, a warning will be issued. (Note: atime is not used because
-      support for atime is even worse than mtime.)
+      \code{get()} is called, it will update the file's mtime.
     }
     \item{\code{"fifo"}}{
       First-in-first-out. The oldest objects will be removed.
     }
   }
+
+Both of these policies use files' mtime. Note that some filesystems (notably
+FAT) have poor mtime resolution. (atime is not used because support for
+atime is worse than mtime.)
 }
 
 \section{Sharing among multiple processes}{


### PR DESCRIPTION
EDIT: Based on a conversation with @jcheng5, we decided to just switch to mtime and not to mtime resolution checks. The worst seems to be FAT, with a resolution of 2s. FAT should be rare, and still sufficient for most use cases.

*****

Previously, the DiskCache would check that the filesystem has an atime (access time) resolution of 0.1 or better (smaller). This switches to use mtime, and as it runs, checks the mtime resolution.

One problem with that test is that a very common filesystem, HFS+, has an atime resolution of 1 second. The previous check required a blocking wait for 0.1 seconds to check for the 0.1s resolution; simply modifying that code to wait for 1 second could work, but that long of a delay is unacceptable.

Here's what I found about the atime resolution on various filesystems:

* APFS (new Macs): 1 ns
* HFS+ (older Macs): 1 second
* FAT: 1 day
* exFAT: 2 seconds (there are conflicting reports on the internet, but I tested this it be 2s on my Mac)
* NTFS: 100 ns, but according to documentation, "The NTFS file system delays update to the last access time for a file by up to one hour after the last access."
* ext4/btrfs/XFS,ZFS: 1 ns, but actual precision depends on kernel timer resolution.

mtime resolution is generally better. On HFS+, it is still 1s. On FAT, it is 2s, and on exFAT, it is 10ms.

This new version uses mtime instead of atime, and uses `Sys.setFileTime()` to change the mtime each time `get()` is called. It will check the mtime resolution 10 times; if it fails any of those times (mtime is greater than 1), then it will raise a warning. If it passes 10 times, then it stops checking.

The warning is:

```
Warning in private$read_rds(filename) :
  DiskCache: eviction policy "lru" will not work correctly because filesystem for /Volumes/FAT/dc does not support mtime, or has poor mtime resolution. (Desired resolution: 1. Found mtime error of : 1.484
```

On Linux, filesystems can be mounted with `noatime`, in which case the atime will be be set only when the file is created, and it will not change.

For testing on a Mac, I created disk images with Disk Utility, with File->New Image->Blank Image, using formats: FAT, exFAT, HFS+ (Mac OS Extended), APFS, giving each volume a name that is the same as the filesystem. Then I mounted those volume; they ended up mounted at /Volumes/FAT, /Volumes/exFAT, /Volumes/HFS, and so on. Then I ran the following code. The FAT and exFAT should raise warnings; HFS should not.

```R
# Default should not raise warning
dc <- DiskCache$new()
dc$set("a", 1)
for (i in 1:20) {
  dc$get("a")
  cat(".")
  Sys.sleep(runif(1, max = 1))
}


# HFS: should not raise warning
dc <- DiskCache$new("/Volumes/hfs/dc")
dc$set("a", 1)
for (i in 1:20) {
  dc$get("a")
  cat(".")
  Sys.sleep(runif(1, max = 1))
}

# FAT: should raise warning
dc <- DiskCache$new("/Volumes/FAT/dc")
dc$set("a", 1)
for (i in 1:20) {
  dc$get("a")
  cat(".")
  Sys.sleep(runif(1, max = 1))
}


# exFAT: should not raise warning
dc <- DiskCache$new("/Volumes/exFAT/dc")
dc$set("a", 1)
for (i in 1:20) {
  dc$get("a")
  cat(".")
  Sys.sleep(runif(1, max = 1))
}
```

On linux, whether a filesystem is mounted relatime or noatime, there should be no warnings. Here's code to check relatime and noatime filesystems:

```
# If running in docker, the container must be started with --privileged to mount the filesystem
# docker run --privileged --rm -ti wch1/r-debug 

# Create image, mount with noatime
dd if=/dev/zero of=/ext4.img bs=1M count=20
/sbin/mkfs.ext4 /ext4.img
mkdir -p /mnt/image
mount -o loop,noatime /ext4.img /mnt/image

RD
devtools::install_github("rstudio/shiny@diskcache-atime-check")
library(shiny)


dc <- diskCache()
dc$set("a", 1)
for (i in 1:20) {
  dc$get("a")
  cat(".")
  Sys.sleep(runif(1, max = 1))
}

dc <- diskCache("/mnt/image")
dc$set("a", 1)
for (i in 1:20) {
  dc$get("a")
  cat(".")
  Sys.sleep(runif(1, max = 1))
}

```


For reference, here's some information I found about testing atime/mtime/ctime support on various platforms:
https://gist.github.com/wch/9bc615c70219c7ac15f7b339ddd7a30d