### PR TITLE
Minimize `str` usage in `rlog$valueStr`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,7 @@ shiny 1.3.0.9000
 
 ### Bug fixes
 
-* Reduced the reactlog calculations being done when `options(shiny.reactlog = FALSE)` (default behavior). If reactlog is enabled, only the top level of `str` output is retrieved. This fixes a major performance bug introduced in v1.3.0 when using complex objects within Shiny. ([#2377](https://github.com/rstudio/shiny/pull/2377))
+* Fixed a performance issue introduced in v1.3.0 when using large nested lists within Shiny. ([#2377](https://github.com/rstudio/shiny/pull/2377))
 
 ### Documentation Updates
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@ shiny 1.3.0.9000
 
 ### Bug fixes
 
+* Reduced the reactlog calculations being done when `options(shiny.reactlog = FALSE)` (default behavior).  If reactlog is enabled, only the top level of `str` output is retrieved.  This fixes a major performance bug introduced in v1.3.0 when using complex objects within Shiny.  ([#2377](https://github.com/rstudio/shiny/pull/2377))
+
 ### Documentation Updates
 
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,7 @@ shiny 1.3.0.9000
 
 ### Bug fixes
 
-* Reduced the reactlog calculations being done when `options(shiny.reactlog = FALSE)` (default behavior).  If reactlog is enabled, only the top level of `str` output is retrieved.  This fixes a major performance bug introduced in v1.3.0 when using complex objects within Shiny.  ([#2377](https://github.com/rstudio/shiny/pull/2377))
+* Reduced the reactlog calculations being done when `options(shiny.reactlog = FALSE)` (default behavior). If reactlog is enabled, only the top level of `str` output is retrieved. This fixes a major performance bug introduced in v1.3.0 when using complex objects within Shiny. ([#2377](https://github.com/rstudio/shiny/pull/2377))
 
 ### Documentation Updates
 

--- a/R/graph.R
+++ b/R/graph.R
@@ -200,6 +200,10 @@ RLog <- R6Class(
     },
 
     valueStr = function(value, n = 200) {
+      if (!self$isLogging()) {
+        # return a placeholder string to avoid calling str
+        return("<reactlog is turned off>")
+      }
       output <- try(silent = TRUE, {
         utils::capture.output(utils::str(value))
       })

--- a/R/graph.R
+++ b/R/graph.R
@@ -205,7 +205,8 @@ RLog <- R6Class(
         return("<reactlog is turned off>")
       }
       output <- try(silent = TRUE, {
-        utils::capture.output(utils::str(value))
+        # only capture the first level of the object
+        utils::capture.output(utils::str(value, max.level = 1))
       })
       outputTxt <- paste0(output, collapse="\n")
       msg$shortenString(outputTxt, n = n)


### PR DESCRIPTION
Minimal fix for #2376.  A full fix will be needed after this is submitted to CRAN.


Testing Code

```r
  n <- 25
  obj <- lapply(1:n, function(i) {
    lapply(1:n, function(j) {
      lapply(1:n, function(k) {
        list(i, j, k)
      })
    })
  })
  system.time(capture.output(str(obj)))

  ui <- fluidPage(
    textOutput("txt")
  )


  server <- function(input, output) {
    r <- reactiveValues(x = 1)

    observe({
      r$x <- obj
    })

    output$txt <- renderText({
      length(r$x)
    })
  }

  library(profvis)
  profvis({
    # options(shiny.reactlog = TRUE)
    runApp(shinyApp(ui = ui, server = server))
  })
```

--------------------

Without reactlog enabled: (640 ms)
![Screen Shot 2019-04-10 at 1 34 01 PM](https://user-images.githubusercontent.com/93231/55900653-a780c680-5b95-11e9-925c-c2efb6ead2e4.png)

With reactlog enabled: (1500ms; ~500ms of GC)
![Screen Shot 2019-04-10 at 1 34 09 PM](https://user-images.githubusercontent.com/93231/55900670-b23b5b80-5b95-11e9-8205-c2b7af05379a.png)


With shiny v1.3.0 without reactlog enabled: (~30s)
![Screen Shot 2019-04-10 at 1 42 49 PM](https://user-images.githubusercontent.com/93231/55901052-95535800-5b96-11e9-860d-256e22ddfe55.png)
