### PR TITLE
Use weakrefs for reactive value to reactive expression dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -90,7 +90,7 @@ Suggests:
     reactlog (>= 1.0.0),
     magrittr
 Remotes:
-    r-lib/fastmap@weakref
+    wch/rlang@weakref
 URL: http://shiny.rstudio.com
 BugReports: https://github.com/rstudio/shiny/issues
 Collate:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -77,7 +77,7 @@ Imports:
     promises (>= 1.0.1),
     tools,
     crayon,
-    rlang,
+    rlang (>= 0.4.0),
     fastmap (>= 0.0.0.9001)
 Suggests:
     datasets,
@@ -89,9 +89,9 @@ Suggests:
     ggplot2,
     reactlog (>= 1.0.0),
     magrittr
-Remotes:
-    wch/rlang@weakref
 URL: http://shiny.rstudio.com
+Remotes:
+    r-lib/fastmap
 BugReports: https://github.com/rstudio/shiny/issues
 Collate:
     'app.R'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -90,7 +90,7 @@ Suggests:
     reactlog (>= 1.0.0),
     magrittr
 Remotes:
-    r-lib/fastmap
+    r-lib/fastmap@weakref
 URL: http://shiny.rstudio.com
 BugReports: https://github.com/rstudio/shiny/issues
 Collate:

--- a/R/react.R
+++ b/R/react.R
@@ -31,11 +31,13 @@ Context <- R6Class(
     .flushCallbacks = list(),
     .domain = NULL,
     .pid = NULL,
+    .weak = NULL,
 
     initialize = function(
       domain, label='', type='other', prevId='',
       reactId = rLog$noReactId,
-      id = .getReactiveEnvironment()$nextId() # For dummy context
+      id = .getReactiveEnvironment()$nextId(), # For dummy context
+      weak = FALSE
     ) {
       id <<- id
       .label <<- label
@@ -43,6 +45,7 @@ Context <- R6Class(
       .pid <<- processId()
       .reactId <<- reactId
       .reactType <<- type
+      .weak <<- weak
       rLog$createContext(id, label, type, prevId, domain)
     },
     run = function(func) {
@@ -108,6 +111,9 @@ Context <- R6Class(
       lapply(.flushCallbacks, function(flushCallback) {
         flushCallback()
       })
+    },
+    isWeak = function() {
+      .weak
     }
   )
 )

--- a/R/reactives.R
+++ b/R/reactives.R
@@ -25,7 +25,7 @@ Dependents <- R6Class(
         }
 
         if (ctx$isWeak()) {
-          .dependents$set(ctx$id, fastmap::make_weakref(ctx))
+          .dependents$set(ctx$id, rlang::new_weakref(ctx))
         } else {
           .dependents$set(ctx$id, ctx)
         }
@@ -50,8 +50,8 @@ Dependents <- R6Class(
       lapply(
         .dependents$values(sort = TRUE),
         function(ctx) {
-          if (fastmap::is_weakref(ctx)) {
-            ctx <- fastmap::get_weakref(ctx)
+          if (rlang::is_weakref(ctx)) {
+            ctx <- rlang::wref_key(ctx)
             if (is.null(ctx)) {
               # Can get here if weakref target was GC'd
               return()

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -48,3 +48,9 @@ contents_identical <- function(a, b) {
 
   TRUE
 }
+
+
+# Don't print out stack traces (which go to stderr)
+suppress_stacktrace <- function(expr) {
+  capture.output(force(expr), type = "message")
+}

--- a/tests/testthat/test-bookmarking.R
+++ b/tests/testthat/test-bookmarking.R
@@ -32,16 +32,16 @@ test_that("Inputs and values in query string", {
   expect_identical(as.list(vals$values), list())
 
   # Multiple instances of _inputs_ or _values_
-  expect_warning(suppressMessages(RestoreContext$new("?_inputs_&a=1&_inputs_")))
-  expect_warning(suppressMessages(RestoreContext$new("?_inputs_&a=1&_inputs_&")))
-  expect_warning(suppressMessages(RestoreContext$new("?_inputs_&a=1&_inputs_&b=2")))
-  expect_warning(suppressMessages(RestoreContext$new("?_inputs_&a=1&_values_&b=2&_inputs_&")))
-  expect_warning(suppressMessages(RestoreContext$new("?_values_&a=1&_values_")))
-  expect_warning(suppressMessages(RestoreContext$new("?_inputs_&a=1&_values_&_values&b=2")))
+  suppress_stacktrace(expect_warning(RestoreContext$new("?_inputs_&a=1&_inputs_")))
+  suppress_stacktrace(expect_warning(RestoreContext$new("?_inputs_&a=1&_inputs_&")))
+  suppress_stacktrace(expect_warning(RestoreContext$new("?_inputs_&a=1&_inputs_&b=2")))
+  suppress_stacktrace(expect_warning(RestoreContext$new("?_inputs_&a=1&_values_&b=2&_inputs_&")))
+  suppress_stacktrace(expect_warning(RestoreContext$new("?_values_&a=1&_values_")))
+  suppress_stacktrace(expect_warning(RestoreContext$new("?_inputs_&a=1&_values_&_values&b=2")))
 
   # If there's an error in the conversion from query string, should have
   # blank values.
-  expect_warning(suppressMessages(rc <- RestoreContext$new("?_inputs_&a=[x&b=1")))
+  suppress_stacktrace(expect_warning(rc <- RestoreContext$new("?_inputs_&a=[x&b=1")))
   expect_identical(rc$input$asList(), list())
   expect_identical(as.list(rc$values), list())
   expect_identical(rc$dir, NULL)

--- a/tests/testthat/test-reactivity.r
+++ b/tests/testthat/test-reactivity.r
@@ -1029,8 +1029,10 @@ test_that("Flush completes even when errors occur", {
 
   # Trigger an error
   vals$x <- 0
-  # Errors in reactive are translated to warnings in observers by default
-  expect_warning(flushReact())
+  suppress_stacktrace(
+    # Errors in reactive are translated to warnings in observers by default
+    expect_warning(flushReact())
+  )
   # Both observers should run up until the reactive that errors
   expect_true(all(c(n11, n12, n21, n22) == c(2,1,2,1)))
 


### PR DESCRIPTION
Fixes #2441, fixes #2423.

@jcheng5 One thing that's odd is that `ReactiveValues` has its own `.dependents` object which is implemented using a `Map`, and it largely duplicates the code in the `Dependents` class. Is there a particular reason for that? Or should it use the `Dependents` class?

Also, don't merge yet; the weakref stuff will be moved from fastmap to rlang.