### PR TITLE
Fix issue with input rate policies

### DIFF
--- a/srcjs/input_rate.js
+++ b/srcjs/input_rate.js
@@ -298,6 +298,9 @@ var InputRateDecorator = function(target) {
 };
 (function() {
   this.setInput = function(name, value, opts) {
+    const input = splitInputNameType(name);
+    name = input.name;
+
     this.$ensureInit(name);
 
     if (opts.priority !== "deferred")

--- a/srcjs/input_rate.js
+++ b/srcjs/input_rate.js
@@ -297,6 +297,10 @@ var InputRateDecorator = function(target) {
   this.inputRatePolicies = {};
 };
 (function() {
+  // Note the 'public' methods setInput() and setRatePolicy() are passed
+  // both the input name (i.e., inputId) and the input type (i.e., the
+  // result of InputBinding.getType()). However, the 'private' methods
+  // are passed just the input name (i.e., inputId).
   this.setInput = function(name_type, value, opts) {
     const {name: inputName} = splitInputNameType(name_type);
 

--- a/srcjs/input_rate.js
+++ b/srcjs/input_rate.js
@@ -189,8 +189,8 @@ var InputBatchSender = function(shinyapp) {
   this.lastChanceCallback = [];
 };
 (function() {
-  this.setInput = function(name, value, opts) {
-    this.pendingData[name] = value;
+  this.setInput = function(name_type, value, opts) {
+    this.pendingData[name_type] = value;
 
     if (!this.reentrant) {
       if (opts.priority === "event") {
@@ -227,8 +227,8 @@ var InputNoResendDecorator = function(target, initialValues) {
   this.lastSentValues = this.reset(initialValues);
 };
 (function() {
-  this.setInput = function(name, value, opts) {
-    const { name: inputName, inputType: inputType } = splitInputNameType(name);
+  this.setInput = function(name_type, value, opts) {
+    const { name: inputName, inputType: inputType } = splitInputNameType(name_type);
     const jsonValue = JSON.stringify(value);
 
     if (opts.priority !== "event" &&
@@ -267,10 +267,10 @@ var InputEventDecorator = function(target) {
   this.target = target;
 };
 (function() {
-  this.setInput = function(name, value, opts) {
+  this.setInput = function(name_type, value, opts) {
     var evt = jQuery.Event("shiny:inputchanged");
 
-    const input = splitInputNameType(name);
+    const input = splitInputNameType(name_type);
     evt.name      = input.name;
     evt.inputType = input.inputType;
     evt.value     = value;
@@ -335,9 +335,9 @@ var InputDeferDecorator = function(target) {
   this.pendingInput = {};
 };
 (function() {
-  this.setInput = function(name, value, opts) {
-    if (/^\./.test(name))
-      this.target.setInput(name, value, opts);
+  this.setInput = function(name_type, value, opts) {
+    if (/^\./.test(name_type))
+      this.target.setInput(name_type, value, opts);
     else
       this.pendingInput[name] = { value, opts };
   };
@@ -356,13 +356,13 @@ const InputValidateDecorator = function(target) {
   this.target = target;
 };
 (function() {
-  this.setInput = function(name, value, opts) {
-    if (!name)
+  this.setInput = function(name_type, value, opts) {
+    if (!name_type)
       throw "Can't set input with empty name.";
 
     opts = addDefaultInputOpts(opts);
 
-    this.target.setInput(name, value, opts);
+    this.target.setInput(name_type, value, opts);
   };
 }).call(InputValidateDecorator.prototype);
 
@@ -391,8 +391,8 @@ function addDefaultInputOpts(opts) {
 }
 
 
-function splitInputNameType(name) {
-  const name2 = name.split(':');
+function splitInputNameType(name_type) {
+  const name2 = name_type.split(':');
   return {
     name:      name2[0],
     inputType: name2.length > 1 ? name2[1] : ''

--- a/srcjs/input_rate.js
+++ b/srcjs/input_rate.js
@@ -303,9 +303,9 @@ var InputRateDecorator = function(target) {
     this.$ensureInit(inputName);
 
     if (opts.priority !== "deferred")
-      this.inputRatePolicies[inputName].immediateCall(name_type, value, opts);
+      this.inputRatePolicies[inputName].immediateCall(inputName, value, opts);
     else
-      this.inputRatePolicies[inputName].normalCall(name_type, value, opts);
+      this.inputRatePolicies[inputName].normalCall(inputName, value, opts);
   };
   this.setRatePolicy = function(name_type, mode, millis) {
     const {name: inputName} = splitInputNameType(name_type);

--- a/srcjs/input_rate.js
+++ b/srcjs/input_rate.js
@@ -309,9 +309,9 @@ var InputRateDecorator = function(target) {
     this.$ensureInit(inputName);
 
     if (opts.priority !== "deferred")
-      this.inputRatePolicies[inputName].immediateCall(inputName, value, opts);
+      this.inputRatePolicies[inputName].immediateCall(nameType, value, opts);
     else
-      this.inputRatePolicies[inputName].normalCall(inputName, value, opts);
+      this.inputRatePolicies[inputName].normalCall(nameType, value, opts);
   };
   this.setRatePolicy = function(nameType, mode, millis) {
     const {name: inputName} = splitInputNameType(nameType);
@@ -330,8 +330,8 @@ var InputRateDecorator = function(target) {
     if (!(name in this.inputRatePolicies))
       this.setRatePolicy(name, 'direct');
   };
-  this.$doSetInput = function(name, value, opts) {
-    this.target.setInput(name, value, opts);
+  this.$doSetInput = function(nameType, value, opts) {
+    this.target.setInput(nameType, value, opts);
   };
 }).call(InputRateDecorator.prototype);
 

--- a/srcjs/input_rate.js
+++ b/srcjs/input_rate.js
@@ -297,38 +297,35 @@ var InputRateDecorator = function(target) {
   this.inputRatePolicies = {};
 };
 (function() {
-  this.setInput = function(name, value, opts) {
-    const input = splitInputNameType(name);
+  this.setInput = function(name_type, value, opts) {
+    const {name: inputName} = splitInputNameType(name_type);
 
-    this.$ensureInit(input.name);
+    this.$ensureInit(inputName);
 
     if (opts.priority !== "deferred")
-      this.inputRatePolicies[input.name].immediateCall(name, value, opts);
+      this.inputRatePolicies[inputName].immediateCall(name_type, value, opts);
     else
-      this.inputRatePolicies[input.name].normalCall(name, value, opts);
+      this.inputRatePolicies[inputName].normalCall(name_type, value, opts);
   };
-  this.setRatePolicy = function(name, mode, millis) {
-    const input = splitInputNameType(name);
+  this.setRatePolicy = function(name_type, mode, millis) {
+    const {name: inputName} = splitInputNameType(name_type);
 
     if (mode === 'direct') {
-      this.inputRatePolicies[input.name] = new Invoker(this, this.$doSetInput);
+      this.inputRatePolicies[inputName] = new Invoker(this, this.$doSetInput);
     }
     else if (mode === 'debounce') {
-      this.inputRatePolicies[input.name] = new Debouncer(this, this.$doSetInput, millis);
+      this.inputRatePolicies[inputName] = new Debouncer(this, this.$doSetInput, millis);
     }
     else if (mode === 'throttle') {
-      this.inputRatePolicies[input.name] = new Throttler(this, this.$doSetInput, millis);
+      this.inputRatePolicies[inputName] = new Throttler(this, this.$doSetInput, millis);
     }
   };
   this.$ensureInit = function(name) {
-    const input = splitInputNameType(name);
-
-    if (!(input.name in this.inputRatePolicies))
-      this.setRatePolicy(input.name, 'direct');
+    if (!(name in this.inputRatePolicies))
+      this.setRatePolicy(name, 'direct');
   };
   this.$doSetInput = function(name, value, opts) {
-    const input = splitInputNameType(name);
-    this.target.setInput(input.name, value, opts);
+    this.target.setInput(name, value, opts);
   };
 }).call(InputRateDecorator.prototype);
 

--- a/srcjs/input_rate.js
+++ b/srcjs/input_rate.js
@@ -299,32 +299,36 @@ var InputRateDecorator = function(target) {
 (function() {
   this.setInput = function(name, value, opts) {
     const input = splitInputNameType(name);
-    name = input.name;
 
-    this.$ensureInit(name);
+    this.$ensureInit(input.name);
 
     if (opts.priority !== "deferred")
-      this.inputRatePolicies[name].immediateCall(name, value, opts);
+      this.inputRatePolicies[input.name].immediateCall(name, value, opts);
     else
-      this.inputRatePolicies[name].normalCall(name, value, opts);
+      this.inputRatePolicies[input.name].normalCall(name, value, opts);
   };
   this.setRatePolicy = function(name, mode, millis) {
+    const input = splitInputNameType(name);
+
     if (mode === 'direct') {
-      this.inputRatePolicies[name] = new Invoker(this, this.$doSetInput);
+      this.inputRatePolicies[input.name] = new Invoker(this, this.$doSetInput);
     }
     else if (mode === 'debounce') {
-      this.inputRatePolicies[name] = new Debouncer(this, this.$doSetInput, millis);
+      this.inputRatePolicies[input.name] = new Debouncer(this, this.$doSetInput, millis);
     }
     else if (mode === 'throttle') {
-      this.inputRatePolicies[name] = new Throttler(this, this.$doSetInput, millis);
+      this.inputRatePolicies[input.name] = new Throttler(this, this.$doSetInput, millis);
     }
   };
   this.$ensureInit = function(name) {
-    if (!(name in this.inputRatePolicies))
-      this.setRatePolicy(name, 'direct');
+    const input = splitInputNameType(name);
+
+    if (!(input.name in this.inputRatePolicies))
+      this.setRatePolicy(input.name, 'direct');
   };
   this.$doSetInput = function(name, value, opts) {
-    this.target.setInput(name, value, opts);
+    const input = splitInputNameType(name);
+    this.target.setInput(input.name, value, opts);
   };
 }).call(InputRateDecorator.prototype);
 


### PR DESCRIPTION
See #2387 for a motivating example. In that example, the slider starts off with the correct `Debouncer` input rate policy, but when the slider is updated, it's policy changes to the default `Invoker` (i.e. immediate) rate policy. 

It seems this happens because `InputRateDecorators`'s `$ensureInit()` method is called with a `name` that contains *both* the input id and type. As a result, when the type of an input changes, it fails to look up the input rate policy and ends up defaulting to `Invoker()` instead.