### PR TITLE
Test for Roxygen doc & JS changes in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,13 @@ matrix:
       r_packages:
         - devtools
         - roxygen2
-      script:
-        - ./tools/checkDocsCurrent.sh
+      script: ./tools/checkDocsCurrent.sh
     - name: "Javascript check"
       language: node_js
       cache: yarn
       script: ./tools/checkJSCurrent.sh
+      node_js:
+        - "10"
     - name: "Old Release Check"
       r: oldrel
     - name: "Current Release Check"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,10 @@ r:
   - devel
 sudo: false
 cache: packages
-
+after_script:
+  - git reset --hard && git clean -ffdx
+  - Rscript -e "install.packages(c('devtools', 'roxygen2'))" || travis_terminate 1
+  - ./tools/checkDocsCurrent.sh || travis_terminate 1
 notifications:
   email:
     on_success: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,21 @@
 language: r
-r:
-  - oldrel
-  - release
-  - devel
+matrix:
+  include:
+    - name: "Doc check"
+      r: release
+      r_packages:
+        - devtools
+        - roxygen2
+      script:
+        - ./tools/checkDocsCurrent.sh
+    - name: "Old Release Check"
+      r: oldrel
+    - name: "Current Release Check"
+      r: release
+    - name: "Development Release Check"
+      r: devel
 sudo: false
 cache: packages
-after_script:
-  - git reset --hard && git clean -ffdx
-  - Rscript -e "install.packages(c('devtools', 'roxygen2'))" || travis_terminate 1
-  - ./tools/checkDocsCurrent.sh || travis_terminate 1
 notifications:
   email:
     on_success: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,17 @@
 language: r
 matrix:
   include:
-    - name: "Doc check"
+    - name: "Roxygen check"
       r: release
       r_packages:
         - devtools
         - roxygen2
       script:
         - ./tools/checkDocsCurrent.sh
+    - name: "Javascript check"
+      language: node_js
+      cache: yarn
+      script: ./tools/checkJSCurrent.sh
     - name: "Old Release Check"
       r: oldrel
     - name: "Current Release Check"

--- a/tools/checkDocsCurrent.sh
+++ b/tools/checkDocsCurrent.sh
@@ -8,8 +8,8 @@ Rscript -e "devtools::document(roclets=c('rd', 'collate', 'namespace'))"
 if [ -n "$(git status --porcelain)" ]
 then
   git status --porcelain
-  echo "Please generate the Roxygen documentation and commit the updates."
-  echo "The above files changed when we generated the Roxygen documentation. This most often occurs when a user changes the Roxygen documentation in an R file but doesn't regenerate the documentation before committing."
+  >&2 echo "Please generate the Roxygen documentation and commit the updates."
+  >&2 echo "The above files changed when we generated the Roxygen documentation. This most often occurs when a user changes the Roxygen documentation in an R file but doesn't regenerate the documentation before committing."
   exit 1
 else
   echo "No difference detected; Roxygen docs are current."

--- a/tools/checkDocsCurrent.sh
+++ b/tools/checkDocsCurrent.sh
@@ -2,6 +2,11 @@
 
 # Generate package docs in the working directory
 Rscript -e "devtools::document(roclets=c('rd', 'collate', 'namespace'))"
+if [ $? -ne 0 ]
+then
+  echo "Error generating Roxygen docs."
+  exit 1
+fi
 
 # This command will return a zero exit code if there are uncommitted changes
 test -n "$(git status --porcelain)"

--- a/tools/checkDocsCurrent.sh
+++ b/tools/checkDocsCurrent.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Generate package docs in the working directory
+Rscript -e "devtools::document(roclets=c('rd', 'collate', 'namespace'))"
+
+# This command will return a zero exit code if there are uncommitted changes
+test -n "$(git status --porcelain)"
+if [ $? -eq 0 ]
+then
+  git status --porcelain
+  echo "Please generate the Roxygen documentation and commit the updates."
+  echo "The above files changed when we generated the Roxygen documentation. This most often occurs when a user changes the Roxygen documentation in an R file but doesn't regenerate the documentation before committing."
+  exit 1
+else
+  echo "No difference detected; Roxygen docs are current."
+fi

--- a/tools/checkDocsCurrent.sh
+++ b/tools/checkDocsCurrent.sh
@@ -1,16 +1,11 @@
 #!/bin/bash
 
