### PR TITLE
Author new tab

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@ shiny 1.3.2.9001
 =======
 
 ## Changes
-* Resolved [#2519](https://github.com/rstudio/shiny/issues/2519): Instead of redirecting away from the application open the `AuthorUrl` provided in the metadata in a new tab.
+* Resolved [#2519](https://github.com/rstudio/shiny/issues/2519): While running the app in showcase mode, clicking the `AuthorUrl` provided in the metadata will now open the window in a new tab instead of navigating away from the application.
 
 * Resolved [#1433](https://github.com/rstudio/shiny/issues/1433): `plotOutput()`'s coordmap info now includes discrete axis limits for **ggplot2** plots. As a result, any **shinytest** tests that contain **ggplot2** plots with discrete axes (that were recorded before this change) will now report differences that can safely be updated. This new coordmap info was added to correctly infer what data points are within an input brush and/or near input click/hover in scenarios where a non-trivial discrete axis scale is involved (e.g., whenever `scale_[x/y]_discrete(limits = ...)` and/or free scales across multiple discrete axes are used). ([#2410](https://github.com/rstudio/shiny/pull/2410))
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@ shiny 1.3.2.9001
 =======
 
 ## Changes
+* Resolved [#2519](https://github.com/rstudio/shiny/issues/2519): Instead of redirecting away from the application open the `AuthorUrl` provided in the metadata in a new tab.
 
 * Resolved [#1433](https://github.com/rstudio/shiny/issues/1433): `plotOutput()`'s coordmap info now includes discrete axis limits for **ggplot2** plots. As a result, any **shinytest** tests that contain **ggplot2** plots with discrete axes (that were recorded before this change) will now report differences that can safely be updated. This new coordmap info was added to correctly infer what data points are within an input brush and/or near input click/hover in scenarios where a non-trivial discrete axis scale is involved (e.g., whenever `scale_[x/y]_discrete(limits = ...)` and/or free scales across multiple discrete axes are used). ([#2410](https://github.com/rstudio/shiny/pull/2410))
 

--- a/R/showcase.R
+++ b/R/showcase.R
@@ -66,7 +66,7 @@ appMetadata <- function(desc) {
         br(), "by",
         if ("AuthorUrl" %in% cols)
           a(href=desc[1,"AuthorUrl"], class="shiny-showcase-appauthor",
-            desc[1,"Author"])
+            target="_blank", desc[1,"Author"])
         else
           desc[1,"Author"],
         if ("AuthorEmail" %in% cols)


### PR DESCRIPTION
I tested this with the default app when you go to rstudio and say "new project / shiny app".  I added a `DESCRIPTION` file and added in something like:

```
Title: test app
Author: Tyler
AuthorUrl: https://github.com/TylerKapushinski
License: GPL-3
DisplayMode: Normal
Type: Shiny
```

I ran the app in Rstudio then clicked on the author link and sure enough I was taken to my github page, but in another tab!  The app was still in tact in it's own window.


Closes #2519 