### PR TITLE
Best-effort task scheduling through the session

### DIFF
--- a/R/reactives.R
+++ b/R/reactives.R
@@ -2375,7 +2375,7 @@ debounce <- function(r, millis, priority = 100, domain = getDefaultReactiveDomai
     }
 
     # The value (or possibly millis) changed. Start or reset the timer.
-    v$when <- Sys.time() + millis()/1000
+    v$when <- getTime(domain) + millis()/1000
   }, label = "debounce tracker", domain = domain, priority = priority)
 
   # This observer is the timer. It rests until v$when elapses, then touches
@@ -2384,7 +2384,7 @@ debounce <- function(r, millis, priority = 100, domain = getDefaultReactiveDomai
     if (is.null(v$when))
       return()
 
-    now <- Sys.time()
+    now <- getTime(domain)
     if (now >= v$when) {
       # Mod by 999999999 to get predictable overflow behavior
       v$trigger <- isolate(v$trigger %OR% 0) %% 999999999 + 1
@@ -2435,12 +2435,12 @@ throttle <- function(r, millis, priority = 100, domain = getDefaultReactiveDomai
     if (is.null(v$lastTriggeredAt)) {
       0
     } else {
-      max(0, (v$lastTriggeredAt + millis()/1000) - Sys.time()) * 1000
+      max(0, (v$lastTriggeredAt + millis()/1000) - getTime(domain)) * 1000
     }
   }
 
   trigger <- function() {
-    v$lastTriggeredAt <- Sys.time()
+    v$lastTriggeredAt <- getTime(domain)
     # Mod by 999999999 to get predictable overflow behavior
     v$trigger <- isolate(v$trigger) %% 999999999 + 1
     v$pending <- FALSE

--- a/R/reactives.R
+++ b/R/reactives.R
@@ -1513,14 +1513,16 @@ reactiveTimer <- function(intervalMs=1000, session = getDefaultReactiveDomain())
   # reactId <- nextGlobalReactId()
   # rLog$define(reactId, paste0("timer(", intervalMs, ")"))
 
+  scheduler <- defineScheduler(session)
+
   dependents <- Map$new()
-  timerHandle <- scheduleTask(intervalMs, function() {
+  timerHandle <- scheduler(intervalMs, function() {
     # Quit if the session is closed
     if (!is.null(session) && session$isClosed()) {
       return(invisible())
     }
 
-    timerHandle <<- scheduleTask(intervalMs, sys.function())
+    timerHandle <<- scheduler(intervalMs, sys.function())
 
     doInvalidate <- function() {
       lapply(
@@ -1613,7 +1615,6 @@ reactiveTimer <- function(intervalMs=1000, session = getDefaultReactiveDomain())
 #' }
 #' @export
 invalidateLater <- function(millis, session = getDefaultReactiveDomain()) {
-
   force(session)
 
   ctx <- getCurrentContext()
@@ -1621,7 +1622,9 @@ invalidateLater <- function(millis, session = getDefaultReactiveDomain()) {
 
   clear_on_ended_callback <- function() {}
 
-  timerHandle <- scheduleTask(millis, function() {
+  scheduler <- defineScheduler(session)
+
+  timerHandle <- scheduler(millis, function() {
     if (is.null(session)) {
       ctx$invalidate()
       return(invisible())

--- a/R/reactives.R
+++ b/R/reactives.R
@@ -1513,14 +1513,16 @@ reactiveTimer <- function(intervalMs=1000, session = getDefaultReactiveDomain())
   # reactId <- nextGlobalReactId()
   # rLog$define(reactId, paste0("timer(", intervalMs, ")"))
 
+  scheduler <- defineScheduler(session)
+
   dependents <- Map$new()
-  timerHandle <- session$.scheduleTask(intervalMs, function() {
+  timerHandle <- scheduler(intervalMs, function() {
     # Quit if the session is closed
     if (!is.null(session) && session$isClosed()) {
       return(invisible())
     }
 
-    timerHandle <<- session$.scheduleTask(intervalMs, sys.function())
+    timerHandle <<- scheduler(intervalMs, sys.function())
 
     doInvalidate <- function() {
       lapply(
@@ -1620,7 +1622,9 @@ invalidateLater <- function(millis, session = getDefaultReactiveDomain()) {
 
   clear_on_ended_callback <- function() {}
 
-  timerHandle <- session$.scheduleTask(millis, function() {
+  scheduler <- defineScheduler(session)
+
+  timerHandle <- scheduler(millis, function() {
     if (is.null(session)) {
       ctx$invalidate()
       return(invisible())
@@ -2371,7 +2375,7 @@ debounce <- function(r, millis, priority = 100, domain = getDefaultReactiveDomai
     }
 
     # The value (or possibly millis) changed. Start or reset the timer.
-    v$when <- domain$.now() + millis()/1000
+    v$when <- getTime(domain) + millis()/1000
   }, label = "debounce tracker", domain = domain, priority = priority)
 
   # This observer is the timer. It rests until v$when elapses, then touches
@@ -2380,7 +2384,7 @@ debounce <- function(r, millis, priority = 100, domain = getDefaultReactiveDomai
     if (is.null(v$when))
       return()
 
-    now <- domain$.now()
+    now <- getTime(domain)
     if (now >= v$when) {
       # Mod by 999999999 to get predictable overflow behavior
       v$trigger <- isolate(v$trigger %OR% 0) %% 999999999 + 1
@@ -2431,12 +2435,12 @@ throttle <- function(r, millis, priority = 100, domain = getDefaultReactiveDomai
     if (is.null(v$lastTriggeredAt)) {
       0
     } else {
-      max(0, (v$lastTriggeredAt + millis()/1000) - domain$.now()) * 1000
+      max(0, (v$lastTriggeredAt + millis()/1000) - getTime(domain)) * 1000
     }
   }
 
   trigger <- function() {
-    v$lastTriggeredAt <- domain$.now()
+    v$lastTriggeredAt <- getTime(domain)
     # Mod by 999999999 to get predictable overflow behavior
     v$trigger <- isolate(v$trigger) %% 999999999 + 1
     v$pending <- FALSE

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -723,8 +723,11 @@ ShinySession <- R6Class(
     requestFlush = function() {
       appsNeedingFlush$set(self$token, self)
     },
-    scheduleTask = function(millis, callback) {
+    .scheduleTask = function(millis, callback) {
       scheduleTask(millis, callback)
+    },
+    .now = function(){
+      getNow()
     },
     rootScope = function() {
       self

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -723,8 +723,11 @@ ShinySession <- R6Class(
     requestFlush = function() {
       appsNeedingFlush$set(self$token, self)
     },
-    scheduleTask = function(millis, callback) {
+    .scheduleTask = function(millis, callback) {
       scheduleTask(millis, callback)
+    },
+    .now = function() {
+      getNow()
     },
     rootScope = function() {
       self

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -723,6 +723,9 @@ ShinySession <- R6Class(
     requestFlush = function() {
       appsNeedingFlush$set(self$token, self)
     },
+    scheduleTask = function(millis, callback) {
+      scheduleTask(millis, callback)
+    },
     rootScope = function() {
       self
     },

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -723,11 +723,8 @@ ShinySession <- R6Class(
     requestFlush = function() {
       appsNeedingFlush$set(self$token, self)
     },
-    .scheduleTask = function(millis, callback) {
+    scheduleTask = function(millis, callback) {
       scheduleTask(millis, callback)
-    },
-    .now = function() {
-      getNow()
     },
     rootScope = function() {
       self

--- a/R/timer.R
+++ b/R/timer.R
@@ -119,25 +119,3 @@ scheduleTask <- function(millis, callback) {
     invisible(timerCallbacks$unschedule(id))
   }
 }
-
-#' Get a scheduler function for scheduling tasks. Give priority to the
-#' session scheduler, but if it doesn't exist, use the global one.
-#' @noRd
-defineScheduler <- function(session){
-  if (!is.null(session) && !is.null(session$scheduleTask)){
-    return(session$scheduleTask)
-  }
-  scheduleTask
-}
-
-
-#' Get the current time a la `Sys.time()`. Prefer to get it via the
-#' `session$now()` function, but if that's not available, just return the
-#' current system time.
-#' @noRd
-getTime <- function(session){
-  if (!is.null(session) && !is.null(session$now)){
-    return(session$now())
-  }
-  Sys.time()
-}

--- a/R/timer.R
+++ b/R/timer.R
@@ -96,3 +96,15 @@ scheduleTask <- function(millis, callback) {
     invisible(timerCallbacks$unschedule(id))
   }
 }
+
+#' Get a scheduler function for scheduling tasks. Give priority to the
+#' session scheduler, but if it doesn't exist, use the global one.
+#' @noRd
+defineScheduler <- function(session){
+  if (!is.null(session)){
+    if (!is.null(session$scheduleTask)){
+      return(session$scheduleTask)
+    }
+  }
+  scheduleTask
+}

--- a/R/timer.R
+++ b/R/timer.R
@@ -4,7 +4,7 @@ getNow <- function() {
   as.numeric(Sys.time()) * 1000
 }
 
-BaseTimerCallbacks <- R6Class(
+TimerCallbacks <- R6Class(
   'TimerCallbacks',
   portable = FALSE,
   class = FALSE,
@@ -88,22 +88,9 @@ BaseTimerCallbacks <- R6Class(
   )
 )
 
-TimerCallbacks <- R6Class(
-  'TimerCallbacks',
-  inherit=BaseTimerCallbacks,
-  portable = FALSE,
-  class = FALSE,
-  public = list(
-    # Empty constructor defaults to the getNow implementation
-    initialize = function() {
-      super$initialize(getNow)
-    }
-  )
-)
-
 MockableTimerCallbacks <- R6Class(
   'MockableTimerCallbacks',
-  inherit=BaseTimerCallbacks,
+  inherit=TimerCallbacks,
   portable = FALSE,
   class = FALSE,
   public = list(
@@ -115,7 +102,7 @@ MockableTimerCallbacks <- R6Class(
       return(private$time)
     },
     elapse = function(millis){
-      private$time <<- private$time + millis
+      private$time <- private$time + millis
     }
   ), private = list(
     time = 0L
@@ -137,10 +124,8 @@ scheduleTask <- function(millis, callback) {
 #' session scheduler, but if it doesn't exist, use the global one.
 #' @noRd
 defineScheduler <- function(session){
-  if (!is.null(session)){
-    if (!is.null(session$scheduleTask)){
-      return(session$scheduleTask)
-    }
+  if (!is.null(session) && !is.null(session$scheduleTask)){
+    return(session$scheduleTask)
   }
   scheduleTask
 }
@@ -151,10 +136,8 @@ defineScheduler <- function(session){
 #' current system time.
 #' @noRd
 getTime <- function(session){
-  if (!is.null(session)){
-    if (!is.null(session$now)){
-      return(session$now())
-    }
+  if (!is.null(session) && !is.null(session$now)){
+    return(session$now())
   }
   Sys.time()
 }

--- a/R/timer.R
+++ b/R/timer.R
@@ -119,3 +119,25 @@ scheduleTask <- function(millis, callback) {
     invisible(timerCallbacks$unschedule(id))
   }
 }
+
+#' Get a scheduler function for scheduling tasks. Give priority to the
+#' session scheduler, but if it doesn't exist, use the global one.
+#' @noRd
+defineScheduler <- function(session){
+  if (!is.null(session) && !is.null(session$scheduleTask)){
+    return(session$scheduleTask)
+  }
+  scheduleTask
+}
+
+
+#' Get the current time a la `Sys.time()`. Prefer to get it via the
+#' `session$now()` function, but if that's not available, just return the
+#' current system time.
+#' @noRd
+getTime <- function(session){
+  if (!is.null(session) && !is.null(session$now)){
+    return(session$now())
+  }
+  Sys.time()
+}

--- a/R/timer.R
+++ b/R/timer.R
@@ -124,20 +124,20 @@ scheduleTask <- function(millis, callback) {
 #' session scheduler, but if it doesn't exist, use the global one.
 #' @noRd
 defineScheduler <- function(session){
-  if (!is.null(session) && !is.null(session$scheduleTask)){
-    return(session$scheduleTask)
+  if (!is.null(session) && !is.null(session$.scheduleTask)){
+    return(session$.scheduleTask)
   }
   scheduleTask
 }
 
 
 #' Get the current time a la `Sys.time()`. Prefer to get it via the
-#' `session$now()` function, but if that's not available, just return the
+#' `session$.now()` function, but if that's not available, just return the
 #' current system time.
 #' @noRd
 getTime <- function(session){
-  if (!is.null(session) && !is.null(session$now)){
-    return(session$now())
+  if (!is.null(session) && !is.null(session$.now)){
+    return(session$.now())
   }
   Sys.time()
 }

--- a/R/timer.R
+++ b/R/timer.R
@@ -144,3 +144,17 @@ defineScheduler <- function(session){
   }
   scheduleTask
 }
+
+
+#' Get the current time a la `Sys.time()`. Prefer to get it via the
+#' `session$now()` function, but if that's not available, just return the
+#' current system time.
+#' @noRd
+getTime <- function(session){
+  if (!is.null(session)){
+    if (!is.null(session$now)){
+      return(session$now())
+    }
+  }
+  Sys.time()
+}

--- a/tests/testthat/test-app.R
+++ b/tests/testthat/test-app.R
@@ -99,7 +99,7 @@ test_that("With ui/server.R, global.R is loaded before R/ helpers and into the r
 })
 
 
-test_that("Loading supporting R fils is opt-out", {
+test_that("Loading supporting R files is opt-out", {
   calls <- list()
   sourceStub <- function(...){
     calls[[length(calls)+1]] <<- list(...)
@@ -128,7 +128,7 @@ test_that("Loading supporting R fils is opt-out", {
 })
 
 
-test_that("Disabling supporting R fils works", {
+test_that("Disabling supporting R files works", {
   calls <- list()
   sourceStub <- function(...){
     calls[[length(calls)+1]] <<- list(...)

--- a/tests/testthat/test-app.R
+++ b/tests/testthat/test-app.R
@@ -99,7 +99,7 @@ test_that("With ui/server.R, global.R is loaded before R/ helpers and into the r
 })
 
 
-test_that("Loading supporting R files is opt-out", {
+test_that("Loading supporting R fils is opt-out", {
   calls <- list()
   sourceStub <- function(...){
     calls[[length(calls)+1]] <<- list(...)
@@ -128,7 +128,7 @@ test_that("Loading supporting R files is opt-out", {
 })
 
 
-test_that("Disabling supporting R files works", {
+test_that("Disabling supporting R fils works", {
   calls <- list()
   sourceStub <- function(...){
     calls[[length(calls)+1]] <<- list(...)

--- a/tests/testthat/test-app.R
+++ b/tests/testthat/test-app.R
@@ -99,7 +99,7 @@ test_that("With ui/server.R, global.R is loaded before R/ helpers and into the r
 })
 
 
-test_that("Loading supporting R fils is opt-in", {
+test_that("Loading supporting R fils is opt-out", {
   calls <- list()
   sourceStub <- function(...){
     calls[[length(calls)+1]] <<- list(...)
@@ -122,11 +122,39 @@ test_that("Loading supporting R fils is opt-in", {
   sa$onStart()
   sa$onStop() # Close down to free up resources
 
-  # Should have seen one call from global.R -- helpers are disabled
-  expect_length(calls, 1)
+  # Should have seen three calls from global.R -- helpers are enabled
+  expect_length(calls, 3)
   expect_match(calls[[1]][[1]], "/global\\.R$", perl=TRUE)
 })
 
+
+test_that("Disabling supporting R fils works", {
+  calls <- list()
+  sourceStub <- function(...){
+    calls[[length(calls)+1]] <<- list(...)
+    NULL
+  }
+
+  # Temporarily unset autoloading option
+  orig <- getOption("shiny.autoload.r", NULL)
+  options(shiny.autoload.r=FALSE)
+  on.exit({options(shiny.autoload.r=orig)}, add=TRUE)
+
+  # + shinyAppDir_serverR
+  # +--- sourceUTF8
+  # +--+ loadSupport
+  # |  +--- sourceUTF8
+  loadSpy <- rewire(loadSupport, sourceUTF8 = sourceStub)
+  sad <- rewire(shinyAppDir_serverR, sourceUTF8 = sourceStub, loadSupport = loadSpy)
+
+  sa <- sad(normalizePath("../test-helpers/app1-standard"))
+  sa$onStart()
+  sa$onStop() # Close down to free up resources
+
+  # Should have seen one calls from global.R -- helpers are disabled
+  expect_length(calls, 1)
+  expect_match(calls[[1]][[1]], "/global\\.R$", perl=TRUE)
+})
 
 test_that("app.R is loaded after R/ helpers and into the right envs", {
   calls <- list()

--- a/tests/testthat/test-reactivity.r
+++ b/tests/testthat/test-reactivity.r
@@ -1366,3 +1366,59 @@ test_that("reactivePoll doesn't leak observer (#1548)", {
 
   expect_equal(i, 3L)
 })
+
+test_that("reactivePoll prefers session$scheduleTask", {
+  called <- 0
+  session <- list(reactlog = function(...){}, onEnded = function(...){}, scheduleTask = function(millis, cb){
+    expect_equal(millis, 50)
+    called <<- called + 1
+  })
+
+  count <- reactivePoll(50, session, function(){}, function(){})
+  observe({
+    count()
+  })
+
+  for (i in 1:4) {
+    Sys.sleep(0.05)
+    shiny:::flushReact()
+  }
+  expect_gt(called, 0)
+})
+
+test_that("invalidateLater prefers session$scheduleTask", {
+  called <- 0
+  session <- list(reactlog = function(...){}, onEnded = function(...){}, scheduleTask = function(millis, cb){
+    expect_equal(millis, 10)
+    called <<- called + 1
+  })
+
+  observe({
+    invalidateLater(10, session)
+  })
+
+  for (i in 1:4) {
+    Sys.sleep(0.05)
+    shiny:::flushReact()
+  }
+  expect_gt(called, 0)
+})
+
+test_that("reactiveTimer prefers session$scheduleTask", {
+  called <- 0
+  session <- list(reactlog = function(...){}, onEnded = function(...){}, scheduleTask = function(millis, cb){
+    expect_equal(millis, 10)
+    called <<- called + 1
+  })
+
+  rt <- reactiveTimer(10, session)
+  observe({
+    rt()
+  })
+
+  for (i in 1:4) {
+    Sys.sleep(0.05)
+    shiny:::flushReact()
+  }
+  expect_gt(called, 0)
+})

--- a/tests/testthat/test-reactivity.r
+++ b/tests/testthat/test-reactivity.r
@@ -1369,7 +1369,7 @@ test_that("reactivePoll doesn't leak observer (#1548)", {
 
 test_that("reactivePoll prefers session$scheduleTask", {
   called <- 0
-  session <- list(reactlog = function(...){}, onEnded = function(...){}, scheduleTask = function(millis, cb){
+  session <- list(reactlog = function(...){}, onEnded = function(...){}, .scheduleTask = function(millis, cb){
     expect_equal(millis, 50)
     called <<- called + 1
   })
@@ -1388,7 +1388,7 @@ test_that("reactivePoll prefers session$scheduleTask", {
 
 test_that("invalidateLater prefers session$scheduleTask", {
   called <- 0
-  session <- list(reactlog = function(...){}, onEnded = function(...){}, scheduleTask = function(millis, cb){
+  session <- list(reactlog = function(...){}, onEnded = function(...){}, .scheduleTask = function(millis, cb){
     expect_equal(millis, 10)
     called <<- called + 1
   })
@@ -1406,7 +1406,7 @@ test_that("invalidateLater prefers session$scheduleTask", {
 
 test_that("reactiveTimer prefers session$scheduleTask", {
   called <- 0
-  session <- list(reactlog = function(...){}, onEnded = function(...){}, scheduleTask = function(millis, cb){
+  session <- list(reactlog = function(...){}, onEnded = function(...){}, .scheduleTask = function(millis, cb){
     expect_equal(millis, 10)
     called <<- called + 1
   })

--- a/tests/testthat/test-timer.R
+++ b/tests/testthat/test-timer.R
@@ -52,3 +52,21 @@ test_that("defineScheduler works", {
   expect_identical(defineScheduler(list()), scheduleTask)
   expect_identical(defineScheduler(list(scheduleTask=123)), 123)
 })
+
+test_that("mockableTimer works", {
+  mt <- MockableTimerCallbacks$new()
+  called <- FALSE
+  mt$schedule(50, function(){
+    called <<- TRUE
+  })
+  expect_false(mt$executeElapsed())
+
+  # Prove that we're not bound to a real clock
+  Sys.sleep(.1)
+  expect_false(mt$executeElapsed())
+  expect_false(called)
+
+  mt$elapse(51)
+  expect_true(mt$executeElapsed())
+  expect_true(called)
+})

--- a/tests/testthat/test-timer.R
+++ b/tests/testthat/test-timer.R
@@ -47,12 +47,6 @@ test_that("Vectorized unscheduling works", {
   expect_identical(timerCallbacks$unschedule(c(key1, key2, key3)), c(TRUE, FALSE, TRUE))
 })
 
-test_that("defineScheduler works", {
-  expect_identical(defineScheduler(NULL), scheduleTask)
-  expect_identical(defineScheduler(list()), scheduleTask)
-  expect_identical(defineScheduler(list(scheduleTask=123)), 123)
-})
-
 test_that("mockableTimer works", {
   mt <- MockableTimerCallbacks$new()
   called <- FALSE
@@ -69,19 +63,4 @@ test_that("mockableTimer works", {
   mt$elapse(51)
   expect_true(mt$executeElapsed())
   expect_true(called)
-})
-
-test_that("getTime works", {
-  start <- Sys.time()
-  t1 <- getTime(NULL)
-  t2 <- getTime(list())
-  t3 <- getTime(list(now = function(){456}))
-  end <- Sys.time()
-
-  expect_gte(t1, start)
-  expect_gte(t2, start)
-  expect_lte(t1, end)
-  expect_lte(t2, end)
-
-  expect_equal(t3, 456)
 })

--- a/tests/testthat/test-timer.R
+++ b/tests/testthat/test-timer.R
@@ -47,6 +47,12 @@ test_that("Vectorized unscheduling works", {
   expect_identical(timerCallbacks$unschedule(c(key1, key2, key3)), c(TRUE, FALSE, TRUE))
 })
 
+test_that("defineScheduler works", {
+  expect_identical(defineScheduler(NULL), scheduleTask)
+  expect_identical(defineScheduler(list()), scheduleTask)
+  expect_identical(defineScheduler(list(scheduleTask=123)), 123)
+})
+
 test_that("mockableTimer works", {
   mt <- MockableTimerCallbacks$new()
   called <- FALSE
@@ -63,4 +69,19 @@ test_that("mockableTimer works", {
   mt$elapse(51)
   expect_true(mt$executeElapsed())
   expect_true(called)
+})
+
+test_that("getTime works", {
+  start <- Sys.time()
+  t1 <- getTime(NULL)
+  t2 <- getTime(list())
+  t3 <- getTime(list(now = function(){456}))
+  end <- Sys.time()
+
+  expect_gte(t1, start)
+  expect_gte(t2, start)
+  expect_lte(t1, end)
+  expect_lte(t2, end)
+
+  expect_equal(t3, 456)
 })

--- a/tests/testthat/test-timer.R
+++ b/tests/testthat/test-timer.R
@@ -27,13 +27,13 @@ test_that("Scheduling works", {
 test_that("Unscheduling works", {
   origTimes <- timerCallbacks$.times
   origFuncKeys <- timerCallbacks$.funcs$keys()
-  
+
   taskHandle <- scheduleTask(1000, function() {
     message("Whatever")
   })
   # Unregister
   taskHandle()
-  
+
   expect_identical(timerCallbacks$.times, origTimes)
   expect_identical(timerCallbacks$.funcs$keys(), origFuncKeys)
 })
@@ -42,7 +42,13 @@ test_that("Vectorized unscheduling works", {
   key1 <- timerCallbacks$schedule(1000, function() {})
   key2 <- timerCallbacks$schedule(1000, function() {})
   key3 <- timerCallbacks$schedule(1000, function() {})
-  
+
   expect_identical(timerCallbacks$unschedule(key2), TRUE)
   expect_identical(timerCallbacks$unschedule(c(key1, key2, key3)), c(TRUE, FALSE, TRUE))
+})
+
+test_that("defineScheduler works", {
+  expect_identical(defineScheduler(NULL), scheduleTask)
+  expect_identical(defineScheduler(list()), scheduleTask)
+  expect_identical(defineScheduler(list(scheduleTask=123)), 123)
 })

--- a/tests/testthat/test-timer.R
+++ b/tests/testthat/test-timer.R
@@ -70,3 +70,18 @@ test_that("mockableTimer works", {
   expect_true(mt$executeElapsed())
   expect_true(called)
 })
+
+test_that("getTime works", {
+  start <- Sys.time()
+  t1 <- getTime(NULL)
+  t2 <- getTime(list())
+  t3 <- getTime(list(now = function(){456}))
+  end <- Sys.time()
+
+  expect_gte(t1, start)
+  expect_gte(t2, start)
+  expect_lte(t1, end)
+  expect_lte(t2, end)
+
+  expect_equal(t3, 456)
+})

--- a/tests/testthat/test-timer.R
+++ b/tests/testthat/test-timer.R
@@ -50,7 +50,7 @@ test_that("Vectorized unscheduling works", {
 test_that("defineScheduler works", {
   expect_identical(defineScheduler(NULL), scheduleTask)
   expect_identical(defineScheduler(list()), scheduleTask)
-  expect_identical(defineScheduler(list(scheduleTask=123)), 123)
+  expect_identical(defineScheduler(list(.scheduleTask=123)), 123)
 })
 
 test_that("mockableTimer works", {
@@ -75,7 +75,7 @@ test_that("getTime works", {
   start <- Sys.time()
   t1 <- getTime(NULL)
   t2 <- getTime(list())
-  t3 <- getTime(list(now = function(){456}))
+  t3 <- getTime(list(.now = function(){456}))
   end <- Sys.time()
 
   expect_gte(t1, start)


### PR DESCRIPTION
Currently a no-op change, as the session just passes through to the global `scheduleTask ` implementation. But this allows us to mock the method for testing.

## QA Validation

Run apps that have (shiny example numbers in parenthesis)...

 - `invalidateLater` (034)
 - `reactivePoll` (059)
 - `reactiveTimer` (142)