### PR TITLE
Fix reactiveTimer error

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -51,6 +51,8 @@ This release features plot caching, an important new tool for improving performa
 
 * Fixed [#2225](https://github.com/rstudio/shiny/issues/2225): Input event queue can stall in apps that use async. [#2226](https://github.com/rstudio/shiny/pull/2226)
 
+* Fixed [#2228](https://github.com/rstudio/shiny/issues/2228): `reactiveTimer` fails when not owned by a session. Thanks, @P-Bettega! [#2229](https://github.com/rstudio/shiny/pull/2229)
+
 ### Documentation Updates
 
 * Addressed [#1864](https://github.com/rstudio/shiny/issues/1864) by changing `optgroup` documentation to use `list` instead of `c`. ([#2084](https://github.com/rstudio/shiny/pull/2084))

--- a/R/reactives.R
+++ b/R/reactives.R
@@ -1402,14 +1402,23 @@ reactiveTimer <- function(intervalMs=1000, session = getDefaultReactiveDomain())
 
     timerHandle <<- scheduleTask(intervalMs, sys.function())
 
-    session$cycleStartAction(function() {
+    doInvalidate <- function() {
       lapply(
         dependents$values(),
         function(dep.ctx) {
           dep.ctx$invalidate()
           NULL
         })
-    })
+    }
+
+    if (!is.null(session)) {
+      # If this timer belongs to a session, we must wait until the next cycle is
+      # ready to invalidate.
+      session$cycleStartAction(doInvalidate)
+    } else {
+      # If this timer doesn't belong to a session, we invalidate right away.
+      doInvalidate()
+    }
   })
 
   if (!is.null(session)) {


### PR DESCRIPTION
When reactiveTimer is created without a default reactive domain
(i.e. outside of a session, i.e. global) there's no session to
call cycleStartAction on. Instead, invalidation should proceed
right away.

Fixes #2228