### PR TITLE
Fix #2247: Async cached plots raise "Error in !: invalid argument type" error

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,19 @@
+shiny 1.2.0.9000
+================
+
+## Full changelog
+
+### Breaking changes
+
+### New features
+
+### Minor new features and improvements
+
+### Bug fixes
+
+* Fixed [#2247](https://github.com/rstudio/shiny/issues/2247): `renderCachedPlot` now supports using promises for either `expr` or `cacheKeyExpr`. (Shiny v1.2.0 supported async `expr`, but only if `cacheKeyExpr` was async as well; now you can use any combination of sync/async for `expr` and `cacheKeyExpr`.) [#2261](https://github.com/rstudio/shiny/pull/2261)
+
+
 shiny 1.2.0
 ===========
 


### PR DESCRIPTION
## Testing notes

Exhaustive test app here:
https://github.com/rstudio/shiny-examples/blob/master/143-async-plot-caching/app.R