### PR TITLE
Add fallthrough to shared/

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -454,7 +454,10 @@ startApp <- function(appObj, port, host, quiet) {
     list(
       # Always handle /session URLs dynamically, even if / is a static path.
       "session" = excludeStaticPath(),
-      "shared" = system.file(package = "shiny", "www", "shared")
+      "shared" = staticPath(
+        system.file(package = "shiny", "www", "shared"),
+        fallthrough = TRUE
+      )
     ),
     .globals$resourcePaths
   )


### PR DESCRIPTION
This adds fallthrough to `shared/`. The issue was reported here: https://community.rstudio.com/t/shiny-app-not-working-anymore/28971
