### PR TITLE
Fix updateSelectizeInput(), fixes #2624

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,7 +26,7 @@ shiny 1.4.0
 
 * Added `resourcePaths()` and `removeResourcePaths()` functions. ([#2459](https://github.com/rstudio/shiny/pull/2459))
 
-* Resolved [#2515](https://github.com/rstudio/shiny/issues/2515): `selectInput()` now deals appropriately with named factors. ([#2524](https://github.com/rstudio/shiny/pull/2524))
+* Resolved [#2515](https://github.com/rstudio/shiny/issues/2515): `selectInput()` and `selectizeInput()` now deal appropriately with named factors. Note that `updateSelectInput()` and `updateSelectizeInput()` **do not** yet handle factors; their behavior is unchanged. ([#2524](https://github.com/rstudio/shiny/pull/2524), [#2540](https://github.com/rstudio/shiny/pull/2540), [#2625](https://github.com/rstudio/shiny/pull/2625))
 
 * Resolved [#2433](https://github.com/rstudio/shiny/issues/2433): An informative warning is now thrown if subdirectories of the app's `www/` directory are masked by other resource prefixes and/or the same resource prefix is mapped to different local file paths. ([#2434](https://github.com/rstudio/shiny/pull/2434))
 

--- a/R/input-utils.R
+++ b/R/input-utils.R
@@ -92,7 +92,10 @@ generateOptions <- function(inputId, selected, inline, type = 'checkbox',
 
 # True when a choice list item represents a group of related inputs.
 isGroup <- function(choice) {
-  length(choice) > 1 || !is.null(names(choice))
+  is.list(choice) ||
+    !is.null(names(choice)) ||
+    length(choice) > 1 ||
+    length(choice) == 0
 }
 
 # True when choices is a list and contains at least one group of related inputs.
@@ -131,6 +134,10 @@ processFlatChoices <- function(choices) {
 processGroupedChoices <- function(choices) {
   # We assert choices is a list, since only a list may contain a group.
   stopifnot(is.list(choices))
+  # The list might be unnamed by this point. We add default names of "" so that
+  # names(choices) is not zero-length and mapply can work. Within mapply, we
+  # error if any group's name is ""
+  choices <- asNamed(choices)
   choices <- mapply(function(name, choice) {
     choiceIsGroup <- isGroup(choice)
     if (choiceIsGroup && name == "") {

--- a/tests/testthat/test-bootstrap.r
+++ b/tests/testthat/test-bootstrap.r
@@ -69,7 +69,7 @@ test_that("Repeated names for selectInput and radioButtons choices", {
 
 
 test_that("Choices are correctly assigned names", {
-  # Empty non-list comes back with names
+  # Empty non-list comes back as a list with names
   expect_identical(
     choicesWithNames(numeric(0)),
     stats::setNames(list(), character(0))
@@ -78,6 +78,16 @@ test_that("Choices are correctly assigned names", {
   expect_identical(
     choicesWithNames(list()),
     stats::setNames(list(), character(0))
+  )
+  # NULL comes back as an empty list with names
+  expect_identical(
+    choicesWithNames(NULL),
+    stats::setNames(list(), character(0))
+  )
+  # NA is processed as a leaf, not a group
+  expect_identical(
+    choicesWithNames(NA),
+    as.list(stats::setNames(as.character(NA), NA))
   )
   # Empty character vector
   # An empty character vector isn't a sensical input, but we preserved this test
@@ -151,8 +161,19 @@ test_that("Choices are correctly assigned names", {
     choicesWithNames(list(A="a", "b", C=list("d", E="e"))),
     list(A="a", b="b", C=list(d="d", E="e"))
   )
+  # List, with a single-item unnamed group list
+  expect_identical(
+    choicesWithNames(list(C=list(123))),
+    list(C=list("123"="123"))
+  )
   # Error when sublist is unnamed
   expect_error(choicesWithNames(list(A="a", "b", list(1,2))))
+  # Error when list is unnamed and contains a group
+  # NULL, list(1,2), and anything of length() == 0 is considered a group.
+  # NA is NOT a group.
+  expect_error(choicesWithNames(list(NULL)), regexp = "must be named")
+  expect_error(choicesWithNames(list(list(1,2))), regexp = "must be named")
+  expect_error(choicesWithNames(list(character(0))), regexp = "must be named")
   # Unnamed factor
   expect_identical(
     choicesWithNames(factor(c("a","b","3"))),
@@ -172,6 +193,16 @@ test_that("Choices are correctly assigned names", {
   expect_identical(
     choicesWithNames(list(A="a", B="b", C=structure(factor(c("d", "e")), names = c("d", "e")))),
     list(A="a", B="b", C=list(d="d", e="e"))
+  )
+  # List, named, with an empty group as an unnamed empty list
+  expect_identical(
+    choicesWithNames(list(C=list())),
+    list(C=stats::setNames(list(), character()))
+  )
+  # List, named, with an empty group as an unnamed empty vector
+  expect_identical(
+    choicesWithNames(list(C=c())),
+    list(C=stats::setNames(list(), character()))
   )
 })
 


### PR DESCRIPTION
This PR fixes #2624 by aligning the choice processing behavior of `selectizeInput()`/`selectInput()` and `updateSelectizeInput()`/`updateSelectInput()`.

* In previous releases of Shiny, named `choices` of length 1 that were unnamed lists were considered groups, not leaves. `list(x=list(123))` is an example. My changes in #2540 altered that behavior so unnamed lists of length 1 were considered leaves, not groups. The bug was revealed during testing of `updateSelectizeInput()`, because its choice processing implementation considered them groups, just like the original `choicesWithNames()` code did before I rewrote it.
  * To fix this, I changed the definition of `isGroup()` to include lists and added a test.
* I noticed that empty lists and vectors were considered leaves and not groups. I modified `isGroup()` to also include them and added tests.
* I noticed that lists containing unnamed groups would result in a different error than the previous code produced. I added an `asNamed()` in `processGroupedChoices()` to ensure `mapply()` would work; the function inside is what produces the correct error. I added tests for this.
* I noticed that a few special cases of `NA` and `NULL` were untested. I added tests.

## Notes

Note that a previous iteration of this PR included [a replacement](https://gist.github.com/alandipert/7da41616548def947fdca7feca6424a5) for `updateSelectizeInput()`'s choice processing code that built on #2540 instead of implementing choice processing separately.

Unfortunately, that code necessitated 2 walks of the `choices` tree, and so was twice as slow. We are highly sensitive to performance in this case as users select `server = TRUE` specifically for performance reasons as `choices` is large.

In order to compete with the existing `updateSelectizeInput()` code, `choicesWithNamesRectangle()` would have needed to be rewritten as a single pass of `choices`, which we deemed too significant an undertaking given the urgency of a 1.4.0 release.

So, instead of doing that, we reduced the scope of this PR to a small change of the new code and the addition of tests that bring it to feature parity with the code inside `updateSelectizeInput()`.