### PR TITLE
Add cleanup function for renderPlot

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,8 @@ shiny 1.3.2.9000
 
 * Fixed [#2329](https://github.com/rstudio/shiny/issues/2329), [#1817](https://github.com/rstudio/shiny/issues/1817): These bugs were reported as fixed in Shiny 1.3.0 but were not actually fixed because some JavaScript changes were accidentally not included in the release. The fix resolves issues that occur when `withProgressBar()` or bookmarking are combined with the [networkD3](https://christophergandrud.github.io/networkD3/) package's Sankey plot.
 
+* Fixed [#2423](https://github.com/rstudio/shiny/issues/2423): When `renderPlot()` is repeatedly called and assigned to an output value, it would leak memory. ([#2440](https://github.com/rstudio/shiny/pull/2440))
+
 shiny 1.3.2
 ===========
 

--- a/R/shinywrappers.R
+++ b/R/shinywrappers.R
@@ -18,9 +18,13 @@ utils::globalVariables('func')
 #'   app authors to customize outputs. (Currently, this is only supported for
 #'   dynamically generated UIs, such as those created by Shiny code snippets
 #'   embedded in R Markdown documents).
+#' @param cleanupFunc An optional function that is executed when the render
+#'   function is no longer used as an output.
 #' @return The \code{renderFunc} function, with annotations.
 #' @export
-markRenderFunction <- function(uiFunc, renderFunc, outputArgs = list()) {
+markRenderFunction <- function(
+  uiFunc, renderFunc, outputArgs = list(), cleanupFunc = NULL
+) {
   # a mutable object that keeps track of whether `useRenderFunction` has been
   # executed (this usually only happens when rendering Shiny code snippets in
   # an interactive R Markdown document); its initial value is FALSE
@@ -45,11 +49,14 @@ markRenderFunction <- function(uiFunc, renderFunc, outputArgs = list()) {
     else origRenderFunc(...)
   }
 
-  structure(renderFunc,
-            class       = c("shiny.render.function", "function"),
-            outputFunc  = uiFunc,
-            outputArgs  = outputArgs,
-            hasExecuted = hasExecuted)
+  structure(
+    renderFunc,
+    class       = c("shiny.render.function", "function"),
+    outputFunc  = uiFunc,
+    outputArgs  = outputArgs,
+    hasExecuted = hasExecuted,
+    cleanupFunc = cleanupFunc
+  )
 }
 
 #' Implement render functions

--- a/man/dateInput.Rd
+++ b/man/dateInput.Rd
@@ -102,7 +102,7 @@ ui <- fluidPage(
 
   # Disable Mondays and Tuesdays.
   dateInput("date7", "Date:", daysofweekdisabled = c(1,2)),
-  
+
   # Disable specific dates.
   dateInput("date8", "Date:", value = "2012-02-29",
             datesdisabled = c("2012-03-01", "2012-03-02"))

--- a/man/markRenderFunction.Rd
+++ b/man/markRenderFunction.Rd
@@ -4,7 +4,8 @@
 \alias{markRenderFunction}
 \title{Mark a function as a render function}
 \usage{
-markRenderFunction(uiFunc, renderFunc, outputArgs = list())
+markRenderFunction(uiFunc, renderFunc, outputArgs = list(),
+  cleanupFunc = NULL)
 }
 \arguments{
 \item{uiFunc}{A function that renders Shiny UI. Must take a single argument:
@@ -19,6 +20,9 @@ list, and pass through the value to \code{markRenderFunction}, to allow
 app authors to customize outputs. (Currently, this is only supported for
 dynamically generated UIs, such as those created by Shiny code snippets
 embedded in R Markdown documents).}
+
+\item{cleanupFunc}{An optional function that is executed when the render
+function is no longer used as an output.}
 }
 \value{
 The \code{renderFunc} function, with annotations.


### PR DESCRIPTION
This resolves #2423 -- at least, it resolves the large memory leak due to repeatedly assigning the result from `renderPlot()` to an output value.

With the test app in #2423, the leak from clicking the first button drops from over 1MB each time, to a couple of kB.

Note that this is an interim fix -- a better fix for the long run would be to implement weak references for reactive dependencies.