### PR TITLE
en dashes -> em dashes

### DIFF
--- a/R/cache-disk.R
+++ b/R/cache-disk.R
@@ -81,7 +81,7 @@
 #'   objects will be removed from the cache. Objects will be removed from the
 #'   cache so that the total size remains under `max_size`. Note that the
 #'   size is calculated using the size of the files, not the size of disk space
-#'   used by the files -- these two values can differ because of files are
+#'   used by the files --- these two values can differ because of files are
 #'   stored in blocks on disk. For example, if the block size is 4096 bytes,
 #'   then a file that is one byte in size will take 4096 bytes on disk.
 #'

--- a/R/cache-memory.R
+++ b/R/cache-memory.R
@@ -80,7 +80,7 @@
 #'   objects will be removed from the cache. Objects will be removed from the
 #'   cache so that the total size remains under `max_size`. Note that the
 #'   size is calculated using the size of the files, not the size of disk space
-#'   used by the files -- these two values can differ because of files are
+#'   used by the files --- these two values can differ because of files are
 #'   stored in blocks on disk. For example, if the block size is 4096 bytes,
 #'   then a file that is one byte in size will take 4096 bytes on disk.
 #'

--- a/R/input-select.R
+++ b/R/input-select.R
@@ -15,12 +15,12 @@
 #'
 #' @inheritParams textInput
 #' @param choices List of values to select from. If elements of the list are
-#'   named, then that name -- rather than the value -- is displayed to the user.
-#'   It's also possible to group related inputs by providing a named list whose
-#'   elements are (either named or unnamed) lists or vectors. In this case, the
-#'   outermost names will be used as the group labels (leveraging the
-#'   `<optgroup>` HTML tag) for the elements in the respective sublist. See
-#'   the example section for a small demo of this feature.
+#'   named, then that name --- rather than the value --- is displayed to the
+#'   user. It's also possible to group related inputs by providing a named list
+#'   whose elements are (either named or unnamed) lists or vectors. In this
+#'   case, the outermost names will be used as the group labels (leveraging the
+#'   `<optgroup>` HTML tag) for the elements in the respective sublist. See the
+#'   example section for a small demo of this feature.
 #' @param selected The initially selected value (or multiple values if
 #'   `multiple = TRUE`). If not specified then defaults to the first value
 #'   for single-select lists and no values for multiple select lists.

