### PR TITLE
Remove Sys.sleep in runApp()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,8 @@ shiny 1.3.2.9001
 
 * Resolved [#2433](https://github.com/rstudio/shiny/issues/2433): An informative warning is now thrown if subdirectories of the app's `www/` directory are masked by other resource prefixes and/or the same resource prefix is mapped to different local file paths. ([#2434](https://github.com/rstudio/shiny/pull/2434))
 
+* Resolved [#2471](https://github.com/rstudio/shiny/issues/2471): Large file uploads to a Windows computer were slow. ([#2579](https://github.com/rstudio/shiny/pull/2579))
+
 ### Bug fixes
 
 * Fixed [#2116](https://github.com/rstudio/shiny/issues/2116): Fixed an issue where dynamic tabs could not be added when on a hosted platform. ([#2545](https://github.com/rstudio/shiny/pull/2545))

--- a/R/server.R
+++ b/R/server.R
@@ -986,7 +986,6 @@ runApp <- function(appDir=getwd(),
     captureStackTraces({
       while (!.globals$stopped) {
         ..stacktracefloor..(serviceApp())
-        Sys.sleep(0.001)
       }
     })
   )


### PR DESCRIPTION
This resolves #2471. The `Sys.sleep()` was added a long time ago, before we used the later package, but is no longer necessary and can cause performance issues.