### PR TITLE
Improve inputFile() accept documentation

### DIFF
--- a/R/input-file.R
+++ b/R/input-file.R
@@ -11,8 +11,15 @@
 #' @param multiple Whether the user should be allowed to select and upload
 #'   multiple files at once. **Does not work on older browsers, including
 #'   Internet Explorer 9 and earlier.**
-#' @param accept A character vector of MIME types; gives the browser a hint of
-#'   what kind of files the server is expecting.
+#' @param accept A character vector of "unique file type specifiers" which
+#'   gives the browser a hint as to the type of file the server expects.
+#'   Many browsers use this prevent the user from selecting an invalid file.
+#'
+#'   A unique file type specifier can be:
+#'   * A case insensitive extension like `.csv` or `.rds`.
+#'   * A valid MIME type, like `text/plain` or `application/pdf`
+#'   * One of `audio/*`, `video/*`, or `image/*` meaning any audio, video,
+#'     or image type, respectively.
 #' @param buttonLabel The label used on the button. Can be text or an HTML tag
 #'   object.
 #' @param placeholder The text to show before a file has been uploaded.
@@ -24,13 +31,7 @@
 #' ui <- fluidPage(
 #'   sidebarLayout(
 #'     sidebarPanel(
-#'       fileInput("file1", "Choose CSV File",
-#'         accept = c(
-#'           "text/csv",
-#'           "text/comma-separated-values,text/plain",
-#'           ".csv")
-#'         ),
-#'       tags$hr(),
+#'       fileInput("file1", "Choose CSV File", accept = ".csv"),
 #'       checkboxInput("header", "Header", TRUE)
 #'     ),
 #'     mainPanel(
@@ -41,17 +42,13 @@
 #'
 #' server <- function(input, output) {
 #'   output$contents <- renderTable({
-#'     # input$file1 will be NULL initially. After the user selects
-#'     # and uploads a file, it will be a data frame with 'name',
-#'     # 'size', 'type', and 'datapath' columns. The 'datapath'
-#'     # column will contain the local filenames where the data can
-#'     # be found.
-#'     inFile <- input$file1
+#'     file <- input$file1
+#'     ext <- tools::file_ext(file$datapath)
 #'
-#'     if (is.null(inFile))
-#'       return(NULL)
+#'     req(file)
+#'     validate(need(ext == "csv", "Please upload a csv file"))
 #'
-#'     read.csv(inFile$datapath, header = input$header)
+#'     read.csv(file$datapath, header = input$header)
 #'   })
 #' }
 #'

--- a/man/fileInput.Rd
+++ b/man/fileInput.Rd
@@ -17,8 +17,17 @@ fileInput(inputId, label, multiple = FALSE, accept = NULL,
 multiple files at once. \strong{Does not work on older browsers, including
 Internet Explorer 9 and earlier.}}
 
-\item{accept}{A character vector of MIME types; gives the browser a hint of
-what kind of files the server is expecting.}
+\item{accept}{A character vector of "unique file type specifiers" which
+gives the browser a hint as to the type of file the server expects.
+Many browsers use this prevent the user from selecting an invalid file.
+
+A unique file type specifier can be:
+\itemize{
+\item A case insensitive extension like \code{.csv} or \code{.rds}.
+\item A valid MIME type, like \code{text/plain} or \code{application/pdf}
+\item One of \code{audio/*}, \code{video/*}, or \code{image/*} meaning any audio, video,
+or image type, respectively.
+}}
 
 \item{width}{The width of the input, e.g. \code{'400px'}, or \code{'100\%'};
 see \code{\link[=validateCssUnit]{validateCssUnit()}}.}
@@ -60,13 +69,7 @@ if (interactive()) {
 ui <- fluidPage(
   sidebarLayout(
     sidebarPanel(
-      fileInput("file1", "Choose CSV File",
-        accept = c(
-          "text/csv",
-          "text/comma-separated-values,text/plain",
-          ".csv")
-        ),
-      tags$hr(),
+      fileInput("file1", "Choose CSV File", accept = ".csv"),
       checkboxInput("header", "Header", TRUE)
     ),
     mainPanel(
@@ -77,17 +80,13 @@ ui <- fluidPage(
 
 server <- function(input, output) {
   output$contents <- renderTable({
-    # input$file1 will be NULL initially. After the user selects
-    # and uploads a file, it will be a data frame with 'name',
-    # 'size', 'type', and 'datapath' columns. The 'datapath'
-    # column will contain the local filenames where the data can
-    # be found.
-    inFile <- input$file1
+    file <- input$file1
+    ext <- tools::file_ext(file$datapath)
 
-    if (is.null(inFile))
-      return(NULL)
+    req(file)
+    validate(need(ext == "csv", "Please upload a csv file"))
 
-    read.csv(inFile$datapath, header = input$header)
+    read.csv(file$datapath, header = input$header)
   })
 }
 


### PR DESCRIPTION
* accept should be a vector of "unique file type identifiers" not a vector of mime types (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#Unique_file_type_specifiers)

* I updated the example to use req() and to validate the uploaded extension; this is good practice since not all browsers will enforce `accept`