### PR TITLE
Add constant time check for shared secret

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,8 @@ shiny 1.2.0.9001
 
 ### Minor new features and improvements
 
+* The `Shiny-Shared-Secret` security header is now checked using constant-time comparison to prevent timing attacks (thanks @dirkschumacher!). ([#2319](https://github.com/rstudio/shiny/pull/2319))
+
 ### Bug fixes
 
 * Fixed [#2245](https://github.com/rstudio/shiny/issues/2245): `updateSelectizeInput()` did not update labels. ([#2248](https://github.com/rstudio/shiny/pull/2248))

--- a/R/middleware.R
+++ b/R/middleware.R
@@ -328,13 +328,13 @@ HandlerManager <- R6Class("HandlerManager",
         }
       )
     },
-    .httpServer = function(handler, sharedSecret) {
+    .httpServer = function(handler, checkSharedSecret) {
       filter <- getOption('shiny.http.response.filter')
       if (is.null(filter))
         filter <- function(req, response) response
 
       function(req) {
-        if (!sharedSecret(req$HTTP_SHINY_SHARED_SECRET)) {
+        if (!checkSharedSecret(req$HTTP_SHINY_SHARED_SECRET)) {
           return(list(status=403,
             body='<h1>403 Forbidden</h1><p>Shared secret mismatch</p>',
             headers=list('Content-Type' = 'text/html')))

--- a/R/middleware.R
+++ b/R/middleware.R
@@ -321,7 +321,7 @@ HandlerManager <- R6Class("HandlerManager",
               }
             )
           },
-          getOption('shiny.sharedSecret')
+          loadSharedSecret()
         ),
         onWSOpen = function(ws) {
           return(wsHandlers$invoke(ws))
@@ -334,8 +334,7 @@ HandlerManager <- R6Class("HandlerManager",
         filter <- function(req, response) response
 
       function(req) {
-        if (!is.null(sharedSecret)
-          && !identical(sharedSecret, req$HTTP_SHINY_SHARED_SECRET)) {
+        if (!sharedSecret(req$HTTP_SHINY_SHARED_SECRET)) {
           return(list(status=403,
             body='<h1>403 Forbidden</h1><p>Shared secret mismatch</p>',
             headers=list('Content-Type' = 'text/html')))

--- a/R/server.R
+++ b/R/server.R
@@ -161,7 +161,7 @@ createAppHandlers <- function(httpHandlers, serverFuncSource) {
   # This value, if non-NULL, must be present on all HTTP and WebSocket
   # requests as the Shiny-Shared-Secret header or else access will be
   # denied (403 response for HTTP, and instant close for websocket).
-  sharedSecret <- loadSharedSecret()
+  checkSharedSecret <- loadSharedSecret()
 
   appHandlers <- list(
     http = joinHandlers(c(
@@ -170,7 +170,7 @@ createAppHandlers <- function(httpHandlers, serverFuncSource) {
       reactLogHandler
     )),
     ws = function(ws) {
-      if (!sharedSecret(ws$request$HTTP_SHINY_SHARED_SECRET)) {
+      if (!checkSharedSecret(ws$request$HTTP_SHINY_SHARED_SECRET)) {
         ws$close()
         return(TRUE)
       }

--- a/R/server.R
+++ b/R/server.R
@@ -161,7 +161,7 @@ createAppHandlers <- function(httpHandlers, serverFuncSource) {
   # This value, if non-NULL, must be present on all HTTP and WebSocket
   # requests as the Shiny-Shared-Secret header or else access will be
   # denied (403 response for HTTP, and instant close for websocket).
-  sharedSecret <- getOption('shiny.sharedSecret')
+  sharedSecret <- loadSharedSecret()
 
   appHandlers <- list(
     http = joinHandlers(c(
@@ -170,8 +170,7 @@ createAppHandlers <- function(httpHandlers, serverFuncSource) {
       reactLogHandler
     )),
     ws = function(ws) {
-      if (!is.null(sharedSecret)
-          && !identical(sharedSecret, ws$request$HTTP_SHINY_SHARED_SECRET)) {
+      if (!sharedSecret(ws$request$HTTP_SHINY_SHARED_SECRET)) {
         ws$close()
         return(TRUE)
       }

--- a/tests/testthat/test-options.R
+++ b/tests/testthat/test-options.R
@@ -64,6 +64,6 @@ test_that("Shared secret", {
   expect_false(checkSharedSecret("this is a secret string"))
   expect_false(checkSharedSecret("This is a secret string "))
   expect_false(checkSharedSecret(""))
-  expect_error(checkSharedSecret(NULL))
+  expect_false(checkSharedSecret(NULL))
   expect_error(checkSharedSecret(1:10))
 })

--- a/tests/testthat/test-options.R
+++ b/tests/testthat/test-options.R
@@ -51,3 +51,19 @@ test_that("Local options", {
   # Finish tests; reset shinyOptions
   shinyOptions(a = NULL)
 })
+
+test_that("Shared secret", {
+  op <- options(shiny.sharedSecret = "This is a secret string")
+  on.exit(options(op))
+
+  checkSharedSecret <- loadSharedSecret()
+
+  expect_true(checkSharedSecret("This is a secret string"))
+  expect_true(checkSharedSecret(charToRaw("This is a secret string")))
+
+  expect_false(checkSharedSecret("this is a secret string"))
+  expect_false(checkSharedSecret("This is a secret string "))
+  expect_false(checkSharedSecret(""))
+  expect_error(checkSharedSecret(NULL))
+  expect_error(checkSharedSecret(1:10))
+})


### PR DESCRIPTION
Here's an exaggerated test to show that comparing two raw vectors using `identical` isn't constant-time, but using `constantTimeEquals()` is:

```r
library(microbenchmark)

# Very long string
str1 <- paste0(rep(letters, 10000), collapse = "")
# Just the last character is different
str2 <- sub(".$", "1", str1, perl = TRUE)
# Just the first character is different
str3 <- sub("^.", "1", str1, perl = TRUE)

raw1 <- charToRaw(str1)
raw2 <- charToRaw(str2)
raw3 <- charToRaw(str3)

# These times are very different
microbenchmark(
  identical(raw1, raw2),
  identical(raw1, raw3)
)

# These times are very similar
microbenchmark(
  shiny:::constantTimeEquals(raw1, raw2),
  shiny:::constantTimeEquals(raw1, raw3)
)
```

## Testing notes

Should verify that:

1. Shiny Server (OS and Pro), Connect, ShinyApps.io all still work
2. Use Shiny Server OS or Pro to cause an R process to launch on localhost, then figure out what port it's listening on and try to access `https://localhost:port`; this should fail.