### PR TITLE
Tweak startup message

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -586,12 +586,14 @@ startApp <- function(appObj, port, host, quiet) {
       hostString <- host
       if (httpuv::ipFamily(host) == 6L)
         hostString <- paste0("[", hostString, "]")
-      message('\n', 'Listening on http://', hostString, ':', port)
+      message('Listening for Shiny app on http://', hostString, ':', port)
+      messageStopApp()
     }
     return(startServer(host, port, httpuvApp))
   } else if (is.character(port)) {
     if (!quiet) {
-      message('\n', 'Listening on domain socket ', port)
+      message('Listening for Shiny app on domain socket ', port)
+      messageStopApp()
     }
     mask <- attr(port, 'mask')
     if (is.null(mask)) {
@@ -602,6 +604,11 @@ startApp <- function(appObj, port, host, quiet) {
     }
     return(startPipeServer(port, mask, httpuvApp))
   }
+}
+
+messageStopApp <- function() {
+  key <- if (identical(.Platform$GUI, "RStudio")) "Escape" else "Ctrl + C/Break"
+  message("Press ", key, " to stop Shiny and return control to console")
 }
 
 # Run an application that was created by \code{\link{startApp}}. This

--- a/R/server.R
+++ b/R/server.R
@@ -586,13 +586,13 @@ startApp <- function(appObj, port, host, quiet) {
       hostString <- host
       if (httpuv::ipFamily(host) == 6L)
         hostString <- paste0("[", hostString, "]")
-      message('Listening for Shiny app on http://', hostString, ':', port)
+      message('Shiny is listening on http://', hostString, ':', port)
       messageStopApp()
     }
     return(startServer(host, port, httpuvApp))
   } else if (is.character(port)) {
     if (!quiet) {
-      message('Listening for Shiny app on domain socket ', port)
+      message('Shiny is listening on domain socket ', port)
       messageStopApp()
     }
     mask <- attr(port, 'mask')


### PR DESCRIPTION
* Specifically mention shiny
* Eliminate leading newline
* Tell the user how to stop it

I _think_ this will help new users, and experienced users will rapidly not see it because they see it so frequently.