### PR TITLE
fix dependency version since htmltools 0.3.6 is used

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -70,7 +70,7 @@ Imports:
     jsonlite (>= 0.9.16),
     xtable,
     digest,
-    htmltools (>= 0.3.5),
+    htmltools (>= 0.3.6),
     R6 (>= 2.0),
     sourcetools,
     later (>= 0.7.2),


### PR DESCRIPTION
Close #2256 

Obviously up for discussion if the use of the `package` parameter in `htmlDependency` should be avoided or if this was caused by some other issue (it was unclear to me in the `htmltools` repo when the `package` parameter was added... it looks like it was not present in 0.3.5). Otherwise, we can just bump up the version of `htmltools` that is used.