### PR TITLE
Fix selectInput/selectizeInput handling character(1) options

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -20,3 +20,4 @@
 ^revdep$
 ^TODO-promises.md$
 ^manualtests$
+^\.github$

--- a/R/input-utils.R
+++ b/R/input-utils.R
@@ -155,9 +155,7 @@ processGroupedChoices <- function(choices) {
 # Takes a vector/list/factor, and adds names (same as the value) to any entries
 # without names. Coerces all leaf nodes to `character`.
 choicesWithNames <- function(choices) {
-  if (length(choices) == 0) {
-    choices
-  } else if (hasGroups(choices)) {
+  if (hasGroups(choices)) {
     processGroupedChoices(choices)
   } else {
     processFlatChoices(choices)

--- a/R/input-utils.R
+++ b/R/input-utils.R
@@ -125,10 +125,12 @@ processFlatChoices <- function(choices) {
 
 # Processes a "nested" set of choices, or a collection of choices that contains
 # one or more named groups of related choices and zero or more "flat" choices.
-# choices should be named, and any choice group must have a non-empty name.
-# Empty names of remaining "flat" choices are replaced with that choice's value
-# coerced to a character.
+# choices should be a named list, and any choice group must have a non-empty
+# name. Empty names of remaining "flat" choices are replaced with that choice's
+# value coerced to a character.
 processGroupedChoices <- function(choices) {
+  # We assert choices is a list, since only a list may contain a group.
+  stopifnot(is.list(choices))
   choices <- mapply(function(name, choice) {
     choiceIsGroup <- isGroup(choice)
     if (choiceIsGroup && name == "") {

--- a/R/input-utils.R
+++ b/R/input-utils.R
@@ -90,21 +90,22 @@ generateOptions <- function(inputId, selected, inline, type = 'checkbox',
   div(class = "shiny-options-group", options)
 }
 
-# Take a vector or list, and convert to named list. Also, if any children are
+# Take a vector/list/factor, and convert to named list. Also, if any children are
 # vectors with length > 1, convert those to list. If the list is unnamed,
 # convert it to a named list with blank names.
-listify <- function(x) {
+#' @importFrom stats setNames
+listify <- function(x, child = FALSE) {
   if (is.list(x) || is.null(x)) {
-    asNamedVector(lapply(x, listify))
-  } else if (is.character(x)) {
-    if (length(x) == 1 && is.null(names(x))) {
-      x
-    } else {
-      as.list(asNamedVector(x))
-    }
+    # List children are processed and a named list is returned
+    asNamed(lapply(x, listify, TRUE))
+  } else if (child && is.null(names(x)) && length(x) == 1) {
+    # Unnamed children of length = 1 are considered leaves and are converted to
+    # a character(1)
+    as.character(x)
   } else {
-    # Can get here if x is a factor.
-    listify(stats::setNames(as.character(x), names(x)))
+    # Anything else is converted to a (possibly named) character vector, then a
+    # named list
+    asNamed(setNames(as.list(as.character(x)), names(x)))
   }
 }
 

--- a/R/input-utils.R
+++ b/R/input-utils.R
@@ -109,8 +109,7 @@ setDefaultNames <- function(x) {
   x
 }
 
-# Makes a character vector out of x in a way that preserves names if x is a
-# factor.
+# Makes a character vector out of x in a way that preserves names.
 asCharacter <- function(x) {
   stats::setNames(as.character(x), names(x))
 }

--- a/R/input-utils.R
+++ b/R/input-utils.R
@@ -97,7 +97,7 @@ isGroup <- function(choice) {
 
 # True when choices is a list and contains at least one group of related inputs.
 hasGroups <- function(choices) {
-  is.list(choices) && Position(isGroup, choices, nomatch = 0)
+  is.list(choices) && any(vapply(choices, isGroup, logical(1)))
 }
 
 # Assigns empty names to x if it's unnamed, and then fills any empty names with

--- a/R/input-utils.R
+++ b/R/input-utils.R
@@ -103,11 +103,11 @@ listify <- function(x, child = FALSE) {
     as.character(x)
   } else {
     # The process for anything else is:
-    # 1. Convert to a (possibly named) character vector
+    # 1. Convert to a (possibly named) character vector.
     # 2. Add names(x), though it's possibly NULL, to the character vector.
     #    This is because as.character() on factors discards names.
-    # 3. Convert to a list
-    # 4. Ensure the list is named
+    # 3. Convert to a list.
+    # 4. Ensure the list is named.
     asNamed(as.list(stats::setNames(as.character(x), names(x))))
   }
 }

--- a/R/input-utils.R
+++ b/R/input-utils.R
@@ -90,59 +90,93 @@ generateOptions <- function(inputId, selected, inline, type = 'checkbox',
   div(class = "shiny-options-group", options)
 }
 
-# Walks tree and coerces any encountered atomic types to possibly-named
-# character vectors.
-coerceAtomicToCharacter <- function(tree) {
+# This pass accepts a compound structure and returns a "normalized" structure
+# that simplifies subsequent passes.
+#
+# Input: A tree consisting of named and unnamed lists and atomic vectors.
+#
+# Output: A tree consisting of possibly-named lists and unnamed character(1)
+# vectors. Lists are branches and character(1) vectors are leaves.
+passNormalizeTree <- function(tree, root = TRUE) {
   if (is.atomic(tree)) {
-    # Names are preserved explicitly here to preserve names on factors, which
-    # are atomic
-    stats::setNames(as.character(tree), names(tree))
+    # Names are copied in this manner to preserve names from factors.
+    chr <- stats::setNames(as.character(tree), names(tree))
+    if (is.null(names(chr)) && length(chr) == 1 && !root) {
+      chr
+    } else {
+      as.list(chr)
+    }
   } else {
-    lapply(tree, coerceAtomicToCharacter)
+    lapply(tree, passNormalizeTree, FALSE)
   }
 }
 
-# Walks tree and converts any unnamed lists or vectors of length 1 to a vector
-# of length 1.
-coerceLeavesToVectors <- function(tree) {
-  if (length(tree) == 1 && is.null(names(tree))) {
-    tree[[1]]
-  } else {
-    lapply(tree, coerceLeavesToVectors)
-  }
-}
+# This pass applies to branches containing unnamed leaves. Leaves are named with
+# a default based on their value.
+#
+# If one branch contains another, the child branch is given the name "" in the
+# parent branch.
+#
+# Input: A tree consisting of possibly-named lists and unnamed character(1)
+# vectors.
+#
+# Output: A tree consisting of named lists and unnamed character(1) vectors.
+passNameLeaves <- function(tree, errorMsg) {
+  if (is.list(tree)) {
+    # asNamed preserves existing names, but they still might be empty
+    tree <- asNamed(tree)
 
-# Walks tree and ensures all lists are named. Lists without names are given
-# blank names.
-nameBranches <- function(tree) {
-  if(is.list(tree)) {
-    asNamed(lapply(tree, nameBranches))
+    # Here we compute the set of children that are both atomic (character
+    # vectors) and have empty names, because those are the only ones we can
+    # meaningfully automatically name. Then, we set the names of those children
+    # to their values.
+    toRename <- sapply(tree, is.atomic) & (names(tree) == "")
+    names(tree)[toRename] <- tree[toRename]
+
+    lapply(tree, passNameLeaves)
   } else {
     tree
   }
+}
+
+# Computes the depth of a tree given by the isBranch and children functions.
+# - isBranch() should return TRUE if the given tree is a branch and FALSE
+#   otherwise
+# - children() should return a branch's children as a list.
+getDepth <- function(tree, isBranch = is.list, children = identity, depth = 0) {
+  if (isBranch(tree)) {
+    max(sapply(children(tree), getDepth, isBranch, children, depth + 1))
+  } else {
+    depth
+  }
+}
+
+# Returns TRUE when every item in the list `branch` is named and no name is "",
+# and FALSE otherwise.
+branchHasNames <- function(branch) {
+  stopifnot(is.list(branch))
+  ns <- names(branch)
+  !is.null(ns) && !length(ns[ns == ""])
 }
 
 # Takes a vector or list, and adds names (same as the value) to any entries
 # without names. Coerces all leaf nodes to `character`.
 choicesWithNames <- function(choices) {
 
-  choices <- coerceAtomicToCharacter(choices)
-  choices <- coerceLeavesToVectors(choices)
-  choices <- nameBranches(choices)
-  choices <- asNamed(choices)
-
   if (length(choices) == 0) return(choices)
 
-  # Recurse into any subgroups
-  choices <- mapply(choices, names(choices), FUN = function(choice, name) {
-    if (!is.list(choice)) return(choice)
-    if (name == "") stop('All sub-lists in "choices" must be named.')
-    choicesWithNames(choice)
-  }, SIMPLIFY = FALSE)
+  choices <- passNormalizeTree(choices)
+  choices <- passNameLeaves(choices)
 
-  # default missing names to choice values
-  missing <- names(choices) == ""
-  names(choices)[missing] <- as.character(choices)[missing]
+  # Only choices of depth 1 and 2 are currently meaningful in Shiny. Earlier versions of this
+  # code did not produce an error if the choices tree was deeper than 2, and so we don't here.
+  #
+  # - radioButtons() and checkboxGroupInput() use a depth=1 tree via normalizeChoicesArgs()
+  # - selectInput() and selectizeInput() use either depth=1 or depth=2 trees. depth=2 trees
+  #   are used for "grouped" inputs.
+  if (getDepth(choices) >= 2 && !branchHasNames(choices)) {
+    stop('All sub-lists in "choices" must be named.')
+  }
 
   choices
 }

--- a/R/input-utils.R
+++ b/R/input-utils.R
@@ -93,7 +93,6 @@ generateOptions <- function(inputId, selected, inline, type = 'checkbox',
 # Take a vector/list/factor, and convert to named list. Also, if any children are
 # vectors with length > 1, convert those to list. If the list is unnamed,
 # convert it to a named list with blank names.
-#' @importFrom stats setNames
 listify <- function(x, child = FALSE) {
   if (is.list(x) || is.null(x)) {
     # List children are processed and a named list is returned
@@ -103,9 +102,13 @@ listify <- function(x, child = FALSE) {
     # a character(1)
     as.character(x)
   } else {
-    # Anything else is converted to a (possibly named) character vector, then a
-    # named list
-    asNamed(setNames(as.list(as.character(x)), names(x)))
+    # The process for anything else is:
+    # 1. Convert to a (possibly named) character vector
+    # 2. Add names(x), though it's possibly NULL, to the character vector.
+    #    This is because as.character() on factors discards names.
+    # 3. Convert to a list
+    # 4. Ensure the list is named
+    asNamed(as.list(stats::setNames(as.character(x), names(x))))
   }
 }
 

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -639,7 +639,7 @@ ShinySession <- R6Class(
           # that the resulting object is represented as an object in JSON
           # instead of an array, and so that the RDS data structure is of a
           # consistent type.
-          values <- lapply(values, asNamedVector)
+          values <- lapply(values, asNamed)
 
           if (length(values) == 0) {
             return(httpResponse(400, "text/plain",

--- a/R/utils.R
+++ b/R/utils.R
@@ -173,8 +173,8 @@ anyUnnamed <- function(x) {
 }
 
 
-# Given a vector/list, returns a named vector (the labels will be blank).
-asNamedVector <- function(x) {
+# Given a vector/list, returns a named vector/list (the labels will be blank).
+asNamed <- function(x) {
   if (is.null(names(x))) {
     names(x) <- character(length(x))
   }

--- a/man/reactlog.Rd
+++ b/man/reactlog.Rd
@@ -15,6 +15,10 @@ showReactLog(time = TRUE)
 
 reactlogReset()
 }
+\arguments{
+\item{time}{A boolean that specifies whether or not to display the
+time that each reactive takes to calculate a result.}
+}
 \description{
 Provides an interactive browser-based tool for visualizing reactive
 dependencies and execution in your application.

--- a/tests/testthat/test-bootstrap.r
+++ b/tests/testthat/test-bootstrap.r
@@ -69,6 +69,11 @@ test_that("Repeated names for selectInput and radioButtons choices", {
 
 
 test_that("Choices are correctly assigned names", {
+  # Empty non-list
+  expect_identical(
+    choicesWithNames(numeric(0)),
+    stats::setNames(list(), character(0))
+  )
   # Empty character vector
   # An empty character vector isn't a sensical input, but we preserved this test
   # in the off chance that somebody relies on the existing behavior.

--- a/tests/testthat/test-bootstrap.r
+++ b/tests/testthat/test-bootstrap.r
@@ -69,6 +69,11 @@ test_that("Repeated names for selectInput and radioButtons choices", {
 
 
 test_that("Choices are correctly assigned names", {
+  # Empty character vector
+  expect_identical(
+    choicesWithNames(c("")),
+    stats::setNames(list(""), "")
+  )
   # Unnamed character vector
   expect_identical(
     choicesWithNames(c("a","b","3")),

--- a/tests/testthat/test-bootstrap.r
+++ b/tests/testthat/test-bootstrap.r
@@ -69,9 +69,14 @@ test_that("Repeated names for selectInput and radioButtons choices", {
 
 
 test_that("Choices are correctly assigned names", {
-  # Empty non-list
+  # Empty non-list comes back with names
   expect_identical(
     choicesWithNames(numeric(0)),
+    stats::setNames(list(), character(0))
+  )
+  # Empty list comes back with names
+  expect_identical(
+    choicesWithNames(list()),
     stats::setNames(list(), character(0))
   )
   # Empty character vector

--- a/tests/testthat/test-bootstrap.r
+++ b/tests/testthat/test-bootstrap.r
@@ -134,11 +134,6 @@ test_that("Choices are correctly assigned names", {
     choicesWithNames(list(A="a", "b", C=list("d", E="e"))),
     list(A="a", b="b", C=list(d="d", E="e"))
   )
-  # Deeper nesting
-  expect_identical(
-    choicesWithNames(list(A="a", "b", C=list(D=list("e", "f"), G=c(H="h", "i")))),
-    list(A="a", b="b", C=list(D=list(e="e", f="f"), G=list(H="h", i="i")))
-  )
   # Error when sublist is unnamed
   expect_error(choicesWithNames(list(A="a", "b", list(1,2))))
   # Unnamed factor

--- a/tests/testthat/test-bootstrap.r
+++ b/tests/testthat/test-bootstrap.r
@@ -70,9 +70,16 @@ test_that("Repeated names for selectInput and radioButtons choices", {
 
 test_that("Choices are correctly assigned names", {
   # Empty character vector
+  # An empty character vector isn't a sensical input, but we preserved this test
+  # in the off chance that somebody relies on the existing behavior.
   expect_identical(
     choicesWithNames(c("")),
     stats::setNames(list(""), "")
+  )
+  # Single-item character vector
+  expect_identical(
+    choicesWithNames(c("foob")),
+    list(foob="foob")
   )
   # Unnamed character vector
   expect_identical(


### PR DESCRIPTION
Addresses a bug found by Shalu in testing #2524 that manifested with the example 013-selectize.

## Notes

Refactoring this code took a *lot* more time than expected. The original version was complex for at least these reasons (or, excuses):

* `choicesWithNames()` was recursive
* `listify()`, called within `choicesWithNames()`, was itself recursive
* `listify()` dispatched internally on combinations of type, named-ness, and length in a single if/else block

The recursion was needless because no other function that depend on `choicesWithNames()` need to process arbitrarily-deep input trees. `selectizeInput()` requires a tree of depth = 2 to process groups, but that's it.

I believe the principal enhancement with this change is the elimination of recursion. Now, it's obvious the 2 broad categories of input accepted: a flat choice list, or a choice list with some groups, each of which will be processed as a flat choice list.