--- a/R/insert-ui.R
+++ b/R/insert-ui.R
@@ -117,7 +117,7 @@ insertUI <- function(selector,
 #' string `s` to be placed in a `$(s)` jQuery call). This selector
 #' will determine the element(s) to be removed. If you want to remove a
 #' Shiny input or output, note that many of these are wrapped in `div`s,
-#' so you may need to use a somewhat complex selector -- see the Examples below.
+#' so you may need to use a somewhat complex selector --- see the Examples below.
 #' (Alternatively, you could also wrap the inputs/outputs that you want to be
 #' able to remove easily in a `div` with an id.)
 #'

--- a/R/render-cached-plot.R
+++ b/R/render-cached-plot.R
@@ -20,11 +20,11 @@
 #'
 #' The key should consist of "normal" R objects, like vectors and lists. Lists
 #' should in turn contain other normal R objects. If the key contains
-#' environments, external pointers, or reference objects -- or even if it has
-#' such objects attached as attributes -- then it is possible that it will
+#' environments, external pointers, or reference objects --- or even if it has
+#' such objects attached as attributes --- then it is possible that it will
 #' change unpredictably even when you do not expect it to. Additionally, because
 #' the entire key is serialized and hashed, if it contains a very large object
-#' -- a large data set, for example -- there may be a noticeable performance
+#' --- a large data set, for example --- there may be a noticeable performance
 #' penalty.
 #'
 #' If you face these issues with the cache key, you can work around them by
@@ -62,8 +62,8 @@
 #'     be deleted. If plots cannot be safely shared across users, this should
 #'     not be used.}
 #'   \item{2}{To scope the cache to one session, use `cache="session"`.
-#'     When a new user session starts -- in other words, when a web browser
-#'     visits the Shiny application -- a new cache will be created on disk
+#'     When a new user session starts --- in other words, when a web browser
+#'     visits the Shiny application --- a new cache will be created on disk
 #'     for that session. When the session ends, the cache will be deleted.
 #'     The cache will not be shared across multiple sessions.}
 #'  }
@@ -379,7 +379,7 @@ renderCachedPlot <- function(expr,
     hybrid_chain(
       # Depend on the user cache key, even though we don't use the value. When
       # it changes, it can cause the drawReactive to re-execute. (Though
-      # drawReactive will not necessarily re-execute -- it must be called from
+      # drawReactive will not necessarily re-execute --- it must be called from
       # renderFunc, which happens only if there's a cache miss.)
       userCacheKey(),
       function(userCacheKeyValue) {

--- a/R/server-input-handlers.R
+++ b/R/server-input-handlers.R
@@ -19,7 +19,7 @@ inputHandlers <- Map$new()
 #'
 #' The `type` of a custom Shiny Input widget will be deduced using the
 #' `getType()` JavaScript function on the registered Shiny inputBinding.
-#' @param type The type for which the handler should be added -- should be a
+#' @param type The type for which the handler should be added --- should be a
 #' single-element character vector.
 #' @param fun The handler function. This is the function that will be used to
 #'   parse the data delivered from the client before it is available in the

--- a/R/utils.R
+++ b/R/utils.R
@@ -1296,7 +1296,7 @@ need <- function(expr, message = paste(label, "must be provided"), label) {
 #' this is used inside an output context (e.g. `output$txt <- ...`). It may
 #' or may not be the case if it is used inside a non-output context (e.g.
 #' [reactive()], [observe()] or [observeEvent()])
-#' -- depending on whether or not there is an `output$...` that is triggered
+#' --- depending on whether or not there is an `output$...` that is triggered
 #' as a result of those calls. See the examples below for concrete scenarios.
 #'
 #' @param ... Values to check for truthiness.

--- a/man/diskCache.Rd
+++ b/man/diskCache.Rd
@@ -132,7 +132,7 @@ If the size of the objects in the cache exceeds \code{max_size}, then
 objects will be removed from the cache. Objects will be removed from the
 cache so that the total size remains under \code{max_size}. Note that the
 size is calculated using the size of the files, not the size of disk space
-used by the files -- these two values can differ because of files are
+used by the files --- these two values can differ because of files are
 stored in blocks on disk. For example, if the block size is 4096 bytes,
 then a file that is one byte in size will take 4096 bytes on disk.
 

--- a/man/memoryCache.Rd
+++ b/man/memoryCache.Rd
@@ -124,7 +124,7 @@ If the size of the objects in the cache exceeds \code{max_size}, then
 objects will be removed from the cache. Objects will be removed from the
 cache so that the total size remains under \code{max_size}. Note that the
 size is calculated using the size of the files, not the size of disk space
-used by the files -- these two values can differ because of files are
+used by the files --- these two values can differ because of files are
 stored in blocks on disk. For example, if the block size is 4096 bytes,
 then a file that is one byte in size will take 4096 bytes on disk.
 

--- a/man/registerInputHandler.Rd
+++ b/man/registerInputHandler.Rd
@@ -7,7 +7,7 @@
 registerInputHandler(type, fun, force = FALSE)
 }
 \arguments{
-\item{type}{The type for which the handler should be added -- should be a
+\item{type}{The type for which the handler should be added --- should be a
 single-element character vector.}
 
 \item{fun}{The handler function. This is the function that will be used to

--- a/man/removeUI.Rd
+++ b/man/removeUI.Rd
@@ -12,7 +12,7 @@ removeUI(selector, multiple = FALSE, immediate = FALSE,
 string \code{s} to be placed in a \code{$(s)} jQuery call). This selector
 will determine the element(s) to be removed. If you want to remove a
 Shiny input or output, note that many of these are wrapped in \code{div}s,
-so you may need to use a somewhat complex selector -- see the Examples below.
+so you may need to use a somewhat complex selector --- see the Examples below.
 (Alternatively, you could also wrap the inputs/outputs that you want to be
 able to remove easily in a \code{div} with an id.)}
 

--- a/man/renderCachedPlot.Rd
+++ b/man/renderCachedPlot.Rd
@@ -58,11 +58,11 @@ the plotting expression, \code{expr}.
 
 The key should consist of "normal" R objects, like vectors and lists. Lists
 should in turn contain other normal R objects. If the key contains
-environments, external pointers, or reference objects -- or even if it has
-such objects attached as attributes -- then it is possible that it will
+environments, external pointers, or reference objects --- or even if it has
+such objects attached as attributes --- then it is possible that it will
 change unpredictably even when you do not expect it to. Additionally, because
 the entire key is serialized and hashed, if it contains a very large object
--- a large data set, for example -- there may be a noticeable performance
+--- a large data set, for example --- there may be a noticeable performance
 penalty.
 
 If you face these issues with the cache key, you can work around them by
@@ -101,8 +101,8 @@ of the application. When the application stops running, the cache will
 be deleted. If plots cannot be safely shared across users, this should
 not be used.}
 \item{2}{To scope the cache to one session, use \code{cache="session"}.
-When a new user session starts -- in other words, when a web browser
-visits the Shiny application -- a new cache will be created on disk
+When a new user session starts --- in other words, when a web browser
+visits the Shiny application --- a new cache will be created on disk
 for that session. When the session ends, the cache will be deleted.
 The cache will not be shared across multiple sessions.}
 }

--- a/man/req.Rd
+++ b/man/req.Rd
@@ -112,7 +112,7 @@ Note that this is always going to be the case if
 this is used inside an output context (e.g. \code{output$txt <- ...}). It may
 or may not be the case if it is used inside a non-output context (e.g.
 \code{\link[=reactive]{reactive()}}, \code{\link[=observe]{observe()}} or \code{\link[=observeEvent]{observeEvent()}})
--- depending on whether or not there is an \code{output$...} that is triggered
+--- depending on whether or not there is an \code{output$...} that is triggered
 as a result of those calls. See the examples below for concrete scenarios.
 }
 \examples{

--- a/man/selectInput.Rd
+++ b/man/selectInput.Rd
@@ -16,12 +16,12 @@ selectizeInput(inputId, ..., options = NULL, width = NULL)
 \item{label}{Display label for the control, or \code{NULL} for no label.}
 
 \item{choices}{List of values to select from. If elements of the list are
-named, then that name -- rather than the value -- is displayed to the user.
-It's also possible to group related inputs by providing a named list whose
-elements are (either named or unnamed) lists or vectors. In this case, the
-outermost names will be used as the group labels (leveraging the
-\code{<optgroup>} HTML tag) for the elements in the respective sublist. See
-the example section for a small demo of this feature.}
+named, then that name --- rather than the value --- is displayed to the
+user. It's also possible to group related inputs by providing a named list
+whose elements are (either named or unnamed) lists or vectors. In this
+case, the outermost names will be used as the group labels (leveraging the
+\code{<optgroup>} HTML tag) for the elements in the respective sublist. See the
+example section for a small demo of this feature.}
 
 \item{selected}{The initially selected value (or multiple values if
 \code{multiple = TRUE}). If not specified then defaults to the first value

--- a/man/updateSelectInput.Rd
+++ b/man/updateSelectInput.Rd
@@ -28,12 +28,12 @@ updateVarSelectizeInput(session, inputId, label = NULL, data = NULL,
 \item{label}{The label to set for the input object.}
 
 \item{choices}{List of values to select from. If elements of the list are
-named, then that name -- rather than the value -- is displayed to the user.
-It's also possible to group related inputs by providing a named list whose
-elements are (either named or unnamed) lists or vectors. In this case, the
-outermost names will be used as the group labels (leveraging the
-\code{<optgroup>} HTML tag) for the elements in the respective sublist. See
-the example section for a small demo of this feature.}
+named, then that name --- rather than the value --- is displayed to the
+user. It's also possible to group related inputs by providing a named list
+whose elements are (either named or unnamed) lists or vectors. In this
+case, the outermost names will be used as the group labels (leveraging the
+\code{<optgroup>} HTML tag) for the elements in the respective sublist. See the
+example section for a small demo of this feature.}
 
 \item{selected}{The initially selected value (or multiple values if
 \code{multiple = TRUE}). If not specified then defaults to the first value


### PR DESCRIPTION
As per https://github.com/rstudio/shiny/pull/2502#discussion_r295048679 and https://www.vappingo.com/word-blog/em-dash-vs-en-dash-a-quick-and-simple-guide/

Rendering with en dash:
<img width="479" alt="Screen Shot 2019-06-25 at 9 04 47 AM" src="https://user-images.githubusercontent.com/1593639/60105274-8ff7b980-9752-11e9-8c01-cfd1f0d4f567.png">

And now em dash:
<img width="476" alt="Screen Shot 2019-06-25 at 9 04 20 AM" src="https://user-images.githubusercontent.com/1593639/60105265-8b330580-9752-11e9-871b-aa0b766f1e41.png">

This should cover all of the instances of ` -- ` in our rendered Rd docs. There are some stragglers in source code comments that don't get exported that I didn't worry about.