### PR TITLE
Fix reactivePoll leak

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,8 @@ shiny 1.3.2.9001
 
 * Fixed [#2267](https://github.com/rstudio/shiny/issues/2267): Fixed a memory leak with `invalidateLater`. ([#2555](https://github.com/rstudio/shiny/pull/2555))
 
+* Fixed [#1548](https://github.com/rstudio/shiny/issues/1548): The `reactivePoll` function leaked an observer; that is the observer would continue to exist even if the `reactivePoll` object was no longer accessible. [#2522](https://github.com/rstudio/shiny/pull/2522)
+
 * Resolved [#2469](https://github.com/rstudio/shiny/issues/2469): `renderText` now takes a `sep` argument that is passed to `cat`. ([#2497](https://github.com/rstudio/shiny/pull/2497))
 
 * Added `resourcePaths()` and `removeResourcePaths()` functions. ([#2459](https://github.com/rstudio/shiny/pull/2459))

--- a/R/reactives.R
+++ b/R/reactives.R
@@ -1734,7 +1734,6 @@ reactivePoll <- function(intervalMillis, session, checkFunc, valueFunc) {
   rv <- reactiveValues(cookie = isolate(checkFunc()))
 
   o <- observe({
-    cat(".")
     rv$cookie <- checkFunc()
     invalidateLater(intervalMillis(), session)
   })
@@ -1749,8 +1748,7 @@ reactivePoll <- function(intervalMillis, session, checkFunc, valueFunc) {
 
   # When no one holds a reference to this object anymore, destroy and remove the
   # observer so that it doesn't keep firing, and hold onto resources.
-  reg.finalizer(attr(re, "observable"), function(e) {
-    message("finalizing reactive")
+  safe_finalizer(attr(re, "observable"), function(e) {
     o$destroy()
     rm(o, envir = parent.env(environment()))
   })

--- a/R/reactives.R
+++ b/R/reactives.R
@@ -1742,6 +1742,7 @@ reactivePoll <- function(intervalMillis, session, checkFunc, valueFunc) {
     if (re_finalized) {
       o$destroy()
       rm(o, envir = parent.env(environment()))
+      return()
     }
 
     rv$cookie <- checkFunc()

--- a/R/utils.R
+++ b/R/utils.R
@@ -1804,3 +1804,14 @@ constantTimeEquals <- function(raw1, raw2) {
 cat_line <- function(...) {
   cat(paste(..., "\n", collapse = ""))
 }
+
+# A wrapper for reg.finalizer that's a bit safer than using it directly.
+# According to the docs for `reg.finalizer`, the finalizer is scheduled during
+# GC, but "run at a relatively safe time thereafter." This wrapper uses
+# `later` to schedule the callback, which lets us run it at an even more
+# controlled time.
+safe_finalizer <- function(obj, finalizer) {
+  reg.finalizer(obj, function(e) {
+    later::later(function() finalizer(e))
+  })
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -1805,13 +1805,3 @@ cat_line <- function(...) {
   cat(paste(..., "\n", collapse = ""))
 }
 
-# A wrapper for reg.finalizer that's a bit safer than using it directly.
-# According to the docs for `reg.finalizer`, the finalizer is scheduled during
-# GC, but "run at a relatively safe time thereafter." This wrapper uses
-# `later` to schedule the callback, which lets us run it at an even more
-# controlled time.
-safe_finalizer <- function(obj, finalizer) {
-  reg.finalizer(obj, function(e) {
-    later::later(function() finalizer(e))
-  })
-}

--- a/tests/testthat/test-reactivity.r
+++ b/tests/testthat/test-reactivity.r
@@ -1364,8 +1364,5 @@ test_that("reactivePoll doesn't leak observer (#1548)", {
     shiny:::flushReact()
   }
 
-  # It is possible in the future we will have a better method which will remove
-  # the observer without requiring the one extra run. If that happens, the
-  # expected value will be 3 instead of 4.
-  expect_equal(i, 4L)
+  expect_equal(i, 3L)
 })


### PR DESCRIPTION
This fixes #1548. It allows `reactivePoll` objects to clean up when there are no longer any references to them.

Note that there must no longer be any references to the `reactivePoll` object for it to be cleaned up. If there's still a reference to the object, even if that reference isn't consumed by any other reactives/observers, that's not sufficient for it to be cleaned up; in other words, it will keep firing.

Example app:

```R
library(shiny)
shinyApp(
  fluidPage(
    p("Value of ", code("count")),
    verbatimTextOutput("count"),
    p("Value of ", code("i()")),
    verbatimTextOutput("i"),
    actionButton("replace", "Replace count()")
  ),
  function(input, output, session) {
    i <- reactiveVal(0)
    count <- reactivePoll(1000, session,
      checkFunc = function() {
        isolate({
          i(i() + 1)
          i()
        })
      },
      valueFunc = function() {
        isolate(i())
      }
    )

    output$count <- renderText({
      count()
    })
    output$i <- renderText({
      i()
    })

    observeEvent(input$replace, {
      count <<- reactive("count() has been replaced")
      gc()
    })
  }
)
```

Here's how it behaves before this PR:

![2019-07-05 16 07 08](https://user-images.githubusercontent.com/86978/60745231-fb097300-9f3e-11e9-9572-e080649cfa0b.gif)


And after this PR:

![2019-07-05 16 05 54](https://user-images.githubusercontent.com/86978/60745211-dc0ae100-9f3e-11e9-8408-718136d906ac.gif)

Note that before the change, the replacement reactive, which has the value `"count() has been replaced"`, shows up in `output$count`, but after the change, it doesn't. This is because, before the change, the invalidation keeps happening on the timer and causes the `renderText` to re-execute; but after the change, the invalidation stops happening after `count()` is replaced, so it does not cause the `renderText` to re-execute.

Here's a test that works outside of a Shiny app:

```R
library(shiny)
i <- 0
count <- reactivePoll(100, NULL,
  checkFunc = function() {
    i <<- i + 1
    i
  },
  valueFunc = function() i
)

observe({
  message(count())
})
while(i < 3) {
  Sys.sleep(0.1)
  shiny:::timerCallbacks$executeElapsed()
  shiny:::flushReact()
}

rm(count)
gc()

# If the reactivePoll was cleaned up, then running the following should no
# longer increment i.
Sys.sleep(0.2)
shiny:::timerCallbacks$executeElapsed()
shiny:::flushReact()
Sys.sleep(0.2)
shiny:::timerCallbacks$executeElapsed()
shiny:::flushReact()

# This is the crucial part
stopifnot(i == 3)
```

Update: With the final version of this PR, in test app, `i()` will go one number higher than `count` -- what's important is that `i()` stops at some point. Also, in the test code for outside of a Shiny app, it should check for `stopifnot(i == 3)` (this is in the unit tests in the PR).