### PR TITLE
Support reading of Shiny outputs

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -1088,6 +1088,9 @@ ShinySession <- R6Class(
         # will be attached to the observer after it's created.
         outputAttrs <- attr(func, "outputAttrs", TRUE)
 
+        # Save this for getOutput purposes
+        outputAttrs$renderFunc <- func
+
         funcFormals <- formals(func)
         # ..stacktraceon matches with the top-level ..stacktraceoff.., because
         # the observer we set up below has ..stacktraceon=FALSE
@@ -1098,9 +1101,6 @@ ShinySession <- R6Class(
             orig(name=name, shinysession=self)
           }
         }
-
-        # Save this for getOutput purposes
-        outputAttrs$renderFunc <- func
 
         # Preserve source reference and file information when formatting the
         # label for display in the reactive graph

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -1099,6 +1099,9 @@ ShinySession <- R6Class(
           }
         }
 
+        # Save this for getOutput purposes
+        outputAttrs$renderFunc <- func
+
         # Preserve source reference and file information when formatting the
         # label for display in the reactive graph
         srcref <- attr(label, "srcref")
@@ -1194,6 +1197,9 @@ ShinySession <- R6Class(
       else {
         stop(paste("Unexpected", class(func), "output for", name))
       }
+    },
+    getOutput = function(name) {
+      attr(private$.outputs[[name]], "renderFunc", exact = TRUE)
     },
     flushOutput = function() {
       if (private$busyCount > 0)
@@ -2094,7 +2100,11 @@ ShinySession <- R6Class(
 
 #' @export
 `$.shinyoutput` <- function(x, name) {
-  stop("Reading objects from shinyoutput object not allowed.")
+  if (getOption("shiny.allowoutputreads", FALSE)) {
+    .subset2(x, 'impl')$getOutput(name)
+  } else {
+    stop("Reading from shinyoutput object is not allowed.")
+  }
 }
 
 #' @export

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -2100,6 +2100,8 @@ ShinySession <- R6Class(
 
 #' @export
 `$.shinyoutput` <- function(x, name) {
+  name <- .subset2(x, 'ns')(name)
+
   if (getOption("shiny.allowoutputreads", FALSE)) {
     .subset2(x, 'impl')$getOutput(name)
   } else {


### PR DESCRIPTION
Until now, you've been able to assign to the `output` object (i.e. `output$table <- renderTable(...)`) but we throw an error if you try to read from it (i.e. `print(output$plot)`). The reason for this is because I didn't want Shiny beginners to think they could read the current plot.

However, with shinymeta we now have a need for reading outputs. Although shinymeta enables an important scenario, this is admittedly a pretty advanced, niche use; so this PR adds the functionality, but you have to enable it with a global option `shiny.allowoutputreads` (undocumented for now).

I've implemented this as an R option instead of a `shinyOption` because we explicitly do not want to tie the lifetime of the option to an app, but instead to the R process lifetime (I am setting this option in shinymeta's `.onLoad`).