### PR TITLE
Mark deprecated functions as internal

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -175,6 +175,7 @@ resourcePathHandler <- function(req) {
 #' }
 #' }
 #' @export
+#' @keywords internal
 shinyServer <- function(func) {
   .globals$server <- list(func)
   invisible(func)

--- a/R/shinyui.R
+++ b/R/shinyui.R
@@ -71,6 +71,7 @@ renderPage <- function(ui, connection, showcase=0, testMode=FALSE) {
 #'
 #' @param ui A user interace definition
 #' @return The user interface definition, without modifications or side effects.
+#' @keywords internal
 #' @export
 shinyUI <- function(ui) {
   .globals$ui <- list(ui)

--- a/man/shinyServer.Rd
+++ b/man/shinyServer.Rd
@@ -54,3 +54,4 @@ function(input, output, session) {
 }
 }
 }
+\keyword{internal}

--- a/man/shinyUI.Rd
+++ b/man/shinyUI.Rd
@@ -19,3 +19,4 @@ ensure that the last expression to be returned from ui.R is a user interface.
 This function is kept for backwards compatibility with older applications. It
 returns the value that is passed to it.
 }
+\keyword{internal}


### PR DESCRIPTION
This prevents them from being listed in the documentation index. Closes #2482.

Discovered this trick via https://cran.r-project.org/web/packages/roxygen2/vignettes/rd.html#keywords