### PR TITLE
enable disabled

### DIFF
--- a/R/input-checkbox.R
+++ b/R/input-checkbox.R
@@ -23,11 +23,22 @@
 #' shinyApp(ui, server)
 #' }
 #' @export
-checkboxInput <- function(inputId, label, value = FALSE, width = NULL) {
+checkboxInput <- function(inputId, label, value = FALSE, width = NULL, ...) {
 
   value <- restoreInput(id = inputId, default = value)
 
-  inputTag <- tags$input(id = inputId, type="checkbox")
+  args <- list(...)
+  if (!is.null(args[["disabled"]])) {
+    if (args[["disabled"]]) {
+      disable = TRUE
+    } else {
+      disable = NULL
+    }
+  } else {
+    disable = NULL
+  }
+
+  inputTag <- tags$input(id = inputId, type="checkbox", disabled = disable)
   if (!is.null(value) && value)
     inputTag$attribs$checked <- "checked"
 

--- a/R/input-numeric.R
+++ b/R/input-numeric.R
@@ -6,6 +6,7 @@
 #' @param min Minimum allowed value
 #' @param max Maximum allowed value
 #' @param step Interval to use when stepping between min and max
+#' @param ... Can be used to set the attribute `disabled`
 #' @return A numeric input control that can be added to a UI definition.
 #'
 #' @family input elements
@@ -26,13 +27,24 @@
 #' }
 #' @export
 numericInput <- function(inputId, label, value, min = NA, max = NA, step = NA,
-  width = NULL) {
+  width = NULL, ...) {
 
   value <- restoreInput(id = inputId, default = value)
 
+  args <- list(...)
+  if (!is.null(args[["disabled"]])) {
+    if (args[["disabled"]]) {
+      disable = TRUE
+    } else {
+      disable = NULL
+    }
+  } else {
+    disable = NULL
+  }
+
   # build input tag
   inputTag <- tags$input(id = inputId, type = "number", class="form-control",
-                         value = formatNoSci(value))
+                         value = formatNoSci(value), disabled = disable)
   if (!is.na(min))
     inputTag$attribs$min = min
   if (!is.na(max))

--- a/R/input-password.R
+++ b/R/input-password.R
@@ -27,11 +27,23 @@
 #' }
 #' @export
 passwordInput <- function(inputId, label, value = "", width = NULL,
-                          placeholder = NULL) {
+                          placeholder = NULL, ...) {
+
+  args <- list(...)
+  if (!is.null(args[["disabled"]])) {
+    if (args[["disabled"]]) {
+      disable = TRUE
+    } else {
+      disable = NULL
+    }
+  } else {
+    disable = NULL
+  }
+
   div(class = "form-group shiny-input-container",
     style = if (!is.null(width)) paste0("width: ", validateCssUnit(width), ";"),
     shinyInputLabel(inputId, label),
     tags$input(id = inputId, type="password", class="form-control", value=value,
-               placeholder = placeholder)
+               placeholder = placeholder, disabled = disable)
   )
 }

--- a/R/input-text.R
+++ b/R/input-text.R
@@ -10,6 +10,7 @@
 #' @param placeholder A character string giving the user a hint as to what can
 #'   be entered into the control. Internet Explorer 8 and 9 do not support this
 #'   option.
+#' @param ... Can be used to set the attribute `disabled`
 #' @return A text input control that can be added to a UI definition.
 #'
 #' @family input elements
@@ -30,14 +31,25 @@
 #' }
 #' @export
 textInput <- function(inputId, label, value = "", width = NULL,
-  placeholder = NULL) {
+  placeholder = NULL, ...) {
 
   value <- restoreInput(id = inputId, default = value)
+
+  args <- list(...)
+  if (!is.null(args[["disabled"]])) {
+    if (args[["disabled"]]) {
+      disable = TRUE
+    } else {
+      disable = NULL
+    }
+  } else {
+    disable = NULL
+  }
 
   div(class = "form-group shiny-input-container",
     style = if (!is.null(width)) paste0("width: ", validateCssUnit(width), ";"),
     shinyInputLabel(inputId, label),
     tags$input(id = inputId, type="text", class="form-control", value=value,
-      placeholder = placeholder)
+      placeholder = placeholder, disabled = disable)
   )
 }

--- a/man/checkboxInput.Rd
+++ b/man/checkboxInput.Rd
@@ -4,7 +4,7 @@
 \alias{checkboxInput}
 \title{Checkbox Input Control}
 \usage{
-checkboxInput(inputId, label, value = FALSE, width = NULL)
+checkboxInput(inputId, label, value = FALSE, width = NULL, ...)
 }
 \arguments{
 \item{inputId}{The \code{input} slot that will be used to access the value.}
@@ -15,6 +15,8 @@ checkboxInput(inputId, label, value = FALSE, width = NULL)
 
 \item{width}{The width of the input, e.g. \code{'400px'}, or \code{'100\%'};
 see \code{\link{validateCssUnit}}.}
+
+\item{...}{Can be used to set the attribute `disabled`}
 }
 \value{
 A checkbox control that can be added to a UI definition.

--- a/man/numericInput.Rd
+++ b/man/numericInput.Rd
@@ -5,7 +5,7 @@
 \title{Create a numeric input control}
 \usage{
 numericInput(inputId, label, value, min = NA, max = NA, step = NA,
-  width = NULL)
+  width = NULL, ...)
 }
 \arguments{
 \item{inputId}{The \code{input} slot that will be used to access the value.}
@@ -22,6 +22,8 @@ numericInput(inputId, label, value, min = NA, max = NA, step = NA,
 
 \item{width}{The width of the input, e.g. \code{'400px'}, or \code{'100\%'};
 see \code{\link{validateCssUnit}}.}
+
+\item{...}{Can be used to set the attribute `disabled`}
 }
 \value{
 A numeric input control that can be added to a UI definition.

--- a/man/passwordInput.Rd
+++ b/man/passwordInput.Rd
@@ -5,7 +5,7 @@
 \title{Create a password input control}
 \usage{
 passwordInput(inputId, label, value = "", width = NULL,
-  placeholder = NULL)
+  placeholder = NULL, ...)
 }
 \arguments{
 \item{inputId}{The \code{input} slot that will be used to access the value.}
@@ -20,6 +20,8 @@ see \code{\link{validateCssUnit}}.}
 \item{placeholder}{A character string giving the user a hint as to what can
 be entered into the control. Internet Explorer 8 and 9 do not support this
 option.}
+
+\item{...}{Can be used to set the attribute `disabled`}
 }
 \value{
 A text input control that can be added to a UI definition.

--- a/man/textInput.Rd
+++ b/man/textInput.Rd
@@ -5,7 +5,7 @@
 \title{Create a text input control}
 \usage{
 textInput(inputId, label, value = "", width = NULL,
-  placeholder = NULL)
+  placeholder = NULL, ...)
 }
 \arguments{
 \item{inputId}{The \code{input} slot that will be used to access the value.}
@@ -20,6 +20,8 @@ see \code{\link{validateCssUnit}}.}
 \item{placeholder}{A character string giving the user a hint as to what can
 be entered into the control. Internet Explorer 8 and 9 do not support this
 option.}
+
+\item{...}{Can be used to set the attribute `disabled`}
 }
 \value{
 A text input control that can be added to a UI definition.


### PR DESCRIPTION
Enables to set `disabled` to textInput, numericInput, passwordInput and checkboxInput

closes #2489 

It's not really elegant, but the attribute has to be set to **NULL**. Setting it to FALSE will still disable the input.
Would there be a nicer way of implementing this?