### PR TITLE
Fix width option for textAreaInput

### DIFF
--- a/R/input-textarea.R
+++ b/R/input-textarea.R
@@ -55,6 +55,7 @@ textAreaInput <- function(inputId, label, value = "", width = NULL, height = NUL
   if (length(style) == 0) style <- NULL
 
   div(class = "form-group shiny-input-container",
+    style = if (!is.null(width)) paste0("width: ", validateCssUnit(width), ";"),
     label %AND% tags$label(label, `for` = inputId),
     tags$textarea(
       id = inputId,


### PR DESCRIPTION
The style in the `textarea` inherits the styles of the parent div. Since the parent div has a `shiny-input-container` class with a specified width, the width option in the `textAreaInput` of the percent type doesn't work. 

This PR modifies the width in the parent div to make the width options declared as percentage work.