### PR TITLE
Set font-awesome path directly

### DIFF
--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -1548,7 +1548,8 @@ icon <- function(name, class = NULL, lib = "font-awesome") {
   # font-awesome needs an additional dependency (glyphicon is in bootstrap)
   if (lib == "font-awesome") {
     htmlDependencies(iconTag) <- htmlDependency(
-      "font-awesome", "5.3.1", "www/shared/fontawesome", package = "shiny",
+      "font-awesome", "5.3.1",
+      src = system.file("www/shared/fontawesome", package = "shiny"),
       stylesheet = c(
         "css/all.min.css",
         "css/v4-shims.min.css"


### PR DESCRIPTION
This changes the `htmlDependency()` call for font-awesome so that it specifies the absolute path for font-awesome, rather than giving it a package name and relative path.

Previously, if you used `devtools::load_all()` to load shiny and then called `icon('calendar')`, you would get this:

```
Error in value[[3L]](cond) : 
  Couldn't normalize path in `addResourcePath`, with arguments: `prefix` = 'font-awesome-5.3.1'; `directoryPath` = 'www/shared/fontawesome'
```

When a package is loaded with `load_all()` it also gets a shimmed version of `system.file()`, because files are in its `inst/` directory instead of at the top level of a package; the shimmed `system.file()` deals with that. However, in this case, shiny is loaded via `load_all()` but htmltools is resolving the path, and since htmltools is not loaded with `load_all()`, it doesn't have the modified version of `system.file()`, and so it fails to find the correct files.

This causes a test failure when testing with `devtools::test()`, and when running tests from RStudio, because those use `load_all()`. The output is:

```
✖ |  61 1     | bootstrap [0.2 s]
─────────────────────────────────────────────────────────────────────────────────────
test-bootstrap.r:48: error: Repeated names for selectInput and radioButtons choices
Couldn't normalize path in `addResourcePath`, with arguments: `prefix` = 'font-awesome-5.3.1'; `directoryPath` = ''
```


With this change, that error doesn't happen anymore.

@jcheng5 I just want to make sure there aren't any weird cases that I'm overlooking here.