### PR TITLE
Ensure that observers fire in consistent order

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -78,7 +78,7 @@ Imports:
     tools,
     crayon,
     rlang,
-    fastmap
+    fastmap (>= 0.0.0.9001)
 Suggests:
     datasets,
     Cairo (>= 1.5-5),

--- a/R/map.R
+++ b/R/map.R
@@ -45,11 +45,11 @@ Map <- R6Class(
     containsKey = function(key) {
       map$has(key)
     },
-    keys = function() {
-      map$keys()
+    keys = function(sort = FALSE) {
+      map$keys(sort = sort)
     },
-    values = function() {
-      map$as_list()
+    values = function(sort = FALSE) {
+      map$as_list(sort = sort)
     },
     clear = function() {
       map$reset()

--- a/R/reactives.R
+++ b/R/reactives.R
@@ -44,7 +44,7 @@ Dependents <- R6Class(
         )
       }
       lapply(
-        .dependents$values(),
+        .dependents$values(sort = TRUE),
         function(ctx) {
           ctx$invalidate()
           NULL

--- a/tests/testthat/test-modules.R
+++ b/tests/testthat/test-modules.R
@@ -52,9 +52,9 @@ test_that("reactiveValues with namespace", {
   # Namespaced reactive values objects only get their own names,
   # minus the namespace prefix, when names() is called.
   # Unnamespaced (root) reactive values objects get all names.
-  expect_equivalent(isolate(names(rv)), c("bar-baz", "bar-qux-quux", "baz", "foo"))
-  expect_equivalent(isolate(names(rv1)), c("baz", "qux-quux"))
-  expect_equivalent(isolate(names(rv2)), c("quux"))
+  expect_setequal(isolate(names(rv)), c("bar-baz", "bar-qux-quux", "baz", "foo"))
+  expect_setequal(isolate(names(rv1)), c("baz", "qux-quux"))
+  expect_setequal(isolate(names(rv2)), c("quux"))
 })
 
 test_that("implicit output respects module namespace", {


### PR DESCRIPTION
Resolves #2466. The key is that the order should be consistent across platforms (though they do not need to be sorted in any particular order). In this particular fix, it also sorts them.