### PR TITLE
Add noscript to basic template

### DIFF
--- a/inst/template/default.html
+++ b/inst/template/default.html
@@ -3,5 +3,8 @@
 <head>
 {{ headContent() }}
 </head>
+<noscript>
+<strong>We are sorry but this application does not work properly without JavaScript enabled. Please enable it to continue.</strong>
+</noscript>
 {{ body }}
 </html>


### PR DESCRIPTION
Since Shiny requires Javascript to work (I believe), this small bit added to basic template should provide a warning in unlikely scenario a user tries to view a Shiny application with Javascript disabled.

Feel free to disregard