### PR TITLE
More supports on class, style, and other attributes for UI

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,16 @@ shiny 1.3.2.9001
 
 ### Improvements
 
+* Added `class` and `...` arguments to `*Output` functions, so that these functions
+  can take more controlls on the outputs' containers (generally `div` or `span`).
+
+* Added `style` arguments to `plotOutput` and `imageOutput`, so that addtional CSS
+  styles can be applied to them.
+
+* Resolved inconsitency in `class` argument among `downloadButton()`, `downloadLink()` and `icon()`.
+  The `class` argument can be a character vector for `downloadLink()`, but not for others.
+  Now all of them accepts a vector.
+
 * Resolved [#2402](https://github.com/rstudio/shiny/issues/2402): An informative warning is now thrown for mis-specified (date) strings in `dateInput()`, `updateDateInput()`, `dateRangeInput()`, and `updateDateRangeInput()`. ([#2403](https://github.com/rstudio/shiny/pull/2403))
 
 * Resolved [#2442](https://github.com/rstudio/shiny/issues/2442): The `shiny:inputchanged` JavaScript event now triggers on the related input element instead of `document`. Existing event listeners bound to `document` will still detect the event due to event bubbling. ([#2446](https://github.com/rstudio/shiny/pull/2446))

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -985,7 +985,7 @@ imageOutput <- function(outputId, width = "100%", height="400px",
                         hover = NULL, hoverDelay = NULL, hoverDelayType = NULL,
                         brush = NULL,
                         clickId = NULL, hoverId = NULL,
-                        inline = FALSE, class = NULL, ...) {
+                        inline = FALSE, style = NULL, class = NULL, ...) {
 
   if (!is.null(clickId)) {
     shinyDeprecated(
@@ -1017,8 +1017,12 @@ imageOutput <- function(outputId, width = "100%", height="400px",
     hover <- hoverOpts(id = hover, delay = hoverDelay, delayType = hoverDelayType)
   }
 
-  style <- if (!inline) {
-    paste("width:", validateCssUnit(width), ";", "height:", validateCssUnit(height))
+  if (!inline) {
+    style <- paste(
+      "width:", validateCssUnit(width), ";",
+      "height:", validateCssUnit(height), ";",
+      style
+    )
   }
 
 
@@ -1146,6 +1150,7 @@ imageOutput <- function(outputId, width = "100%", height="400px",
 #'   `imageOutput`/`plotOutput` calls may share the same `id`
 #'   value; brushing one image or plot will cause any other brushes with the
 #'   same `id` to disappear.
+#' @param style Additional CSS styles to apply to the container, if any.
 #' @inheritParams textOutput
 #' @note The arguments `clickId` and `hoverId` only work for R base graphics
 #'   (see the \pkg{\link[graphics:graphics-package]{graphics}} package). They do
@@ -1319,12 +1324,12 @@ plotOutput <- function(outputId, width = "100%", height="400px",
                        hover = NULL, hoverDelay = NULL, hoverDelayType = NULL,
                        brush = NULL,
                        clickId = NULL, hoverId = NULL,
-                       inline = FALSE, class = NULL, ...) {
+                       inline = FALSE, style = NULL, class = NULL, ...) {
 
   # Result is the same as imageOutput, except for HTML class
   res <- imageOutput(outputId, width, height, click, dblclick,
                      hover, hoverDelay, hoverDelayType, brush,
-                     clickId, hoverId, inline, ...)
+                     clickId, hoverId, inline, style, ...)
 
   res$attribs$class <- paste(c("shiny-plot-output", class), collapse = " ")
   res

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -1424,12 +1424,12 @@ dataTableOutput <- function(outputId, class = NULL, ...) {
 #' )
 #' @export
 htmlOutput <- function(outputId, inline = FALSE,
-  container = if (inline) span else div, class, ...)
+  container = if (inline) span else div, class = NULL, ...)
 {
   if (anyUnnamed(list(...))) {
     warning("Unnamed elements in ... will be replaced with dynamic UI.")
   }
-  container(id = outputId, class = paste("shiny-html-output", class), collapse = " "), ...)
+  container(id = outputId, class = paste(c("shiny-html-output", class), collapse = " "), ...)
 }
 
 #' @rdname htmlOutput

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -923,6 +923,8 @@ buildTabItem <- function(index, tabsetId, foundSelected, tabs = NULL,
 #' @param container a function to generate an HTML element to contain the text
 #' @param inline use an inline (`span()`) or block container (`div()`)
 #'   for the output
+#' @param class Additional CSS classes to apply to the container, if any.
+#' @param ... Additional arguments to apply to the container, if any.
 #' @return A text output element that can be included in a panel
 #' @details Text is HTML-escaped prior to rendering. This element is often used
 #'   to display [renderText] output variables.
@@ -944,6 +946,8 @@ textOutput <- function(outputId, container = if (inline) span else div,
 #' @param placeholder if the output is empty or `NULL`, should an empty
 #'   rectangle be displayed to serve as a placeholder? (does not affect
 #'   behavior when the the output in nonempty)
+#' @param class Additional CSS classes to apply to the pre tag, if any.
+#' @param ... Additional arguments to apply to the pre tag, if any.
 #' @return A verbatim text output element that can be included in a panel
 #' @details Text is HTML-escaped prior to rendering. This element is often used
 #'   with the [renderPrint] function to preserve fixed-width formatting
@@ -1334,6 +1338,8 @@ plotOutput <- function(outputId, width = "100%", height="400px",
 #' interactive table with more features.
 #'
 #' @param outputId output variable to read the table from
+#' @param class Additional CSS classes to apply to the div tag, if any.
+#' @param ... Additional arguments to apply to the div tag, if any.
 #' @return A table output element that can be included in a panel
 #'
 #' @seealso [renderTable()], [renderDataTable()].

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -929,8 +929,11 @@ buildTabItem <- function(index, tabsetId, foundSelected, tabs = NULL,
 #' @examples
 #' h3(textOutput("caption"))
 #' @export
-textOutput <- function(outputId, container = if (inline) span else div, inline = FALSE) {
-  container(id = outputId, class = "shiny-text-output")
+textOutput <- function(outputId, container = if (inline) span else div,
+                       inline = FALSE, class = NULL, ...) {
+  container(id = outputId,
+            class = paste(c("shiny-text-output", class), collapse = " "),
+            ...)
 }
 
 #' Create a verbatim text output element
@@ -961,11 +964,12 @@ textOutput <- function(outputId, container = if (inline) span else div, inline =
 #'   )
 #' }
 #' @export
-verbatimTextOutput <- function(outputId, placeholder = FALSE) {
+verbatimTextOutput <- function(outputId, placeholder = FALSE, class = NULL, ...) {
   pre(id = outputId,
-      class = paste(c("shiny-text-output", if (!placeholder) "noplaceholder"),
-                    collapse = " ")
-      )
+      class = paste(c("shiny-text-output", if (!placeholder) "noplaceholder", class),
+                    collapse = " "),
+      ...
+  )
 }
 
 
@@ -977,7 +981,7 @@ imageOutput <- function(outputId, width = "100%", height="400px",
                         hover = NULL, hoverDelay = NULL, hoverDelayType = NULL,
                         brush = NULL,
                         clickId = NULL, hoverId = NULL,
-                        inline = FALSE) {
+                        inline = FALSE, class = NULL, ...) {
 
   if (!is.null(clickId)) {
     shinyDeprecated(
@@ -1017,8 +1021,9 @@ imageOutput <- function(outputId, width = "100%", height="400px",
   # Build up arguments for call to div() or span()
   args <- list(
     id = outputId,
-    class = "shiny-image-output",
-    style = style
+    class = paste(c("shiny-image-output", class), collapse = " "),
+    style = style,
+    ...
   )
 
   # Given a named list with options, replace names like "delayType" with
@@ -1310,14 +1315,14 @@ plotOutput <- function(outputId, width = "100%", height="400px",
                        hover = NULL, hoverDelay = NULL, hoverDelayType = NULL,
                        brush = NULL,
                        clickId = NULL, hoverId = NULL,
-                       inline = FALSE) {
+                       inline = FALSE, class = NULL, ...) {
 
   # Result is the same as imageOutput, except for HTML class
   res <- imageOutput(outputId, width, height, click, dblclick,
                      hover, hoverDelay, hoverDelayType, brush,
-                     clickId, hoverId, inline)
+                     clickId, hoverId, inline, ...)
 
-  res$attribs$class <- "shiny-plot-output"
+  res$attribs$class <- paste(c("shiny-plot-output", class), collapse = " ")
   res
 }
 
@@ -1365,8 +1370,8 @@ plotOutput <- function(outputId, width = "100%", height="400px",
 #'   )
 #' }
 #' @export
-tableOutput <- function(outputId) {
-  div(id = outputId, class="shiny-html-output")
+tableOutput <- function(outputId, class = NULL, ...) {
+  div(id = outputId, class = paste(c("shiny-html-output", class), collapse = " "), ...)
 }
 
 dataTableDependency <- list(
@@ -1383,9 +1388,9 @@ dataTableDependency <- list(
 
 #' @rdname tableOutput
 #' @export
-dataTableOutput <- function(outputId) {
+dataTableOutput <- function(outputId, class = NULL, ...) {
   attachDependencies(
-    div(id = outputId, class="shiny-datatable-output"),
+    div(id = outputId, class = paste(c("shiny-datatable-output", class), collapse = " "), ...),
     dataTableDependency
   )
 }
@@ -1413,12 +1418,12 @@ dataTableOutput <- function(outputId) {
 #' )
 #' @export
 htmlOutput <- function(outputId, inline = FALSE,
-  container = if (inline) span else div, ...)
+  container = if (inline) span else div, class, ...)
 {
   if (anyUnnamed(list(...))) {
     warning("Unnamed elements in ... will be replaced with dynamic UI.")
   }
-  container(id = outputId, class="shiny-html-output", ...)
+  container(id = outputId, class = paste("shiny-html-output", class), collapse = " "), ...)
 }
 
 #' @rdname htmlOutput

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -1472,7 +1472,7 @@ downloadButton <- function(outputId,
                            label="Download",
                            class=NULL, ...) {
   aTag <- tags$a(id=outputId,
-                 class=paste('btn btn-default shiny-download-link', class),
+                 class=paste(c('btn btn-default shiny-download-link', class), collapse = " "),
                  href='',
                  target='_blank',
                  download=NA,
@@ -1551,7 +1551,7 @@ icon <- function(name, class = NULL, lib = "font-awesome") {
     iconClass <- paste0(prefix_class, " ", prefix, "-", name)
   }
   if (!is.null(class))
-    iconClass <- paste(iconClass, class)
+    iconClass <- paste(c(iconClass, class), collapse = " ")
 
   iconTag <- tags$i(class = iconClass)
 

--- a/man/htmlOutput.Rd
+++ b/man/htmlOutput.Rd
@@ -6,10 +6,10 @@
 \title{Create an HTML output element}
 \usage{
 htmlOutput(outputId, inline = FALSE, container = if (inline) span else
-  div, ...)
+  div, class = NULL, ...)
 
 uiOutput(outputId, inline = FALSE, container = if (inline) span else
-  div, ...)
+  div, class = NULL, ...)
 }
 \arguments{
 \item{outputId}{output variable to read the value from}
@@ -18,6 +18,8 @@ uiOutput(outputId, inline = FALSE, container = if (inline) span else
 for the output}
 
 \item{container}{a function to generate an HTML element to contain the text}
+
+\item{class}{Additional CSS classes to apply to the container, if any.}
 
 \item{...}{Other arguments to pass to the container tag function. This is
 useful for providing additional classes for the tag.}

--- a/man/plotOutput.Rd
+++ b/man/plotOutput.Rd
@@ -8,12 +8,12 @@
 imageOutput(outputId, width = "100\%", height = "400px",
   click = NULL, dblclick = NULL, hover = NULL, hoverDelay = NULL,
   hoverDelayType = NULL, brush = NULL, clickId = NULL,
-  hoverId = NULL, inline = FALSE)
+  hoverId = NULL, inline = FALSE, class = NULL, ...)
 
 plotOutput(outputId, width = "100\%", height = "400px", click = NULL,
   dblclick = NULL, hover = NULL, hoverDelay = NULL,
   hoverDelayType = NULL, brush = NULL, clickId = NULL,
-  hoverId = NULL, inline = FALSE)
+  hoverId = NULL, inline = FALSE, class = NULL, ...)
 }
 \arguments{
 \item{outputId}{output variable to read the plot/image from.}
@@ -76,6 +76,10 @@ same \code{id} to disappear.}
 
 \item{inline}{use an inline (\code{span()}) or block container (\code{div()})
 for the output}
+
+\item{class}{Additional CSS classes to apply to the container, if any.}
+
+\item{...}{Additional arguments to apply to the container, if any.}
 }
 \value{
 A plot or image output element that can be included in a panel.

--- a/man/plotOutput.Rd
+++ b/man/plotOutput.Rd
@@ -8,12 +8,12 @@
 imageOutput(outputId, width = "100\%", height = "400px",
   click = NULL, dblclick = NULL, hover = NULL, hoverDelay = NULL,
   hoverDelayType = NULL, brush = NULL, clickId = NULL,
-  hoverId = NULL, inline = FALSE, class = NULL, ...)
+  hoverId = NULL, inline = FALSE, style = NULL, class = NULL, ...)
 
 plotOutput(outputId, width = "100\%", height = "400px", click = NULL,
   dblclick = NULL, hover = NULL, hoverDelay = NULL,
   hoverDelayType = NULL, brush = NULL, clickId = NULL,
-  hoverId = NULL, inline = FALSE, class = NULL, ...)
+  hoverId = NULL, inline = FALSE, style = NULL, class = NULL, ...)
 }
 \arguments{
 \item{outputId}{output variable to read the plot/image from.}
@@ -76,6 +76,8 @@ same \code{id} to disappear.}
 
 \item{inline}{use an inline (\code{span()}) or block container (\code{div()})
 for the output}
+
+\item{style}{Additional CSS styles to apply to the container, if any.}
 
 \item{class}{Additional CSS classes to apply to the container, if any.}
 

--- a/man/tableOutput.Rd
+++ b/man/tableOutput.Rd
@@ -5,12 +5,16 @@
 \alias{dataTableOutput}
 \title{Create a table output element}
 \usage{
-tableOutput(outputId)
+tableOutput(outputId, class = NULL, ...)
 
-dataTableOutput(outputId)
+dataTableOutput(outputId, class = NULL, ...)
 }
 \arguments{
 \item{outputId}{output variable to read the table from}
+
+\item{class}{Additional CSS classes to apply to the div tag, if any.}
+
+\item{...}{Additional arguments to apply to the div tag, if any.}
 }
 \value{
 A table output element that can be included in a panel

--- a/man/textOutput.Rd
+++ b/man/textOutput.Rd
@@ -5,7 +5,7 @@
 \title{Create a text output element}
 \usage{
 textOutput(outputId, container = if (inline) span else div,
-  inline = FALSE)
+  inline = FALSE, class = NULL, ...)
 }
 \arguments{
 \item{outputId}{output variable to read the value from}
@@ -14,6 +14,10 @@ textOutput(outputId, container = if (inline) span else div,
 
 \item{inline}{use an inline (\code{span()}) or block container (\code{div()})
 for the output}
+
+\item{class}{Additional CSS classes to apply to the container, if any.}
+
+\item{...}{Additional arguments to apply to the container, if any.}
 }
 \value{
 A text output element that can be included in a panel

--- a/man/verbatimTextOutput.Rd
+++ b/man/verbatimTextOutput.Rd
@@ -4,7 +4,7 @@
 \alias{verbatimTextOutput}
 \title{Create a verbatim text output element}
 \usage{
-verbatimTextOutput(outputId, placeholder = FALSE)
+verbatimTextOutput(outputId, placeholder = FALSE, class = NULL, ...)
 }
 \arguments{
 \item{outputId}{output variable to read the value from}
@@ -12,6 +12,10 @@ verbatimTextOutput(outputId, placeholder = FALSE)
 \item{placeholder}{if the output is empty or \code{NULL}, should an empty
 rectangle be displayed to serve as a placeholder? (does not affect
 behavior when the the output in nonempty)}
+
+\item{class}{Additional CSS classes to apply to the pre tag, if any.}
+
+\item{...}{Additional arguments to apply to the pre tag, if any.}
 }
 \value{
 A verbatim text output element that can be included in a panel


### PR DESCRIPTION
This PR makes following changes as written in NEWS.md

* Added `class` and `...` arguments to `*Output` functions, so that these functions
  can take more controlls on the outputs' containers (generally `div` or `span`).

* Added `style` arguments to `plotOutput` and `imageOutput`, so that addtional CSS
  styles can be applied to them.

* Resolved inconsitency in `class` argument among `downloadButton()`, `downloadLink()` and `icon()`.
  The `class` argument can be a character vector for `downloadLink()`, but not for others.
  Now all of them accepts a vector.

# Usage example

To apply `display: inline-block` to plots to arrange them,
currently they have to be wrapped by additional `div` (see `ui`).

This PR removes additional `div` (see `ui_new`).

```
library(shiny)
library(ggplot2)

p <- ggplot2::qplot(1, 1)

server <- function(input, output, session) {
  output$a <- output$b <- output$c <- renderPlot(p)
}

# ui's are wrapped by div
ui <- fluidPage(
  plotOutput("a", width = 200, height = 200) %>% tags$div(style = "display: inline-block"),
  plotOutput("b", width = 200, height = 200) %>% tags$div(style = "display: inline-block"),
  plotOutput("c", width = 200, height = 200) %>% tags$div(style = "display: inline-block")
)

# ui's does not have to be wrapped by div anymore
ui_new <- fluidPage(
  plotOutput("a", width = 200, height = 200, style = "display: inline-block"),
  plotOutput("b", width = 200, height = 200, style = "display: inline-block"),
  plotOutput("c", width = 200, height = 200, style = "display: inline-block")
)

# compare
runGadget(ui, server)
runGadget(ui_new, server)

```