### PR TITLE
Add sep argument to renderText

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@ shiny 1.3.2.9000
 
 * Partially resolved [#2423](https://github.com/rstudio/shiny/issues/2423): Reactivity in Shiny leaked some memory, because R can leak memory whenever a new symbols is interned, which happens whenever a new name/key is used in an environment. R now uses the fastmap package, which avoids this problem. ([#2429](https://github.com/rstudio/shiny/pull/2429))
 
+* Resolved [#2469](https://github.com/rstudio/shiny/issues/2469): `renderText` now takes a `sep` argument that is passed to `cat`.
 
 ### Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,7 +15,7 @@ shiny 1.3.2.9000
 
 * Partially resolved [#2423](https://github.com/rstudio/shiny/issues/2423): Reactivity in Shiny leaked some memory, because R can leak memory whenever a new symbols is interned, which happens whenever a new name/key is used in an environment. R now uses the fastmap package, which avoids this problem. ([#2429](https://github.com/rstudio/shiny/pull/2429))
 
-* Resolved [#2469](https://github.com/rstudio/shiny/issues/2469): `renderText` now takes a `sep` argument that is passed to `cat`.
+* Resolved [#2469](https://github.com/rstudio/shiny/issues/2469): `renderText` now takes a `sep` argument that is passed to `cat`. ([#2497](https://github.com/rstudio/shiny/pull/2497))
 
 ### Bug fixes
 

--- a/R/shinywrappers.R
+++ b/R/shinywrappers.R
@@ -416,6 +416,8 @@ createRenderPrintPromiseDomain <- function(width) {
 #' @param outputArgs A list of arguments to be passed through to the implicit
 #'   call to \code{\link{textOutput}} when \code{renderText} is used in an
 #'   interactive R Markdown document.
+#' @param sep A separator passed to \code{cat} to be appended after each
+#'   element.
 #'
 #' @seealso \code{\link{renderPrint}} for capturing the print output of a
 #'   function, rather than the returned text value.
@@ -423,13 +425,13 @@ createRenderPrintPromiseDomain <- function(width) {
 #' @example res/text-example.R
 #' @export
 renderText <- function(expr, env=parent.frame(), quoted=FALSE,
-                       outputArgs=list()) {
+                       outputArgs=list(), sep=" ") {
   installExprFunction(expr, "func", env, quoted)
 
   createRenderFunction(
     func,
     function(value, session, name, ...) {
-      paste(utils::capture.output(cat(value)), collapse="\n")
+      paste(utils::capture.output(cat(value, sep=sep)), collapse="\n")
     },
     textOutput, outputArgs
   )

--- a/man/renderText.Rd
+++ b/man/renderText.Rd
@@ -5,7 +5,7 @@
 \title{Text Output}
 \usage{
 renderText(expr, env = parent.frame(), quoted = FALSE,
-  outputArgs = list())
+  outputArgs = list(), sep)
 }
 \arguments{
 \item{expr}{An expression that returns an R object that can be used as an
@@ -19,6 +19,9 @@ is useful if you want to save an expression in a variable.}
 \item{outputArgs}{A list of arguments to be passed through to the implicit
 call to \code{\link{textOutput}} when \code{renderText} is used in an
 interactive R Markdown document.}
+
+\item{sep}{A separator passed to \code{cat} to be appended after each
+element.}
 }
 \description{
 Makes a reactive version of the given function that also uses

--- a/man/renderText.Rd
+++ b/man/renderText.Rd
@@ -5,7 +5,7 @@
 \title{Text Output}
 \usage{
 renderText(expr, env = parent.frame(), quoted = FALSE,
-  outputArgs = list(), sep)
+  outputArgs = list(), sep = " ")
 }
 \arguments{
 \item{expr}{An expression that returns an R object that can be used as an

--- a/tests/testthat/test-text.R
+++ b/tests/testthat/test-text.R
@@ -18,6 +18,17 @@ test_that("renderPrint and renderText behavior is correct", {
                'foo')
   expect_equal(isolate(renderText({ invisible("foo") })()),
                'foo')
+  expect_equal(isolate(renderText({ c("hello", "world") })()),
+               'hello world')
+
+  expect_equal(isolate(renderText({ c("hello", "world") }, sep=", ")()),
+               'hello, world')
+  # Really just measuring the behavior of `cat` when it receives a vector of
+  # separators, but probably worth covering.
+  expect_equal(isolate(renderText({ c("hello", "there", "world", "repeats") },
+                                  sep=c(" ", ", "))()),
+               'hello there, world repeats')
+
   # Capture the print output so it's not shown on console during test, and
   # also check that it is correct
   print_out <- utils::capture.output(ret <- isolate(renderText({ print("foo"); "bar"})()))


### PR DESCRIPTION
### Questions

I'd rather defer the `sep` default to `cat` rather than having to specify it myself in `renderText`. Is there a more idiomatic way to specify the `sep` passthrough to `renderText`? If I don't provide a default, I get a "missing with no default" error. I could check with `missing` but I'll still end up having to provide my own default in `renderText`. Seem unlikely that `cat` will change its default, so it's probably just an academic concern, but it made me feel a little icky.

### Behavior

<img width="559" alt="Screen Shot 2019-06-14 at 10 28 06 AM" src="https://user-images.githubusercontent.com/1593639/59520739-2528c180-8eba-11e9-898a-af15ad5d5228.png">
<img width="543" alt="Screen Shot 2019-06-14 at 10 27 53 AM" src="https://user-images.githubusercontent.com/1593639/59520740-25c15800-8eba-11e9-9571-2e8c98ba5e61.png">

Closes #2469