### PR TITLE
Coordmap info should retain discrete limits

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 shiny 1.3.2.9000
 =======
 
+## Changes
+
+* Resolved ([#1433](https://github.com/rstudio/shiny/issues/1433)): `plotOutput()`'s coordmap info now includes discrete axis limits for **ggplot2** plots. As a result, any **shinytest** tests that contain **ggplot2** plots with discrete axes (that were recorded before this change) will now report differences that can safely be updated. This new coordmap info was added to correctly infer what data points are within an input brush and/or near input click/hover in scenarios where a non-trivial discrete axis scale is involved (e.g., whenever `scale_[x/y]_discrete(limits = ...)` and/or free scales across multiple discrete axes are used). ([#2410](https://github.com/rstudio/shiny/pull/2410))
+
 ### Improvements
 
 * Resolved ([#2402](https://github.com/rstudio/shiny/issues/2402)): An informative warning is now thrown for mis-specified (date) strings in `dateInput()`, `updateDateInput()`, `dateRangeInput()`, and `updateDateRangeInput()`. ([#2403](https://github.com/rstudio/shiny/pull/2403))

--- a/R/image-interact.R
+++ b/R/image-interact.R
@@ -278,8 +278,8 @@ nearPoints <- function(df, coordinfo, xvar = NULL, yvar = NULL,
     stop("nearPoints: `yvar` ('", yvar ,"')  not in names of input")
 
   # Extract data values from the data frame
-  x <- asNumber(df[[xvar]], coordinfo$domain$discrete_mapping$x)
-  y <- asNumber(df[[yvar]], coordinfo$domain$discrete_mapping$y)
+  x <- asNumber(df[[xvar]], coordinfo$domain$discrete_limits$x)
+  y <- asNumber(df[[yvar]], coordinfo$domain$discrete_limits$y)
 
   # Get the coordinates of the point (in img pixel coordinates)
   point_img <- coordinfo$coords_img
@@ -403,9 +403,10 @@ nearPoints <- function(df, coordinfo, xvar = NULL, yvar = NULL,
 # an input brush
 within_brush <- function(vals, brush, var = "x") {
   var <- match.arg(var, c("x", "y"))
-  vals <- asNumber(vals, brush$domain$discrete_mapping[[var]])
-  # At least when a discrete mapping is relevant,
-  # it's possible for the data values to not be
+  vals <- asNumber(vals, brush$domain$discrete_limits[[var]])
+  # It's possible for a non-missing data values to not
+  # map to the axis limits, for example:
+  # https://github.com/rstudio/shiny/pull/2410#issuecomment-488100881
   !is.na(vals) &
     vals >= brush[[paste0(var, "min")]] &
     vals <= brush[[paste0(var, "max")]]

--- a/R/image-interact.R
+++ b/R/image-interact.R
@@ -281,8 +281,8 @@ nearPoints <- function(df, coordinfo, xvar = NULL, yvar = NULL,
     stop("nearPoints: `yvar` ('", yvar ,"')  not in names of input")
 
   # Extract data values from the data frame
-  x <- asNumber(df[[xvar]])
-  y <- asNumber(df[[yvar]])
+  x <- asNumber(df[[xvar]], coordinfo$domain$xrange)
+  y <- asNumber(df[[yvar]], coordinfo$domain$yrange)
 
   # Get the coordinates of the point (in img pixel coordinates)
   point_img <- coordinfo$coords_img
@@ -406,8 +406,8 @@ nearPoints <- function(df, coordinfo, xvar = NULL, yvar = NULL,
 
 # Coerce various types of variables to numbers. This works for Date, POSIXt,
 # characters, and factors. Used because the mouse coords are numeric.
-asNumber <- function(x, map = NULL) {
-  if (length(map)) return(match(x, map))
+asNumber <- function(x, range = NULL) {
+  if (length(range)) return(match(x, range))
   if (is.character(x)) x <- as.factor(x)
   if (is.factor(x)) x <- as.integer(x)
   as.numeric(x)

--- a/R/image-interact.R
+++ b/R/image-interact.R
@@ -414,8 +414,12 @@ within_brush <- function(vals, brush, var = "x") {
 
 # Coerce various types of variables to numbers. This works for Date, POSIXt,
 # characters, and factors. Used because the mouse coords are numeric.
-asNumber <- function(x, range = NULL) {
-  if (length(range)) return(match(x, range))
+# The `levels` argument should be used when mapping this variable to
+# a known set of discrete levels, which is needed for ggplot2 since
+# it allows you to control ordering and possible values of a discrete
+# positional scale (#2410)
+asNumber <- function(x, levels = NULL) {
+  if (length(levels)) return(match(x, levels))
   if (is.character(x)) x <- as.factor(x)
   if (is.factor(x)) x <- as.integer(x)
   as.numeric(x)

--- a/R/image-interact.R
+++ b/R/image-interact.R
@@ -89,28 +89,16 @@ brushedPoints <- function(df, brush, xvar = NULL, yvar = NULL,
     if (!(xvar %in% names(df)))
       stop("brushedPoints: `xvar` ('", xvar ,"')  not in names of input")
     # Extract data values from the data frame
-    if ("xmap" %in% names(brush$domain)) {
-      xmap <- brush$domain$xmap
-      xmap_ <- xmap[xmap >= brush$xmin & xmap <= brush$xmax]
-      keep_rows <- keep_rows & (df[[xvar]] %in% names(xmap_))
-    } else {
-      x <- asNumber(df[[xvar]])
-      keep_rows <- keep_rows & (x >= brush$xmin & x <= brush$xmax)
-    }
+    x <- asNumber(df[[xvar]], brush$domain$xrange)
+    keep_rows <- keep_rows & (x >= brush$xmin & x <= brush$xmax)
   }
   if (use_y) {
     if (is.null(yvar))
       stop("brushedPoints: not able to automatically infer `yvar` from brush")
     if (!(yvar %in% names(df)))
       stop("brushedPoints: `yvar` ('", yvar ,"') not in names of input")
-    if ("ymap" %in% names(brush$domain)) {
-      ymap <- brush$domain$ymap
-      ymap_ <- ymap[ymap >= brush$xmin & ymap <= brush$xmax]
-      keep_rows <- keep_rows & (df[[xvar]] %in% names(ymap_))
-    } else {
-      y <- asNumber(df[[yvar]])
-      keep_rows <- keep_rows & (y >= brush$ymin & y <= brush$ymax)
-    }
+    y <- asNumber(df[[yvar]], brush$domain$yrange)
+    keep_rows <- keep_rows & (y >= brush$ymin & y <= brush$ymax)
   }
 
   # Find which rows are matches for the panel vars (if present)
@@ -418,7 +406,8 @@ nearPoints <- function(df, coordinfo, xvar = NULL, yvar = NULL,
 
 # Coerce various types of variables to numbers. This works for Date, POSIXt,
 # characters, and factors. Used because the mouse coords are numeric.
-asNumber <- function(x) {
+asNumber <- function(x, map = NULL) {
+  if (length(map)) return(match(x, map))
   if (is.character(x)) x <- as.factor(x)
   if (is.factor(x)) x <- as.integer(x)
   as.numeric(x)

--- a/R/image-interact.R
+++ b/R/image-interact.R
@@ -89,16 +89,28 @@ brushedPoints <- function(df, brush, xvar = NULL, yvar = NULL,
     if (!(xvar %in% names(df)))
       stop("brushedPoints: `xvar` ('", xvar ,"')  not in names of input")
     # Extract data values from the data frame
-    x <- asNumber(df[[xvar]])
-    keep_rows <- keep_rows & (x >= brush$xmin & x <= brush$xmax)
+    if ("xmap" %in% names(brush$domain)) {
+      xmap <- brush$domain$xmap
+      xmap_ <- xmap[xmap >= brush$xmin & xmap <= brush$xmax]
+      keep_rows <- keep_rows & (df[[xvar]] %in% names(xmap_))
+    } else {
+      x <- asNumber(df[[xvar]])
+      keep_rows <- keep_rows & (x >= brush$xmin & x <= brush$xmax)
+    }
   }
   if (use_y) {
     if (is.null(yvar))
       stop("brushedPoints: not able to automatically infer `yvar` from brush")
     if (!(yvar %in% names(df)))
       stop("brushedPoints: `yvar` ('", yvar ,"') not in names of input")
-    y <- asNumber(df[[yvar]])
-    keep_rows <- keep_rows & (y >= brush$ymin & y <= brush$ymax)
+    if ("ymap" %in% names(brush$domain)) {
+      ymap <- brush$domain$ymap
+      ymap_ <- ymap[ymap >= brush$xmin & ymap <= brush$xmax]
+      keep_rows <- keep_rows & (df[[xvar]] %in% names(ymap_))
+    } else {
+      y <- asNumber(df[[yvar]])
+      keep_rows <- keep_rows & (y >= brush$ymin & y <= brush$ymax)
+    }
   }
 
   # Find which rows are matches for the panel vars (if present)

--- a/R/render-plot.R
+++ b/R/render-plot.R
@@ -570,6 +570,9 @@ find_panel_info_api <- function(b) {
       domain$bottom <- -domain$bottom
     }
 
+    domain$xmap <- discrete_map(xscale)
+    domain$ymap <- discrete_map(yscale)
+
     domain
   }
 
@@ -688,6 +691,9 @@ find_panel_info_non_api <- function(b, ggplot_format) {
       domain$top    <- -domain$top
       domain$bottom <- -domain$bottom
     }
+
+    domain$xmap <- discrete_map(xscale)
+    domain$ymap <- discrete_map(yscale)
 
     domain
   }
@@ -994,4 +1000,17 @@ find_panel_ranges <- function(g, res) {
       top    = y_pos[p$t - 1]
     )
   })
+}
+
+# For free discrete positional scales, the inverse
+# mapping of 1, 2, 3, etc back to the original data
+# is potentially different for each panel. For example,
+# x=1 might map to "a" in the first panel, but it might
+# map to "b" in the second panel. To help workaround this,
+# we store a mapping from the 'trained' (numeric)
+# positional coordinates back to the original data scale
+discrete_map <- function(scale) {
+  if (!scale$is_discrete()) return(NULL)
+  rng <- scale$range$range
+  setNames(seq_along(rng), rng)
 }

--- a/R/render-plot.R
+++ b/R/render-plot.R
@@ -1002,10 +1002,17 @@ find_panel_ranges <- function(g, res) {
   })
 }
 
-# Remember the x/y range if it's a faceted
-# plot with a free discrete axis. This is necessary
-# to properly inverse map the numeric (i.e., trained)
-# positions back to the data scale (#2410)
+# Remember the x/y limits of discrete axes. This info is
+# necessary to properly inverse map the numeric (i.e., trained)
+# positions back to the data scale, for example:
+# https://github.com/rstudio/shiny/pull/2410#issuecomment-487783828
+# https://github.com/rstudio/shiny/pull/2410#issuecomment-488100881
+#
+# Eventually, we may want to consider storing the entire ggplot2
+# object server-side and querying information from that object
+# as we need it...that's the only way we'll ever be able to
+# faithfully brush examples like this:
+# https://github.com/rstudio/shiny/issues/2411
 add_discrete_limits <- function(domain, scale, var = "x") {
   var <- match.arg(var, c("x", "y"))
   if (scale$is_discrete()) {

--- a/R/render-plot.R
+++ b/R/render-plot.R
@@ -1041,8 +1041,9 @@ find_panel_ranges <- function(g, res) {
 # https://github.com/rstudio/shiny/issues/2411
 add_discrete_limits <- function(domain, scale, var = "x") {
   var <- match.arg(var, c("x", "y"))
+  if (!is.function(scale$is_discrete) || !is.function(scale$get_limits)) return(domain)
   if (scale$is_discrete()) {
-    domain$discrete_limits[[var]] <- scale$limits %OR% scale$range$range
+    domain$discrete_limits[[var]] <- scale$get_limits()
   }
   domain
 }

--- a/R/render-plot.R
+++ b/R/render-plot.R
@@ -570,16 +570,8 @@ find_panel_info_api <- function(b) {
       domain$bottom <- -domain$bottom
     }
 
-    # Remember the x/y range if it's a faceted
-    # plot with a free discrete axis. This is necessary
-    # to properly inverse map the numeric (i.e., trained)
-    # positions back to the data scale (#2410)
-    if (xscale$is_discrete()) {
-      domain$discrete_mapping$x <- (xscale$limits %OR% xscale$range$range)
-    }
-    if (yscale$is_discrete()) {
-      domain$discrete_mapping$y <- (yscale$limits %OR% yscale$range$range)
-    }
+    domain <- add_discrete_limits(domain, xscale, "x")
+    domain <- add_discrete_limits(domain, yscale, "y")
 
     domain
   }
@@ -700,16 +692,8 @@ find_panel_info_non_api <- function(b, ggplot_format) {
       domain$bottom <- -domain$bottom
     }
 
-    # Remember the x/y range if it's a faceted
-    # plot with a free discrete axis. This is necessary
-    # to properly inverse map the numeric (i.e., trained)
-    # positions back to the data scale (#2410)
-    if (xscale$is_discrete()) {
-      domain$discrete_mapping$x <- (xscale$limits %OR% xscale$range$range)
-    }
-    if (yscale$is_discrete()) {
-      domain$discrete_mapping$y <- (yscale$limits %OR% yscale$range$range)
-    }
+    domain <- add_discrete_limits(domain, xscale, "x")
+    domain <- add_discrete_limits(domain, yscale, "y")
 
     domain
   }
@@ -1016,4 +1000,16 @@ find_panel_ranges <- function(g, res) {
       top    = y_pos[p$t - 1]
     )
   })
+}
+
+# Remember the x/y range if it's a faceted
+# plot with a free discrete axis. This is necessary
+# to properly inverse map the numeric (i.e., trained)
+# positions back to the data scale (#2410)
+add_discrete_limits <- function(domain, scale, var = "x") {
+  var <- match.arg(var, c("x", "y"))
+  if (scale$is_discrete()) {
+    domain$discrete_limits[[var]] <- scale$limits %OR% scale$range$range
+  }
+  domain
 }

--- a/R/render-plot.R
+++ b/R/render-plot.R
@@ -574,11 +574,11 @@ find_panel_info_api <- function(b) {
     # plot with a free discrete axis. This is necessary
     # to properly inverse map the numeric (i.e., trained)
     # positions back to the data scale (#2410)
-    if (nrow(layout) > 1) {
-      free_x <- isTRUE(b$layout$facet$params$free$x)
-      free_y <- isTRUE(b$layout$facet$params$free$y)
-      if (free_x && xscale$is_discrete()) domain$xrange <- xscale$range$range
-      if (free_y && yscale$is_discrete()) domain$yrange <- yscale$range$range
+    if (xscale$is_discrete()) {
+      domain$discrete_mapping$x <- (xscale$limits %OR% xscale$range$range)
+    }
+    if (yscale$is_discrete()) {
+      domain$discrete_mapping$y <- (yscale$limits %OR% yscale$range$range)
     }
 
     domain
@@ -700,15 +700,8 @@ find_panel_info_non_api <- function(b, ggplot_format) {
       domain$bottom <- -domain$bottom
     }
 
-    # Remember the x/y range if it's a faceted
-    # plot with a free discrete axis. This is necessary
-    # to properly inverse map the numeric (i.e., trained)
-    # positions back to the data scale (#2410)
-    layout <- if (ggplot_format == "new") b$layout else b$panel$layout
-    if (nrow(layout) > 1) {
-      if (xscale$is_discrete()) domain$xrange <- xscale$range$range
-      if (yscale$is_discrete()) domain$yrange <- yscale$range$range
-    }
+    if (xscale$is_discrete()) domain$discrete_mapping$x <- xscale$limits
+    if (yscale$is_discrete()) domain$discrete_mapping$y <- yscale$limits
 
     domain
   }

--- a/R/render-plot.R
+++ b/R/render-plot.R
@@ -353,62 +353,88 @@ custom_print.ggplot <- function(x) {
 # With a faceted ggplot2 plot, the outer list contains two objects, each of
 # which represents one panel. In this example, there is one panelvar, but there
 # can be up to two of them.
-# mtc <- mtcars
-# mtc$am <- factor(mtc$am)
-# p <- print(ggplot(mtc, aes(wt, mpg)) + geom_point() + facet_wrap(~ am))
-# str(getGgplotCoordmap(p, 400, 300, 72))
+# p <- print(ggplot(mpg) + geom_point(aes(fl, cty), alpha = 0.2) + facet_wrap(~drv, scales = "free_x"))
+# str(getGgplotCoordmap(p, 500, 400, 72))
 # List of 2
-#  $ panels:List of 2
+#  $ panels:List of 3
 #   ..$ :List of 8
 #   .. ..$ panel     : num 1
 #   .. ..$ row       : int 1
 #   .. ..$ col       : int 1
 #   .. ..$ panel_vars:List of 1
-#   .. .. ..$ panelvar1: Factor w/ 2 levels "0","1": 1
+#   .. .. ..$ panelvar1: chr "4"
 #   .. ..$ log       :List of 2
 #   .. .. ..$ x: NULL
 #   .. .. ..$ y: NULL
-#   .. ..$ domain    :List of 4
-#   .. .. ..$ left  : num 1.32
-#   .. .. ..$ right : num 5.62
-#   .. .. ..$ bottom: num 9.22
-#   .. .. ..$ top   : num 35.1
+#   .. ..$ domain    :List of 5
+#   .. .. ..$ left           : num 0.4
+#   .. .. ..$ right          : num 4.6
+#   .. .. ..$ bottom         : num 7.7
+#   .. .. ..$ top            : num 36.3
+#   .. .. ..$ discrete_limits:List of 1
+#   .. .. .. ..$ x: chr [1:4] "d" "e" "p" "r"
 #   .. ..$ mapping   :List of 3
-#   .. .. ..$ x        : chr "wt"
-#   .. .. ..$ y        : chr "mpg"
-#   .. .. ..$ panelvar1: chr "am"
+#   .. .. ..$ x        : chr "fl"
+#   .. .. ..$ y        : chr "cty"
+#   .. .. ..$ panelvar1: chr "drv"
 #   .. ..$ range     :List of 4
 #   .. .. ..$ left  : num 33.3
-#   .. .. ..$ right : num 191
-#   .. .. ..$ bottom: num 328
+#   .. .. ..$ right : num 177
+#   .. .. ..$ bottom: num 448
 #   .. .. ..$ top   : num 23.1
 #   ..$ :List of 8
 #   .. ..$ panel     : num 2
 #   .. ..$ row       : int 1
 #   .. ..$ col       : int 2
 #   .. ..$ panel_vars:List of 1
-#   .. .. ..$ panelvar1: Factor w/ 2 levels "0","1": 2
+#   .. .. ..$ panelvar1: chr "f"
 #   .. ..$ log       :List of 2
 #   .. .. ..$ x: NULL
 #   .. .. ..$ y: NULL
-#   .. ..$ domain    :List of 4
-#   .. .. ..$ left  : num 1.32
-#   .. .. ..$ right : num 5.62
-#   .. .. ..$ bottom: num 9.22
-#   .. .. ..$ top   : num 35.1
+#   .. ..$ domain    :List of 5
+#   .. .. ..$ left           : num 0.4
+#   .. .. ..$ right          : num 5.6
+#   .. .. ..$ bottom         : num 7.7
+#   .. .. ..$ top            : num 36.3
+#   .. .. ..$ discrete_limits:List of 1
+#   .. .. .. ..$ x: chr [1:5] "c" "d" "e" "p" ...
 #   .. ..$ mapping   :List of 3
-#   .. .. ..$ x        : chr "wt"
-#   .. .. ..$ y        : chr "mpg"
-#   .. .. ..$ panelvar1: chr "am"
+#   .. .. ..$ x        : chr "fl"
+#   .. .. ..$ y        : chr "cty"
+#   .. .. ..$ panelvar1: chr "drv"
 #   .. ..$ range     :List of 4
-#   .. .. ..$ left  : num 197
-#   .. .. ..$ right : num 355
-#   .. .. ..$ bottom: num 328
+#   .. .. ..$ left  : num 182
+#   .. .. ..$ right : num 326
+#   .. .. ..$ bottom: num 448
+#   .. .. ..$ top   : num 23.1
+#   ..$ :List of 8
+#   .. ..$ panel     : num 3
+#   .. ..$ row       : int 1
+#   .. ..$ col       : int 3
+#   .. ..$ panel_vars:List of 1
+#   .. .. ..$ panelvar1: chr "r"
+#   .. ..$ log       :List of 2
+#   .. .. ..$ x: NULL
+#   .. .. ..$ y: NULL
+#   .. ..$ domain    :List of 5
+#   .. .. ..$ left           : num 0.4
+#   .. .. ..$ right          : num 3.6
+#   .. .. ..$ bottom         : num 7.7
+#   .. .. ..$ top            : num 36.3
+#   .. .. ..$ discrete_limits:List of 1
+#   .. .. .. ..$ x: chr [1:3] "e" "p" "r"
+#   .. ..$ mapping   :List of 3
+#   .. .. ..$ x        : chr "fl"
+#   .. .. ..$ y        : chr "cty"
+#   .. .. ..$ panelvar1: chr "drv"
+#   .. ..$ range     :List of 4
+#   .. .. ..$ left  : num 331
+#   .. .. ..$ right : num 475
+#   .. .. ..$ bottom: num 448
 #   .. .. ..$ top   : num 23.1
 #  $ dims  :List of 2
-#   ..$ width : num 400
-#   ..$ height: num 300
-
+#   ..$ width : num 500
+#   ..$ height: num 400
 
 getCoordmap <- function(x, width, height, res) {
   if (inherits(x, "ggplot_build_gtable")) {

--- a/R/render-plot.R
+++ b/R/render-plot.R
@@ -700,8 +700,16 @@ find_panel_info_non_api <- function(b, ggplot_format) {
       domain$bottom <- -domain$bottom
     }
 
-    if (xscale$is_discrete()) domain$discrete_mapping$x <- xscale$limits
-    if (yscale$is_discrete()) domain$discrete_mapping$y <- yscale$limits
+    # Remember the x/y range if it's a faceted
+    # plot with a free discrete axis. This is necessary
+    # to properly inverse map the numeric (i.e., trained)
+    # positions back to the data scale (#2410)
+    if (xscale$is_discrete()) {
+      domain$discrete_mapping$x <- (xscale$limits %OR% xscale$range$range)
+    }
+    if (yscale$is_discrete()) {
+      domain$discrete_mapping$y <- (yscale$limits %OR% yscale$range$range)
+    }
 
     domain
   }

--- a/R/render-plot.R
+++ b/R/render-plot.R
@@ -1010,6 +1010,5 @@ find_panel_ranges <- function(g, res) {
 # we store a mapping from the 'trained' (numeric)
 # positional coordinates back to the original data scale
 discrete_range <- function(scale) {
-  if (!scale$is_discrete()) return(NULL)
-  scale$range$range
+  if (scale$is_discrete()) scale$range$range else NULL
 }

--- a/R/render-plot.R
+++ b/R/render-plot.R
@@ -570,8 +570,8 @@ find_panel_info_api <- function(b) {
       domain$bottom <- -domain$bottom
     }
 
-    domain$xmap <- discrete_map(xscale)
-    domain$ymap <- discrete_map(yscale)
+    domain$xrange <- discrete_range(xscale)
+    domain$yrange <- discrete_range(yscale)
 
     domain
   }
@@ -692,8 +692,8 @@ find_panel_info_non_api <- function(b, ggplot_format) {
       domain$bottom <- -domain$bottom
     }
 
-    domain$xmap <- discrete_map(xscale)
-    domain$ymap <- discrete_map(yscale)
+    domain$xrange <- discrete_range(xscale)
+    domain$yrange <- discrete_range(yscale)
 
     domain
   }
@@ -1009,8 +1009,7 @@ find_panel_ranges <- function(g, res) {
 # map to "b" in the second panel. To help workaround this,
 # we store a mapping from the 'trained' (numeric)
 # positional coordinates back to the original data scale
-discrete_map <- function(scale) {
+discrete_range <- function(scale) {
   if (!scale$is_discrete()) return(NULL)
-  rng <- scale$range$range
-  setNames(seq_along(rng), rng)
+  scale$range$range
 }

--- a/tests/testthat/test-plot-coordmap.R
+++ b/tests/testthat/test-plot-coordmap.R
@@ -368,3 +368,51 @@ test_that("ggplot coordmap with various scales and coords", {
     sortList(list(left=-1, right=3, bottom=-2, top=4))
   )
 })
+
+
+test_that("ggplot coordmap maintains discrete limits", {
+  tmpfile <- tempfile("test-shiny", fileext = ".png")
+  on.exit(rm(tmpfile))
+
+  p <- ggplot(mpg) +
+    geom_point(aes(fl, cty), alpha = 0.2) +
+    facet_wrap(~drv, scales = "free_x")
+  png(tmpfile)
+  m <- getGgplotCoordmap(print(p), 500, 400, 72)
+  dev.off()
+
+  expect_length(m$panels, 3)
+  expect_equal(
+    m$panels[[1]]$domain$discrete_limits,
+    list(x = c("d", "e", "p", "r"))
+  )
+  expect_equal(
+    m$panels[[2]]$domain$discrete_limits,
+    list(x = c("c", "d", "e", "p", "r"))
+  )
+  expect_equal(
+    m$panels[[3]]$domain$discrete_limits,
+    list(x = c("e", "p", "r"))
+  )
+
+  p2 <- ggplot(mpg) +
+    geom_point(aes(cty, fl), alpha = 0.2) +
+    facet_wrap(~drv, scales = "free_y")
+  png(tmpfile)
+  m2 <- getGgplotCoordmap(print(p2), 500, 400, 72)
+  dev.off()
+
+  expect_length(m2$panels, 3)
+  expect_equal(
+    m2$panels[[1]]$domain$discrete_limits,
+    list(y = c("d", "e", "p", "r"))
+  )
+  expect_equal(
+    m2$panels[[2]]$domain$discrete_limits,
+    list(y = c("c", "d", "e", "p", "r"))
+  )
+  expect_equal(
+    m2$panels[[3]]$domain$discrete_limits,
+    list(y = c("e", "p", "r"))
+  )
+})

--- a/tests/testthat/test-plot-coordmap.R
+++ b/tests/testthat/test-plot-coordmap.R
@@ -271,9 +271,20 @@ test_that("ggplot coordmap with various data types", {
   dev.off()
 
   # Check domain
+  expectation <- list(
+    left = 1,
+    right = 3,
+    bottom = 1,
+    top = 4,
+    discrete_limits = list(
+      x = letters[1:3],
+      y = LETTERS[1:4]
+    )
+  )
+
   expect_equal(
     sortList(m$panels[[1]]$domain),
-    sortList(list(left=1, right=3, bottom=1, top=4))
+    sortList(expectation)
   )
 
   # Dates and date-times

--- a/tests/testthat/test-plot-coordmap.R
+++ b/tests/testthat/test-plot-coordmap.R
@@ -374,6 +374,7 @@ test_that("ggplot coordmap maintains discrete limits", {
   tmpfile <- tempfile("test-shiny", fileext = ".png")
   on.exit(unlink(tmpfile))
 
+  # check discrete limits are correct for free x scales
   p <- ggplot(mpg) +
     geom_point(aes(fl, cty), alpha = 0.2) +
     facet_wrap(~drv, scales = "free_x")
@@ -395,6 +396,7 @@ test_that("ggplot coordmap maintains discrete limits", {
     list(x = c("e", "p", "r"))
   )
 
+  # same for free y
   p2 <- ggplot(mpg) +
     geom_point(aes(cty, fl), alpha = 0.2) +
     facet_wrap(~drv, scales = "free_y")
@@ -415,4 +417,54 @@ test_that("ggplot coordmap maintains discrete limits", {
     m2$panels[[3]]$domain$discrete_limits,
     list(y = c("e", "p", "r"))
   )
+
+  # check that specifying x limits is captured
+  p3 <- ggplot(mpg) +
+    geom_point(aes(fl, cty), alpha = 0.2) +
+    scale_x_discrete(limits = c("c", "d", "e"))
+
+  png(tmpfile)
+  m3 <- getGgplotCoordmap(suppressWarnings(print(p3)), 500, 400, 72)
+  dev.off()
+
+  expect_length(m3$panels, 1)
+  expect_equal(
+    m3$panels[[1]]$domain$discrete_limits,
+    list(x = c("c", "d", "e"))
+  )
+
+  # same for y
+  p4 <- ggplot(mpg) +
+    geom_point(aes(cty, fl), alpha = 0.2) +
+    scale_y_discrete(limits = c("e", "f"))
+
+  png(tmpfile)
+  m4 <- getGgplotCoordmap(suppressWarnings(print(p4)), 500, 400, 72)
+  dev.off()
+
+  expect_length(m4$panels, 1)
+  expect_equal(
+    m4$panels[[1]]$domain$discrete_limits,
+    list(y = c("e", "f"))
+  )
+
+  # make sure that when labels are specified, where
+  # still relaying the input data
+  p5 <- ggplot(mpg) +
+    geom_point(aes(fl, cty), alpha = 0.2) +
+    scale_x_discrete(
+      limits = c("e", "f"),
+      labels = c("foo", "bar")
+    )
+
+  png(tmpfile)
+  m5 <- getGgplotCoordmap(suppressWarnings(print(p5)), 500, 400, 72)
+  dev.off()
+
+  expect_length(m5$panels, 1)
+  expect_equal(
+    m5$panels[[1]]$domain$discrete_limits,
+    list(x = c("e", "f"))
+  )
+
 })

--- a/tests/testthat/test-plot-coordmap.R
+++ b/tests/testthat/test-plot-coordmap.R
@@ -14,7 +14,7 @@ test_that("ggplot coordmap", {
   dat <- data.frame(xvar = c(0, 5), yvar = c(10, 20))
 
   tmpfile <- tempfile("test-shiny", fileext = ".png")
-  on.exit(rm(tmpfile))
+  on.exit(unlink(tmpfile))
 
   # Basic scatterplot
   p <- ggplot(dat, aes(xvar, yvar)) + geom_point() +
@@ -75,7 +75,7 @@ test_that("ggplot coordmap with facet_wrap", {
                     g = c("a", "b", "c"))
 
   tmpfile <- tempfile("test-shiny", fileext = ".png")
-  on.exit(rm(tmpfile))
+  on.exit(unlink(tmpfile))
 
   # facet_wrap
   p <- ggplot(dat, aes(xvar, yvar)) + geom_point() +
@@ -123,7 +123,7 @@ test_that("ggplot coordmap with facet_grid", {
                     g = c("a", "b", "c"))
 
   tmpfile <- tempfile("test-shiny", fileext = ".png")
-  on.exit(rm(tmpfile))
+  on.exit(unlink(tmpfile))
 
   p <- ggplot(dat, aes(xvar, yvar)) + geom_point() +
     scale_x_continuous(expand = c(0, 0)) +
@@ -209,7 +209,7 @@ test_that("ggplot coordmap with 2D facet_grid", {
                     g = c("a", "b"), h = c("i", "j"))
 
   tmpfile <- tempfile("test-shiny", fileext = ".png")
-  on.exit(rm(tmpfile))
+  on.exit(unlink(tmpfile))
 
   p <- ggplot(dat, aes(xvar, yvar)) + geom_point() +
     scale_x_continuous(expand = c(0, 0)) +
@@ -259,7 +259,7 @@ test_that("ggplot coordmap with 2D facet_grid", {
 
 test_that("ggplot coordmap with various data types", {
   tmpfile <- tempfile("test-shiny", fileext = ".png")
-  on.exit(rm(tmpfile))
+  on.exit(unlink(tmpfile))
 
   # Factors
   dat <- expand.grid(xvar = letters[1:3], yvar = LETTERS[1:4])
@@ -313,7 +313,7 @@ test_that("ggplot coordmap with various data types", {
 
 test_that("ggplot coordmap with various scales and coords", {
   tmpfile <- tempfile("test-shiny", fileext = ".png")
-  on.exit(rm(tmpfile))
+  on.exit(unlink(tmpfile))
 
   # Reversed scales
   dat <- data.frame(xvar = c(0, 5), yvar = c(10, 20))
@@ -372,7 +372,7 @@ test_that("ggplot coordmap with various scales and coords", {
 
 test_that("ggplot coordmap maintains discrete limits", {
   tmpfile <- tempfile("test-shiny", fileext = ".png")
-  on.exit(rm(tmpfile))
+  on.exit(unlink(tmpfile))
 
   p <- ggplot(mpg) +
     geom_point(aes(fl, cty), alpha = 0.2) +


### PR DESCRIPTION
See #1433 for some related discussion and motivating examples. It's worth noting some examples there use `geom_jitter()`, but a fix for jittering would be more involved than what's addressed here, so I filed a separate issue #2411

This PR address the fact that the current coordmap model assumes that the numeric (i.e., trained) brush domain maps directly back to the input data, which is problematic for discrete axes. I can think of at least two cases where it becomes a problem for ggplot2:

1. Anytime `scale_[x/y]_discrete(limits = ...)` is used. Since `limits` defines possible values of the scale as well as their order, it breaks the coordmap assumption that a brush domain that spans, say [0.8, 1.2], maps back to the first level of discrete variable.
2. Anytime you a discrete axis that is 'free' across multiple panels, for example:

```r
library(ggplot2)
p <- ggplot(mpg) +
    geom_point(aes(fl, cty), alpha = 0.2) +
    facet_wrap(~drv, scales = "free_x")
layout <- summarise_layout(ggplot_build(p))
layouts <- split(layout, seq_len(nrow(layout)))
lapply(layouts, function(lay) {
  rng <- lay$xscale[[1]]$range$range
  setNames(seq_along(rng), rng)
})
```

```r
$`1`
d e p r 
1 2 3 4 

$`2`
c d e p r 
1 2 3 4 5 

$`3`
e p r 
1 2 3 
```

Notice how, in panel 1, a value of `x=1` maps back to `"d"`, but in panel 2, that same x value maps back to `"c"`. The `asNumber()` function, used to do this 'inverse mapping' in both `brushedPoints()` and `nearPoints()`, currently does not consider the actual axis limits in this way, which is why you get an incorrect result when brushing in the app provided and discussed in https://github.com/rstudio/shiny/issues/1433#issuecomment-260043730:

```r
library(shiny)
library(ggplot2)
mtcars$wt2 <- cut(mtcars$wt,4)
mtcars$mpg2 <- cut(mtcars$mpg,4)

ui <- basicPage(
  plotOutput("plot1", brush = "plot_brush"),
  verbatimTextOutput("info")
)

server <- function(input, output) {
  output$plot1 <- renderPlot({
    ggplot(mtcars, aes(wt2,mpg)) +
      geom_point(alpha = 0.5) +
      facet_grid(~mpg2, scales = "free_x")
  })
  output$info <- renderPrint({
    brushedPoints(mtcars, input$plot_brush)
  })
}

shinyApp(ui, server)
```

This PR works around the issue by attaching any discrete limits to the `coordmap.panels` info and using that information inside `brushedPoints()` and `nearPoints()`