### PR TITLE
addResourcePath: create staticPath object immediately. Fixes #2339

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -70,7 +70,7 @@ addResourcePath <- function(prefix, directoryPath) {
   }
 
   # .globals$resourcePaths persists across runs of applications.
-  .globals$resourcePaths[[prefix]] <- normalizedPath
+  .globals$resourcePaths[[prefix]] <- staticPath(normalizedPath)
 }
 
 #' Define Server Functionality


### PR DESCRIPTION
This fixes #2339. It creates the `staticPath` object immediately (which in turn calls `normalizePath`, which is where the error occurs when the path is missing), instead of doing it when the application starts.