### PR TITLE
Fix invalidateLater memory leak

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,8 @@ shiny 1.3.2.9001
 
 * Partially resolved [#2423](https://github.com/rstudio/shiny/issues/2423): Reactivity in Shiny leaked some memory, because R can leak memory whenever a new symbols is interned, which happens whenever a new name/key is used in an environment. R now uses the fastmap package, which avoids this problem. ([#2429](https://github.com/rstudio/shiny/pull/2429))
 
+* Fixed [#2267](https://github.com/rstudio/shiny/issues/2267): Fixed a memory leak with `invalidateLater`. ([#2555](https://github.com/rstudio/shiny/pull/2555))
+
 * Resolved [#2469](https://github.com/rstudio/shiny/issues/2469): `renderText` now takes a `sep` argument that is passed to `cat`. ([#2497](https://github.com/rstudio/shiny/pull/2497))
 
 * Resolved [#2515](https://github.com/rstudio/shiny/issues/2515): `selectInput()` now deals appropriately with named factors. ([#2524](https://github.com/rstudio/shiny/pull/2524))


### PR DESCRIPTION
Closes #2267.

In this test app, it redraws the plot and checks the memory used once per second.

Before this PR, the memory increases by about 7kB each iteration; after this PR, it does not increase at all (after the first few iterations).

```R
library(shiny)
library(pryr)

ui <- fluidPage(
  plotOutput("hist1"),
  verbatimTextOutput("Memory")
)

server <- function(input, output, session) {
  i <- 0
  last_mem <- mem_used()

  output$hist1 <- renderPlot({
    invalidateLater(1000)
    plot(c(1:100))
  })
    
  output$Memory <- renderText({
    invalidateLater(1000)
    cur_mem <- mem_used()
    on.exit({
      i <<- i + 1
      last_mem <<- cur_mem
    })
    paste0(
      "Iteration:    ", i, "\n",
      "Memory usage: ", cur_mem, "\n",
      "Increase:     ", cur_mem - last_mem
    )
  })
}

shinyApp(ui,server)
```

Screenshot of before:

![2019-08-19 12 31 21](https://user-images.githubusercontent.com/86978/63286323-5d170100-c27d-11e9-9dfc-1457121c2b9c.gif)

And after:
![2019-08-19 12 31 45](https://user-images.githubusercontent.com/86978/63286334-6011f180-c27d-11e9-9e8d-1981089d9136.gif)
