### PR TITLE
Remove icon examples

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,10 @@ This release features plot caching, an important new tool for improving performa
 
 ## Full changelog
 
+### Breaking changes
+
+* The URL paths for FontAwesome CSS/JS/font assets have changed, due to our upgrade from FontAwesome 4 to 5. This shouldn't affect you unless you're using `www/index.html` to provide your UI and have hardcoded the old FontAwesome paths into your HTML. If that's you, consider switching to [HTML templates](https://shiny.rstudio.com/articles/templates.html), which give you the syntax of raw HTML while still taking advantage of Shiny's automatic management of web dependencies.
+
 ### New features
 
 * Added `renderCachedPlot()`, which stores plots in a cache so that they can be served up almost instantly. ([#1997](https://github.com/rstudio/shiny/pull/1997))

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -1508,10 +1508,6 @@ downloadLink <- function(outputId, label="Download", class=NULL, ...) {
 #'
 #'
 #' @examples
-#' icon("calendar")               # standard icon
-#' icon("calendar", "fa-3x")      # 3x normal size
-#' icon("cog", lib = "glyphicon") # From glyphicon library
-#'
 #' # add an icon to a submit button
 #' submitButton("Update View", icon = icon("refresh"))
 #'

--- a/man/icon.Rd
+++ b/man/icon.Rd
@@ -30,10 +30,6 @@ of a button, or as an icon for a \code{\link{tabPanel}} within a
 \code{\link{navbarPage}}.
 }
 \examples{
-icon("calendar")               # standard icon
-icon("calendar", "fa-3x")      # 3x normal size
-icon("cog", lib = "glyphicon") # From glyphicon library
-
 # add an icon to a submit button
 submitButton("Update View", icon = icon("refresh"))
 


### PR DESCRIPTION
These cause browser windows to pop up during R CMD check, which is
against CRAN policy. @wch will merge a PR that has other examples
once we release v1.2.