### PR TITLE
Allow vector as digit parameter in renderTable() fixes #2596

### DIFF
--- a/R/render-table.R
+++ b/R/render-table.R
@@ -32,10 +32,13 @@
 #' @param rownames,colnames Logicals: include rownames? include colnames
 #'   (column headers)?
 #' @param digits An integer specifying the number of decimal places for
-#'   the numeric columns (this will not apply to columns with an integer
-#'   class). If `digits` is set to a negative value, then the numeric
-#'   columns will be displayed in scientific format with a precision of
-#'   `abs(digits)` digits.
+#'   the numeric columns, or a vector with the same number of integers
+#'   as the resulting table (if `rownames = TRUE`, this will be equal to
+#'   `ncol()+1`), with the *i*-th integer specifying the number of decimal
+#'   places for the *i*-th column (the integer is ignored if the
+#'   column is not of type double).
+#'   If `digits` is set to a negative value, then the numeric columns will
+#'   be displayed in scientific format with a precision of `abs(digits)` digits.
 #' @param na The string to use in the table cells whose values are missing
 #'   (i.e. they either evaluate to `NA` or `NaN`).
 #' @param ... Arguments to be passed through to [xtable::xtable()]
@@ -151,8 +154,12 @@ renderTable <- function(expr, striped = FALSE, hover = FALSE,
         }
       }
 
+      # If rownames is false, add dummy value for rownames
+      # So xtable always gets ncol + 1 or 1 values
+      if (!rownames && length(digits) == ncol(data)) digits <- c(0, digits)
+
       # Call xtable with its (updated) args
-      xtable_args <- c(xtable_args, align = cols, digits = digits)
+      xtable_args <- c(xtable_args, align = cols, digits = list(digits))
       xtable_res <- do.call(xtable, c(list(data), xtable_args))
 
       # Set up print args


### PR DESCRIPTION
Fixes #2596 

Digits parameter is was not correctly forwarded to `xtable()` when you want to specify the `digits` parameter for specific columns. To mimic behaviour of the `align`-parameter, `renderTable()` expects `ncol` integers when `rownames`-parameter is `FALSE` and `ncol + 1` integers when `rownames`-parameter is `TRUE`. Failing to input the correct number of integers results in a xtable error, instead of silently ignoring the values, when the digits parameter has a length > 1.

Minimal example below. Previously only the first line would work as expected and in the other 3 the digits parameter was ignored

```
# Same as old behaviour:
shiny::renderTable(mtcars, digits = 2)
# Xtable error (number of integers is too low):
shiny::renderTable(mtcars, digits = c(1, 2, 3)) 
# Add integer for rowname:
shiny::renderTable(mtcars, digits = c(0, 1:ncol(mtcars)), rownames = TRUE) 
# Rowname integer not needed:
shiny::renderTable(mtcars, digits = c(1:ncol(mtcars)), rownames = FALSE)
```
