### PR TITLE
add domain to reactlog for context exit

### DIFF
--- a/R/graph.R
+++ b/R/graph.R
@@ -97,8 +97,8 @@ renderReactLog <- function(sessionToken = NULL, time = TRUE) {
   .graphAppend(list(action='enter', id=id))
 }
 
-.graphExitContext <- function(id) {
-  .graphAppend(list(action='exit', id=id))
+.graphExitContext <- function(id, domain) {
+  .graphAppend(list(action='exit', id=id), domain = domain)
 }
 
 .graphValueChange <- function(label, value) {

--- a/R/react.R
+++ b/R/react.R
@@ -43,7 +43,9 @@ Context <- R6Class(
         withReactiveDomain(.domain, {
           env <- .getReactiveEnvironment()
           .graphEnterContext(id)
-          on.exit(.graphExitContext(id), add = TRUE)
+          on.exit({
+            .graphExitContext(id, domain = .domain %OR% getDefaultReactiveDomain())
+          }, add = TRUE)
           env$runWith(self, func)
         })
       })

--- a/R/react.R
+++ b/R/react.R
@@ -44,7 +44,7 @@ Context <- R6Class(
           env <- .getReactiveEnvironment()
           .graphEnterContext(id)
           on.exit({
-            .graphExitContext(id, domain = .domain %OR% getDefaultReactiveDomain())
+            .graphExitContext(id, domain = (if (is.null(.domain)) getDefaultReactiveDomain() else .domain))
           }, add = TRUE)
           env$runWith(self, func)
         })


### PR DESCRIPTION
Fixes rstudio/shiny#2177

The domain being saved when the context was exiting is not properly saved when a top level context is exiting.  

The errors received in rstudio/shiny#2177 were due to a `NULL` session token. When only looking at a single session, this was not an issue.  When looking at the result of multiple sessions, either session would improperly capture the extra exits being generated in the global session space (when they are really session specific).

Regular, single session exit tokens done in a session only.  The default global domain token is not being captured properly, while the local `.domain$token` value is captured correctly.

```
$id
[1] "4"

$token
[1] "8af79d835e15cbc31cb8d28f2fe79cea"

$defaultToken
[1] "8af79d835e15cbc31cb8d28f2fe79cea"

$id
[1] "3"

$token
[1] "8af79d835e15cbc31cb8d28f2fe79cea"

$defaultToken
[1] "8af79d835e15cbc31cb8d28f2fe79cea"

$id
[1] "2"

$token
[1] "8af79d835e15cbc31cb8d28f2fe79cea"

$defaultToken
NULL

$id
[1] "5"

$token
[1] "8af79d835e15cbc31cb8d28f2fe79cea"

$defaultToken
NULL
```