### PR TITLE
Clarify required argumented to shinyApp()

### DIFF
--- a/R/app.R
+++ b/R/app.R
@@ -68,10 +68,10 @@
 #'   runApp(app)
 #' }
 #' @export
-shinyApp <- function(ui=NULL, server=NULL, onStart=NULL, options=list(),
+shinyApp <- function(ui, server, onStart=NULL, options=list(),
                      uiPattern="/", enableBookmarking=NULL) {
-  if (is.null(server)) {
-    stop("`server` missing from shinyApp")
+  if (!is.function(server)) {
+    stop("`server` must be a function", call. = FALSE)
   }
 
   # Ensure that the entire path is a match

--- a/man/shinyApp.Rd
+++ b/man/shinyApp.Rd
@@ -13,8 +13,8 @@
 \alias{as.tags.shiny.appobj}
 \title{Create a Shiny app object}
 \usage{
-shinyApp(ui = NULL, server = NULL, onStart = NULL,
-  options = list(), uiPattern = "/", enableBookmarking = NULL)
+shinyApp(ui, server, onStart = NULL, options = list(),
+  uiPattern = "/", enableBookmarking = NULL)
 
 shinyAppDir(appDir, options = list())
 


### PR DESCRIPTION
This does technically change the interface as `shinyApp(server = function(input, output) ...))` would have previously worked, but it didn't generate a useful app.

Fixes #2462