### PR TITLE
Debounce short circuit

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+shiny 1.2.0.9002
+================
+
+### New features
+
+* Added functionality to short-circuit timers for debounce and throttle using a second reactive.
+
 shiny 1.2.0.9001
 ================
 

--- a/man/debounce.Rd
+++ b/man/debounce.Rd
@@ -6,10 +6,10 @@
 \title{Slow down a reactive expression with debounce/throttle}
 \usage{
 debounce(r, millis, priority = 100,
-  domain = getDefaultReactiveDomain())
+  domain = getDefaultReactiveDomain(), short_circuit = NULL)
 
 throttle(r, millis, priority = 100,
-  domain = getDefaultReactiveDomain())
+  domain = getDefaultReactiveDomain(), short_circuit = NULL)
 }
 \arguments{
 \item{r}{A reactive expression (that invalidates too often).}
@@ -24,6 +24,10 @@ these observers. Generally, this should be higher than the priorities of
 downstream observers and outputs (which default to zero).}
 
 \item{domain}{See \link{domains}.}
+
+\item{short_circuit}{An optional reactive that will short-circuit the
+timer. Use this to implement an action button that triggers recalculation
+immediately without waiting for the timer to run out.}
 }
 \description{
 Transforms a reactive expression by preventing its invalidation signals from


### PR DESCRIPTION
`debounce` and `throttle` were added to shiny 1.0.0. They're useful functions, but there's no way of short-circuiting the timer to implement, for example, an action button that immediately triggers output. I've added code to both functions that implements this by using an optional, second reactive. Example implementation:

```
library(shiny)
library(magrittr)

ui <- fluidPage(
  titlePanel("Old Faithful Geyser Data"),
  sidebarLayout(
    sidebarPanel(
      sliderInput("bins",
                  "Number of bins:",
                  min = 1,
                  max = 50,
                  value = 30),
      selectInput("column", "Column", colnames(faithful), selected = "waiting"),
      actionButton("redraw", "Redraw")
    ),
    mainPanel(
      plotOutput("distPlot")
    )
  )
)
server <- function(input, output, session) {
  reac <- reactive(list(bins = input$bins, column  = input$column)) %>% 
    debounce(5000, short_circuit = reactive(input$redraw))
  
  # Only triggered by the debounced reactive
  output$distPlot <- renderPlot({
    x    <- faithful[, reac()$column]
    bins <- seq(min(x), max(x), length.out = reac()$bins + 1)
    hist(x, breaks = bins, col = 'darkgray', border = 'white',
         main = sprintf("Histogram of %s", reac()$column))
  })
}
shinyApp(ui, server)

```