### PR TITLE
Datepicker: make disabled months and years lighter gray

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@ shiny 1.4.0.9000
 
 ### Minor new features and improvements
 
+* Fixed [#2042](https://github.com/rstudio/shiny/issues/2042), [#2628](https://github.com/rstudio/shiny/issues/2628): In a `dateInput` and `dateRangeInput`, disabled months and years are now a lighter gray, to make it easier to see that they are disabled. ([#2690](https://github.com/rstudio/shiny/pull/2690))
+
 ### Bug fixes
 
 * Fixed [#2606](https://github.com/rstudio/shiny/issues/2606): `debounce()` would not work properly if the code in the reactive expression threw an error on the first run. ([#2652](https://github.com/rstudio/shiny/pull/2652))

--- a/inst/www/shared/shiny.css
+++ b/inst/www/shared/shiny.css
@@ -405,4 +405,5 @@ pre.shiny-text-output {
 .datepicker table tbody tr td span.disabled,
 .datepicker table tbody tr td span.disabled:hover {
   color: #aaa;
+  cursor: not-allowed;
 }

--- a/inst/www/shared/shiny.css
+++ b/inst/www/shared/shiny.css
@@ -401,6 +401,8 @@ pre.shiny-text-output {
 /* Overrides bootstrap-datepicker3.css styling for invalid date ranges.
    See https://github.com/rstudio/shiny/issues/2042 for details. */
 .datepicker table tbody tr td.disabled,
-.datepicker table tbody tr td.disabled:hover {
+.datepicker table tbody tr td.disabled:hover,
+.datepicker table tbody tr td span.disabled,
+.datepicker table tbody tr td span.disabled:hover {
   color: #aaa;
 }


### PR DESCRIPTION
Closes #2042, closes #2628.

This makes disabled months and years a lighter gray, which makes it more obvious that they're disabled.

When running shiny-examples/037-date-and-date-range/:

Before:

![image](https://user-images.githubusercontent.com/86978/67898694-d14c0b80-fb2e-11e9-98b3-b339ae38877e.png)


After:

![image](https://user-images.githubusercontent.com/86978/67898671-c2655900-fb2e-11e9-89fa-176c24b492dd.png)


Test notes:

Run shiny-examples/037-date-and-date-range/, and make sure that disabled years and months are light gray.