### PR TITLE
Exclude "session" from static path serving

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -65,7 +65,7 @@ Depends:
 Imports:
     utils,
     grDevices,
-    httpuv (>= 1.4.5.9001),
+    httpuv (>= 1.4.5.9004),
     mime (>= 0.3),
     jsonlite (>= 0.9.16),
     xtable,

--- a/R/app.R
+++ b/R/app.R
@@ -171,7 +171,9 @@ shinyAppDir_serverR <- function(appDir, options=list()) {
 
   wwwDir <- file.path.ci(appDir, "www")
   if (dirExists(wwwDir)) {
-    staticPaths <- list("/" = staticPath(wwwDir, indexhtml = FALSE, fallthrough = TRUE))
+    staticPaths <- list(
+      "/" = staticPath(wwwDir, indexhtml = FALSE, fallthrough = TRUE, exclude = "session")
+    )
   } else {
     staticPaths <- list()
   }
@@ -326,7 +328,9 @@ shinyAppDir_appR <- function(fileName, appDir, options=list())
     #
     # The call to staticPath normalizes the path, so that if the working dir
     # later changes, it will continue to point to the right place.
-    staticPaths <- list("/" = staticPath(wwwDir, indexhtml = FALSE, fallthrough = TRUE))
+    staticPaths <- list(
+      "/" = staticPath(wwwDir, indexhtml = FALSE, fallthrough = TRUE, exclude = "session")
+    )
   } else {
     staticPaths <- list()
   }

--- a/R/app.R
+++ b/R/app.R
@@ -90,12 +90,6 @@ shinyApp <- function(ui=NULL, server=NULL, onStart=NULL, options=list(),
     enableBookmarking(bookmarkStore)
   }
 
-  # Always handle /session URLs dynamically. This is useful just in case there
-  # is user code that adds "/" as a static path.
-  staticPaths <- list(
-    "/session" = excludeStaticPath()
-  )
-
   # Store the appDir and bookmarking-related options, so that we can read them
   # from within the app.
   shinyOptions(appDir = getwd())
