### PR TITLE
Disable dragging of plots with any interactions enabled

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@ shiny 1.3.2.9000
 
 * Resolved ([#2402](https://github.com/rstudio/shiny/issues/2402)): An informative warning is now thrown for mis-specified (date) strings in `dateInput()`, `updateDateInput()`, `dateRangeInput()`, and `updateDateRangeInput()`. ([#2403](https://github.com/rstudio/shiny/pull/2403))
 
+* Fixed [#1393](https://github.com/rstudio/shiny/issues/1393), [#2223](https://github.com/rstudio/shiny/issues/2223): For plots with any interactions enabled, the image is no longer draggable. ([#2460](https://github.com/rstudio/shiny/pull/2460))
+
 ### Bug fixes
 
 * Fixed [#2387](https://github.com/rstudio/shiny/issues/2387): Updating a `sliderInput()`'s type from numeric to date no longer changes the rate policy from debounced to immediate. More generally, updating an input binding with a new type should (no longer) incorrectly alter the input rate policy. ([#2404](https://github.com/rstudio/shiny/pull/2404))

--- a/srcjs/output_binding_image.js
+++ b/srcjs/output_binding_image.js
@@ -139,6 +139,8 @@ $.extend(imageOutputBinding, {
       // Register the various event handlers
       // ----------------------------------------------------------
       if (opts.clickId) {
+        imageutils.disableDrag($el, $img);
+
         var clickHandler = imageutils.createClickHandler(opts.clickId,
           opts.clickClip, opts.coordmap);
         $el.on('mousedown2.image_output', clickHandler.mousedown);
@@ -151,6 +153,8 @@ $.extend(imageOutputBinding, {
       }
 
       if (opts.dblclickId) {
+        imageutils.disableDrag($el, $img);
+
         // We'll use the clickHandler's mousedown function, but register it to
         // our custom 'dblclick2' event.
         var dblclickHandler = imageutils.createClickHandler(opts.dblclickId,
@@ -162,6 +166,8 @@ $.extend(imageOutputBinding, {
       }
 
       if (opts.hoverId) {
+        imageutils.disableDrag($el, $img);
+
         var hoverHandler = imageutils.createHoverHandler(opts.hoverId,
           opts.hoverDelay, opts.hoverDelayType, opts.hoverClip,
           opts.hoverNullOutside, opts.coordmap);
@@ -173,13 +179,7 @@ $.extend(imageOutputBinding, {
       }
 
       if (opts.brushId) {
-        // Make image non-draggable (Chrome, Safari)
-        $img.css('-webkit-user-drag', 'none');
-        // Firefox, IE<=10
-        $img.on('dragstart.image_output', function() { return false; });
-
-        // Disable selection of image and text when dragging in IE<=10
-        $el.on('selectstart.image_output', function() { return false; });
+        imageutils.disableDrag($el, $img);
 
         var brushHandler = imageutils.createBrushHandler(opts.brushId, $el, opts,
           opts.coordmap, outputId);
@@ -225,6 +225,19 @@ outputBindings.register(imageOutputBinding, 'shiny.imageOutput');
 
 var imageutils = {};
 
+imageutils.disableDrag = function($el, $img) {
+  // Make image non-draggable (Chrome, Safari)
+  $img.css('-webkit-user-drag', 'none');
+
+  // Firefox, IE<=10
+  // First remove existing handler so we don't keep adding handlers.
+  $img.off('dragstart.image_output');
+  $img.on('dragstart.image_output', function() { return false; });
+
+  // Disable selection of image and text when dragging in IE<=10
+  $el.off('selectstart.image_output');
+  $el.on('selectstart.image_output', function() { return false; });
+};
 
 // Modifies the panel objects in a coordmap, adding scaleImgToData(),
 // scaleDataToImg(), and clipImg() functions to each one. The panel objects


### PR DESCRIPTION
Closes #1393, closes #2223.

Test app:

```R
library(shiny)

shinyApp(
  ui = fluidPage(
    p("The plot below doesn't have any interactions. It should be draggable."),
    plotOutput("plot_no_interact", height = 250, width = 250),
    
    p("The plot below allows click interactions. It should not be draggable."),
    plotOutput("plot_interact", height = 250, width = 250, hover = "plot_click")
  ),
  server = function(input, output) {
    output$plot_no_interact <- renderPlot({
      plot(cars)
    })
    output$plot_interact <- renderPlot({
      plot(cars)
    })
  }
)
```