### PR TITLE
Bookmarking: restore inputs that have a leading dot

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,8 @@ shiny 1.2.0.9001
 
 * Fixed [#2245](https://github.com/rstudio/shiny/issues/2245): `updateSelectizeInput()` did not update labels. ([#2248](https://github.com/rstudio/shiny/pull/2248))
 
+* Fixed [#2308](https://github.com/rstudio/shiny/issues/2308): When restoring a bookmarked application, inputs with a leading `.` would not be restored. ([#2311](https://github.com/rstudio/shiny/pull/2311))
+
 ### Documentation Updates
 
 * Fixed [#2247](https://github.com/rstudio/shiny/issues/2247): `renderCachedPlot` now supports using promises for either `expr` or `cacheKeyExpr`. (Shiny v1.2.0 supported async `expr`, but only if `cacheKeyExpr` was async as well; now you can use any combination of sync/async for `expr` and `cacheKeyExpr`.) [#2261](https://github.com/rstudio/shiny/pull/2261)

--- a/R/bookmark-state.R
+++ b/R/bookmark-state.R
@@ -426,7 +426,7 @@ RestoreInputSet <- R6Class("RestoreInputSet",
     },
 
     asList = function() {
-      as.list.environment(private$values)
+      as.list.environment(private$values, all.names = TRUE)
     }
   )
 )


### PR DESCRIPTION
Fixes #2308.

Test app:

```R
library(shiny)

ui <- function(req) {
  fluidPage(
    bookmarkButton(),
    numericInput(".n", "Number", min = 0, max = 100, value = 1)
  )
}

server <- function(input, output, session) { }

shinyApp(ui, server, enableBookmarking = "url")
```