### PR TITLE
Use xxhash64 instead of sha256 for hash algorithm

### DIFF
--- a/R/render-cached-plot.R
+++ b/R/render-cached-plot.R
@@ -436,7 +436,7 @@ renderCachedPlot <- function(expr,
         height <- fitDims$height
         pixelratio <- session$clientData$pixelratio %OR% 1
 
-        key <- digest::digest(list(outputName, userCacheKeyResult, width, height, res, pixelratio), "sha256")
+        key <- digest::digest(list(outputName, userCacheKeyResult, width, height, res, pixelratio), "xxhash64")
 
         plotObj <- cache$get(key)
 


### PR DESCRIPTION
On the advice of @jimhester and @hadley, this PR switches from SHA256 to xxHash64, because it's significantly faster:


```
> system.time(digest::digest(ggplot2::diamonds, "sha256"))
   user  system elapsed 
  0.042   0.002   0.046 
> system.time(digest::digest(ggplot2::diamonds, "xxhash64"))
   user  system elapsed 
  0.013   0.002   0.016 
```
