### PR TITLE
Short reactlog labels

### DIFF
--- a/R/graph.R
+++ b/R/graph.R
@@ -512,11 +512,15 @@ MessageLogger = R6Class(
       self$reactCache[[reactObj$reactId]] <- reactObj
     },
     shortenString = function(txt, n = 250) {
-      if (nchar(txt) > n) {
-        paste0(substr(txt, 1, n - 3), "...")
-      } else {
-        txt
+      if (is.na(txt) || is.null(txt)) {
+        return("")
       }
+      if (nchar(txt) > n) {
+        return(
+          paste0(substr(txt, 1, n - 3), "...")
+        )
+      }
+      return(txt)
     },
     singleLine = function(txt) {
       gsub("[^\\]\\n", "\\\\n", txt)

--- a/R/graph.R
+++ b/R/graph.R
@@ -512,7 +512,7 @@ MessageLogger = R6Class(
       self$reactCache[[reactObj$reactId]] <- reactObj
     },
     shortenString = function(txt, n = 250) {
-      if (is.na(txt) || is.null(txt)) {
+      if (is.null(txt) || isTRUE(is.na(txt))) {
         return("")
       }
       if (nchar(txt) > n) {

--- a/R/graph.R
+++ b/R/graph.R
@@ -511,7 +511,7 @@ MessageLogger = R6Class(
       if (identical(force, FALSE) && self$isNotLogging()) return(NULL)
       self$reactCache[[reactObj$reactId]] <- reactObj
     },
-    shortenString = function(txt, n = 100) {
+    shortenString = function(txt, n = 250) {
       if (nchar(txt) > n) {
         paste0(substr(txt, 1, n - 3), "...")
       } else {

--- a/R/graph.R
+++ b/R/graph.R
@@ -237,7 +237,7 @@ RLog <- R6Class(
       private$appendEntry(domain, list(
         action = "define",
         reactId = reactId,
-        label = label,
+        label = msg$shortenString(label),
         type = type,
         value = valueStr
       ))
@@ -294,7 +294,7 @@ RLog <- R6Class(
       private$appendEntry(domain, list(
         action = "createContext",
         ctxId = ctxId,
-        label = label,
+        label = msg$shortenString(label),
         type = type,
         prevCtxId = prevCtxId,
         srcref = as.vector(attr(label, "srcref")), srcfile=attr(label, "srcfile")


### PR DESCRIPTION
We were shortening the value, never the label until within reactlog.  Now it's shortened to 250 chars for all shortened strings.