+set -e
+
 # Generate package docs in the working directory
 Rscript -e "devtools::document(roclets=c('rd', 'collate', 'namespace'))"
-if [ $? -ne 0 ]
-then
-  echo "Error generating Roxygen docs."
-  exit 1
-fi
 
-# This command will return a zero exit code if there are uncommitted changes
-test -n "$(git status --porcelain)"
-if [ $? -eq 0 ]
+if [ -n "$(git status --porcelain)" ]
 then
   git status --porcelain
   echo "Please generate the Roxygen documentation and commit the updates."

--- a/tools/checkJSCurrent.sh
+++ b/tools/checkJSCurrent.sh
@@ -1,16 +1,11 @@
 #!/bin/bash
 
+set -e
+
 # Run JS build process
 (cd "$(dirname "$0")" && yarn && yarn build)
-if [ $? -ne 0 ]
-then
-  echo "Error generating JavaScript assets with yarn."
-  exit 1
-fi
 
-# This command will return a zero exit code if there are uncommitted changes
-test -n "$(git status --porcelain)"
-if [ $? -eq 0 ]
+if [ -n "$(git status --porcelain)" ]
 then
   git status --porcelain
   echo "Please rebuild the JavaScript and commit the changes."

--- a/tools/checkJSCurrent.sh
+++ b/tools/checkJSCurrent.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Run JS build process
-(cd "$(dirname "$0")" && yarn build)
+(cd "$(dirname "$0")" && yarn && yarn build)
 if [ $? -ne 0 ]
 then
   echo "Error generating JavaScript assets with yarn."

--- a/tools/checkJSCurrent.sh
+++ b/tools/checkJSCurrent.sh
@@ -8,8 +8,8 @@ set -e
 if [ -n "$(git status --porcelain)" ]
 then
   git status --porcelain
-  echo "Please rebuild the JavaScript and commit the changes."
-  echo "The above files changed when we built the JavaScript assets. This most often occurs when a user makes changes to the JavaScript sources but doesn't rebuild and commit them."
+  >&2 echo "Please rebuild the JavaScript and commit the changes."
+  >&2 echo "The above files changed when we built the JavaScript assets. This most often occurs when a user makes changes to the JavaScript sources but doesn't rebuild and commit them."
   exit 1
 else
   echo "No difference detected; JavaScript build is current."

--- a/tools/checkJSCurrent.sh
+++ b/tools/checkJSCurrent.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Run JS build process
+(cd "$(dirname "$0")" && yarn build)
+if [ $? -ne 0 ]
+then
+  echo "Error generating JavaScript assets with yarn."
+  exit 1
+fi
+
+# This command will return a zero exit code if there are uncommitted changes
+test -n "$(git status --porcelain)"
+if [ $? -eq 0 ]
+then
+  git status --porcelain
+  echo "Please rebuild the JavaScript and commit the changes."
+  echo "The above files changed when we built the JavaScript assets. This most often occurs when a user makes changes to the JavaScript sources but doesn't rebuild and commit them."
+  exit 1
+else
+  echo "No difference detected; JavaScript build is current."
+fi


### PR DESCRIPTION
This work checks to make sure that the Roxygen docs are current in proposed changes. If the rendered docs are stale, it fails the Travis build with an informative message.

Right now this takes multiple minutes, but my understanding is that Travis doesn't cache changes into the packages directory until they're deployed via master. So I believe that once this is merged we should see all the built packages from installing `devtools` and `roxygen2` will become much faster.

Related to #2505 

Happy output from Travis: https://travis-ci.org/rstudio/shiny/jobs/547498661

```
Updating shiny documentation
Writing NAMESPACE
Loading shiny
Writing NAMESPACE
No difference detected; Roxygen docs are current.
```

Sad output from Travis: https://travis-ci.org/rstudio/shiny/jobs/547497580

```
Updating shiny documentation
Writing NAMESPACE
Loading shiny
Writing textAreaInput.Rd
Writing NAMESPACE
 M man/textAreaInput.Rd
Please generate the Roxygen documentation and commit the updates.
The above files changed when we generated the Roxygen documentation. This most often occurs when a user changes the Roxygen documentation in an R file but doesn't regenerate the documentation before committing.
```