### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,46 +4,39 @@ about : Report a bug in Shiny.
 ---
 
 <!--
-
-Before you file an issue, we would appreciate it if you would upgrade to the latest version of Shiny from CRAN and confirm that the problem persists.
-
-# To install latest shiny from CRAN:
-install.packages("shiny")
-# To update all your R packages:
-update.packages(ask = FALSE, checkBuilt = TRUE)
-# Please remember to restart R after updating packages.
-
 This issue tracker is for bugs and feature requests in the Shiny package. If you're having trouble with Shiny Server or a related package, please file an issue in the appropriate repository. 
 
 If you're having trouble with shinyapps.io, and you have a paid account (Starter, Basic, Standard, or Pro), please file a support ticket via https://support.rstudio.com. If you have a Free account, please post to the RStudio Community with the shinyappsio tag: https://community.rstudio.com/tags/shinyappsio.
 
 Finally, if you are an RStudio customer and are having trouble with one of our Pro products, get in touch with our support team at support@rstudio.com.
 
+Before you file an issue, please upgrade to the latest version of Shiny from CRAN and confirm that the problem persists.
+
+# First, restart R.
+# To install latest shiny from CRAN:
+install.packages("shiny")
+
 See our guide to writing good bug reports for further guidance: https://github.com/rstudio/shiny/wiki/Writing-Good-Bug-Reports. The better your report is, the likelier we are to be able to reproduce and ultimately solve it.
 -->
 
 ### System details
 
-    Shiny Version           :
-    OS Version              : 
-    R Version               : 
-    Browser Version         :
-    RStudio Edition/Version : <!-- If applicable -->
+Browser Version: <!-- If applicable -->
+
+Output of `sessionInfo()`:
+
+```
+# sessionInfo() output goes here
+```
 
 ### Example application *or* steps to reproduce the problem
 
-<!-- A minimal, self-contained example app demonstrating the problem is extremely helpful to us. Thank you in advance for taking the time to create one. For guidance on how to do so, please see https://github.com/rstudio/shiny/wiki/Writing-Good-Bug-Reports -->
+<!-- If you're able to create one, a reproducible example is extremely helpful to us. For instructions on how to create one, please see: https://github.com/rstudio/shiny/wiki/Creating-a-Reproducible-Example --> 
 
 ```R
-# Minimal, self-contained example app goes here
+# Minimal, self-contained example app code goes here
 ```
 
 ### Describe the problem in detail
 
 ### Describe the behavior you expected
-
-<!-- Depending on the problem, the following may also be helpful
-
-1. The output of sessionInfo() 
-
-Thank you for taking the time to file an issue!  -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,43 @@
+---
+name  : Bug report
+about : Report a bug in Shiny.
+---
+
+<!--
+
+Shiny v1.3.2 is now available on CRAN. If you're currently using an older version of Shiny, we would appreciate it if you could update to Shiny v1.3.2 and confirm whether the problem still persists.
+
+This issue tracker is for bugs and feature requests in the Shiny package. If you're having trouble with Shiny Server or a related package, please file an issue in the appropriate repository. 
+
+If you're having trouble with shinyapps.io, and you have a paid account (Starter, Basic, Standard, or Pro), please file a support ticket via https://support.rstudio.com. If you have a Free account, please post to the RStudio Community with the shinyappsio tag: https://community.rstudio.com/tags/shinyappsio.
+
+Finally, if you are an RStudio customer and are having trouble with one of our Pro products, get in touch with our support team at support@rstudio.com.
+
+See our guide to writing good bug reports for further guidance: https://github.com/rstudio/shiny/wiki/Writing-Good-Bug-Reports
+-->
+
+### System details
+
+    Shiny Version           :
+    OS Version              : 
+    R Version               : 
+    Browser Version         :
+    RStudio Edition/Version : <!-- If applicable -->
+
+### Example application *or* steps to reproduce the problem
+
+<!-- A minimal, self-contained example app demonstrating the problem is extremely helpful to us. Thank you in advance for taking the time to create one. For guidance on how to do so, please see https://github.com/rstudio/shiny/wiki/Writing-Good-Bug-Reports -->
+
+```R
+# Minimal, self-contained example app goes here
+```
+
+### Describe the problem in detail
+
+### Describe the behavior you expected
+
+<!-- Depending on the problem, the following may also be helpful
+
+1. The output of sessionInfo() 
+
+Thank you for taking the time to file an issue!  -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,7 +5,13 @@ about : Report a bug in Shiny.
 
 <!--
 
-Shiny v1.3.2 is now available on CRAN. If you're currently using an older version of Shiny, we would appreciate it if you could update to Shiny v1.3.2 and confirm whether the problem still persists.
+Before you file an issue, we would appreciate it if you would upgrade to the latest version of Shiny from CRAN and confirm that the problem persists.
+
+# To install latest shiny from CRAN:
+install.packages("shiny")
+# To update all your R packages:
+update.packages(ask = FALSE, checkBuilt = TRUE)
+# Please remember to restart R after updating packages.
 
 This issue tracker is for bugs and feature requests in the Shiny package. If you're having trouble with Shiny Server or a related package, please file an issue in the appropriate repository. 
 
@@ -13,7 +19,7 @@ If you're having trouble with shinyapps.io, and you have a paid account (Starter
 
 Finally, if you are an RStudio customer and are having trouble with one of our Pro products, get in touch with our support team at support@rstudio.com.
 
-See our guide to writing good bug reports for further guidance: https://github.com/rstudio/shiny/wiki/Writing-Good-Bug-Reports
+See our guide to writing good bug reports for further guidance: https://github.com/rstudio/shiny/wiki/Writing-Good-Bug-Reports. The better your report is, the likelier we are to be able to reproduce and ultimately solve it.
 -->
 
 ### System details

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name  : Feature request
+about : Request a new feature.
+---
+
+<!--
+
+Thanks for taking the time to file a feature request! Please take the time to search for an existing feature request, to avoid creating duplicate requests. If you find an existing feature request, please give it a thumbs-up reaction, as we'll use these reactions to help prioritize the implementation of these features in the future.
+
+If the feature has not yet been filed, then please describe the feature you'd like to see become a part of RStudio. See:
+
+https://github.com/rstudio/shiny/wiki/Writing-Good-Feature-Requests
+
+for a guide on how to write good feature requests.
+
+-->
+

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,7 @@
+---
+name  : Ask a Question
+about : The issue tracker is not for questions -- please ask questions at https://community.rstudio.com/c/shiny.
+---
+
+The issue tracker is not for questions. If you have a question, please feel free to ask it on our community site, at https://community.rstudio.com/c/shiny.
+


### PR DESCRIPTION
These were adapted from rstudio/rstudio and will give us a new issue page like this one: https://github.com/rstudio/rstudio/issues/new/choose

I also adapted these wiki pages, linked from the new issue templates:

* [Writing Good Bug Reports](https://github.com/rstudio/shiny/wiki/Writing-Good-Bug-Reports)
* [Writing Good Feature Requests](https://github.com/rstudio/shiny/wiki/Writing-Good-Feature-Requests)