@@ -103,7 +97,6 @@ shinyApp <- function(ui=NULL, server=NULL, onStart=NULL, options=list(),
 
   structure(
     list(
-      staticPaths = staticPaths,
       httpHandler = httpHandler,
       serverFuncSource = serverFuncSource,
       onStart = onStart,
@@ -176,14 +169,11 @@ shinyAppDir_serverR <- function(appDir, options=list()) {
     uiHandlerSource()(req)
   }
 
-  # Always handle /session URLs dynamically.
-  staticPaths <- list(
-    "/session" = excludeStaticPath()
-  )
-
   wwwDir <- file.path.ci(appDir, "www")
   if (dirExists(wwwDir)) {
-    staticPaths[["/"]] <- staticPath(wwwDir, indexhtml = FALSE, fallthrough = TRUE)
+    staticPaths <- list("/" = staticPath(wwwDir, indexhtml = FALSE, fallthrough = TRUE))
+  } else {
+    staticPaths <- list()
   }
 
   fallbackWWWDir <- system.file("www-dir", package = "shiny")
@@ -326,11 +316,6 @@ shinyAppDir_appR <- function(fileName, appDir, options=list())
     appObj()$serverFuncSource(...)
   }
 
-  # Always handle /session URLs dynamically.
-  staticPaths <- list(
-    "/session" = excludeStaticPath()
-  )
-
   wwwDir <- file.path.ci(appDir, "www")
   if (dirExists(wwwDir)) {
     # wwwDir is a static path served by httpuv. It does _not_ serve up
@@ -341,7 +326,9 @@ shinyAppDir_appR <- function(fileName, appDir, options=list())
     #
     # The call to staticPath normalizes the path, so that if the working dir
     # later changes, it will continue to point to the right place.
-    staticPaths[["/"]] <- staticPath(wwwDir, indexhtml = FALSE, fallthrough = TRUE)
+    staticPaths <- list("/" = staticPath(wwwDir, indexhtml = FALSE, fallthrough = TRUE))
+  } else {
+    staticPaths <- list()
   }
 
   fallbackWWWDir <- system.file("www-dir", package = "shiny")

--- a/R/app.R
+++ b/R/app.R
@@ -90,6 +90,12 @@ shinyApp <- function(ui=NULL, server=NULL, onStart=NULL, options=list(),
     enableBookmarking(bookmarkStore)
   }
 
+  # Always handle /session URLs dynamically. This is useful just in case there
+  # is user code that adds "/" as a static path.
+  staticPaths <- list(
+    "/session" = excludeStaticPath()
+  )
+
   # Store the appDir and bookmarking-related options, so that we can read them
   # from within the app.
   shinyOptions(appDir = getwd())
@@ -97,6 +103,7 @@ shinyApp <- function(ui=NULL, server=NULL, onStart=NULL, options=list(),
 
   structure(
     list(
+      staticPaths = staticPaths,
       httpHandler = httpHandler,
       serverFuncSource = serverFuncSource,
       onStart = onStart,
@@ -169,14 +176,14 @@ shinyAppDir_serverR <- function(appDir, options=list()) {
     uiHandlerSource()(req)
   }
 
+  # Always handle /session URLs dynamically.
+  staticPaths <- list(
+    "/session" = excludeStaticPath()
+  )
+
   wwwDir <- file.path.ci(appDir, "www")
   if (dirExists(wwwDir)) {
-    staticPaths <- list(
-      "/" = staticPath(wwwDir, indexhtml = FALSE, fallthrough = TRUE),
-      "/session" = excludeStaticPath()
-    )
-  } else {
-    staticPaths <- list()
+    staticPaths[["/"]] <- staticPath(wwwDir, indexhtml = FALSE, fallthrough = TRUE)
   }
 
   fallbackWWWDir <- system.file("www-dir", package = "shiny")
@@ -319,6 +326,11 @@ shinyAppDir_appR <- function(fileName, appDir, options=list())
     appObj()$serverFuncSource(...)
   }
 
+  # Always handle /session URLs dynamically.
+  staticPaths <- list(
+    "/session" = excludeStaticPath()
+  )
+
   wwwDir <- file.path.ci(appDir, "www")
   if (dirExists(wwwDir)) {
     # wwwDir is a static path served by httpuv. It does _not_ serve up
@@ -329,12 +341,7 @@ shinyAppDir_appR <- function(fileName, appDir, options=list())
     #
     # The call to staticPath normalizes the path, so that if the working dir
     # later changes, it will continue to point to the right place.
-    staticPaths <- list(
-      "/" = staticPath(wwwDir, indexhtml = FALSE, fallthrough = TRUE),
-      "/session" = excludeStaticPath()
-    )
-  } else {
-    staticPaths <- list()
+    staticPaths[["/"]] <- staticPath(wwwDir, indexhtml = FALSE, fallthrough = TRUE)
   }
 
   fallbackWWWDir <- system.file("www-dir", package = "shiny")

--- a/R/app.R
+++ b/R/app.R
@@ -172,7 +172,8 @@ shinyAppDir_serverR <- function(appDir, options=list()) {
   wwwDir <- file.path.ci(appDir, "www")
   if (dirExists(wwwDir)) {
     staticPaths <- list(
-      "/" = staticPath(wwwDir, indexhtml = FALSE, fallthrough = TRUE, exclude = "session")
+      "/" = staticPath(wwwDir, indexhtml = FALSE, fallthrough = TRUE),
+      "/session" = excludeStaticPath()
     )
   } else {
     staticPaths <- list()
@@ -329,7 +330,8 @@ shinyAppDir_appR <- function(fileName, appDir, options=list())
     # The call to staticPath normalizes the path, so that if the working dir
     # later changes, it will continue to point to the right place.
     staticPaths <- list(
-      "/" = staticPath(wwwDir, indexhtml = FALSE, fallthrough = TRUE, exclude = "session")
+      "/" = staticPath(wwwDir, indexhtml = FALSE, fallthrough = TRUE),
+      "/session" = excludeStaticPath()
     )
   } else {
     staticPaths <- list()

--- a/R/server.R
+++ b/R/server.R
@@ -393,6 +393,8 @@ startApp <- function(appObj, port, host, quiet) {
   httpuvApp$staticPaths <- c(
     appObj$staticPaths,
     list(
+      # Always handle /session URLs dynamically, even if / is a static path.
+      "session" = excludeStaticPath(),
       "shared" = system.file(package = "shiny", "www", "shared")
     ),
     .globals$resourcePaths


### PR DESCRIPTION
This fixes #2325. It depends on rstudio/httpuv#197.

To test:

```R
devtools::install_github("rstudio/httpuv@staticpath-exclude")
devtools::install_github("rstudio/shiny@staticpath-exclude")
```

Then run the test app from #2325. File uploads should now work.

![image](https://user-images.githubusercontent.com/86978/52685458-61014980-2f0f-11e9-8d26-235df99a07dc.png)
