### PR TITLE
Bump later version requirement

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -73,7 +73,7 @@ Imports:
     htmltools (>= 0.3.6.9004),
     R6 (>= 2.0),
     sourcetools,
-    later (>= 0.7.2),
+    later (>= 0.8.0.9004),
     promises (>= 1.0.1),
     tools,
     crayon,
@@ -91,7 +91,8 @@ Suggests:
     magrittr
 Remotes:
     rstudio/htmltools,
-    rstudio/httpuv
+    rstudio/httpuv,
+    r-lib/later
 URL: http://shiny.rstudio.com
 BugReports: https://github.com/rstudio/shiny/issues
 Collate:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -65,7 +65,7 @@ Depends:
 Imports:
     utils,
     grDevices,
-    httpuv (>= 1.5.1.9002),
+    httpuv (>= 1.5.2),
     mime (>= 0.3),
     jsonlite (>= 0.9.16),
     xtable,
@@ -91,7 +91,6 @@ Suggests:
     magrittr
 Remotes:
     rstudio/htmltools,
-    rstudio/httpuv,
     r-lib/later
 URL: http://shiny.rstudio.com
 BugReports: https://github.com/rstudio/shiny/issues


### PR DESCRIPTION
This should be merged after https://github.com/r-lib/later/pull/104 is merged. It is not strictly required for shiny to work properly, but it will help users get the updated version of later.