### PR TITLE
Reduce the information sent to shiny showcase

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -1629,8 +1629,14 @@ ShinySession <- R6Class(
     reactlog = function(logEntry) {
       # Use sendCustomMessage instead of sendMessage, because the handler in
       # shiny-showcase.js only has access to public API of the Shiny object.
-      if (private$showcase)
-        self$sendCustomMessage("reactlog", logEntry)
+      if (private$showcase) {
+        srcref <- logEntry$srcref
+        srcfile <- logEntry$srcfile
+        if (!is.null(srcref) && !is.null(srcfile)) {
+          # only send needed information, not all of reactlog info.
+          self$sendCustomMessage("showcase-src", list(srcref = srcref, srcfile = srcfile))
+        }
+      }
     },
     reload = function() {
       private$sendMessage(reload = TRUE)

--- a/inst/www/shared/shiny-showcase.js
+++ b/inst/www/shared/shiny-showcase.js
@@ -117,7 +117,7 @@
 
   // If this is the main Shiny window, wire up our custom message handler.
   if (window.Shiny) {
-    Shiny.addCustomMessageHandler('reactlog', function(message) {
+    Shiny.addCustomMessageHandler('showcase-src', function(message) {
       if (message.srcref && message.srcfile) {
         highlightSrcref(message.srcref, message.srcfile);
       }
@@ -267,4 +267,3 @@
   if (window.hljs)
     hljs.initHighlightingOnLoad();
 })();
-


### PR DESCRIPTION
Fixes #2378 

Changes: 
* does not send messages to the browser that are immediately discarded in the browser. Instead, discard the messages with in the R process
* send required source info only for showcase information.

Possible things to change back:
* changed shiny custom message key to `showcase-src` from `reactlog` as it has nothing to do with `reactlog` and only the showcase source files.  
  * Can users listen to this? This might be an unnecessary/bug introducing name change