### PR TITLE
Don't wrap text in verbatimTextOuput in Safari

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,9 @@ shiny 1.3.0.9000
 
 ### Bug fixes
 
+* Fixed [#2233](https://github.com/rstudio/shiny/issues/2233): `verbatimTextOutput()` produced wrapped text on Safari, but the text should not be wrapped. ([#2353](https://github.com/rstudio/shiny/pull/2353))
+
+
 ### Documentation Updates
 
 

--- a/inst/www/shared/shiny.css
+++ b/inst/www/shared/shiny.css
@@ -12,6 +12,13 @@ pre.shiny-text-output.noplaceholder:empty {
   height: 0;
 }
 
+/* Some browsers (like Safari) will wrap text in <pre> tags with Bootstrap's
+   CSS. This changes the behavior to not wrap.
+*/
+pre.shiny-text-output {
+  word-wrap: normal;
+}
+
 .shiny-image-output img.shiny-scalable, .shiny-plot-output img.shiny-scalable {
   max-width: 100%;
   max-height: 100%;


### PR DESCRIPTION
Fixes #2233.

This requires a NEWS update, but I'll hold off on that until after the upcoming Shiny release, to avoid a merge conflict.