### PR TITLE
Remove adding reactlog resource paths

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -86,7 +86,7 @@ Suggests:
     markdown,
     rmarkdown,
     ggplot2,
-    reactlog (>= 0.0.0.9002),
+    reactlog (>= 0.0.0.9003),
     magrittr
 URL: http://shiny.rstudio.com
 BugReports: https://github.com/rstudio/shiny/issues

--- a/R/middleware-shiny.R
+++ b/R/middleware-shiny.R
@@ -28,9 +28,6 @@ reactLogHandler <- function(req) {
     # `renderReactLog` will check/throw if reactlog doesn't exist
     reactlogFile <- renderReactlog(sessionToken)
 
-    # add asset path after reactlog has been calculated (makes sure package exists)
-    reactlog::reactlog_add_shiny_resource_paths()
-
     return(httpResponse(
       status = 200,
       content = list(


### PR DESCRIPTION
This is now being done within `reactlog::reactlog_render` (inside `reactlog::reactlog_show`)