### PR TITLE
.testModule(): remove args parameter fixes #2709

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -171,6 +171,6 @@ Collate:
     'test-module.R'
     'test.R'
     'update-input.R'
-RoxygenNote: 7.0.1
+RoxygenNote: 7.0.2
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/R/test-module.R
+++ b/R/test-module.R
@@ -26,11 +26,8 @@
 #'   })
 #' }
 #'
-#' # !!/:= and !!! from rlang are used below to programmatically splice
-#' # these into the testModule() argument list.
-#' multiplier_arg_name = "multiplier"
-#' more_args <- list(prefix = "I am ")
-#'
+#' # Basic Usage
+#' # -----------
 #' testModule(module, {
 #'   session$setInputs(x = 1)
 #'   # You're also free to use third-party
@@ -42,6 +39,19 @@
 #'   session$setInputs(x = 2)
 #'   stopifnot(myreactive() == 4)
 #'   stopifnot(output$txt == "I am 4")
+#'   # Any additional arguments, below, are passed along to the module.
+#' }, multiplier = 2)
+#'
+#' # Advanced Usage
+#' # --------------
+#' multiplier_arg_name = "multiplier"
+#' more_args <- list(prefix = "I am ")
+#' testModule(module, {
+#'   session$setInputs(x = 1)
+#'   stopifnot(myreactive() == 2)
+#'   stopifnot(output$txt == "I am 2")
+#'   # !!/:= and !!! from rlang are used below to splice computed arguments
+#'   # into the testModule() argument list.
 #' }, !!multiplier_arg_name := 2, !!!more_args)
 #' @export
 testModule <- function(module, expr, ...) {

--- a/R/test-module.R
+++ b/R/test-module.R
@@ -49,16 +49,17 @@ testModule <- function(module, expr, args, ...) {
 .testModule <- function(module, expr, args, ...) {
   # Capture the environment from the module
   # Inserts `session$env <- environment()` at the top of the function
-  fn_body <- body(module)
-  fn_body[seq(3, length(fn_body)+1)] <- fn_body[seq(2, length(fn_body))]
-  fn_body[[2]] <- quote(session$env <- environment())
-  body(module) <- fn_body
+  body(module) <- rlang::expr({
+    session$env <- environment()
+    !!!body(module)
+  })
 
   # Create a mock session
   session <- MockShinySession$new()
 
   # Parse the additional arguments
-  args <- list(..., input = session$input, output = session$output, session = session)
+  args <- if (missing(args)) list() else args
+  args <- append(rlang::list2(..., input = session$input, output = session$output, session = session), args)
 
   # Initialize the module
   isolate(

--- a/R/test-module.R
+++ b/R/test-module.R
@@ -39,9 +39,9 @@
 #'   stopifnot(output$txt == "I am 4")
 #' })
 #' @export
-testModule <- function(module, expr, args, ...) {
+testModule <- function(module, expr, ...) {
   expr <- substitute(expr)
-  .testModule(module, expr, args, ...)
+  .testModule(module, expr, ...)
 }
 
 #' @noRd

--- a/R/test-module.R
+++ b/R/test-module.R
@@ -11,8 +11,8 @@
 #'   in the module's environment, meaning that the module's parameters (e.g.
 #'   `input`, `output`, and `session`) will be available along with any other
 #'   values created inside of the module.
-#' @param ... Additional named arguments to be passed on to the module function.
-#'   These arguments are processed with [rlang::list2()] and so are
+#' @param ... Additional arguments to pass to the module function. These
+#'   arguments are processed with [rlang::list2()] and so are
 #'   _[dynamic][rlang::dyn-dots]_.
 #' @include mock-session.R
 #' @rdname testModule

--- a/R/test-module.R
+++ b/R/test-module.R
@@ -11,20 +11,25 @@
 #'   in the module's environment, meaning that the module's parameters (e.g.
 #'   `input`, `output`, and `session`) will be available along with any other
 #'   values created inside of the module.
-#' @param args A list of arguments to pass into the module beyond `input`,
-#'   `output`, and `session`.
 #' @param ... Additional named arguments to be passed on to the module function.
+#'   These arguments are processed with [rlang::list2()] and so are
+#'   _[dynamic][rlang::dyn-dots]_.
 #' @include mock-session.R
 #' @rdname testModule
 #' @examples
-#' module <- function(input, output, session) {
+#' module <- function(input, output, session, multiplier = 2, prefix = "I am ") {
 #'   myreactive <- reactive({
-#'     input$x * 2
+#'     input$x * multiplier
 #'   })
 #'   output$txt <- renderText({
-#'     paste0("I am ", myreactive())
+#'     paste0(prefix, myreactive())
 #'   })
 #' }
+#'
+#' # !!/:= and !!! from rlang are used below to programmatically splice
+#' # these into the testModule() argument list.
+#' multiplier_arg_name = "multiplier"
+#' more_args <- list(prefix = "I am ")
 #'
 #' testModule(module, {
 #'   session$setInputs(x = 1)
@@ -37,7 +42,7 @@
 #'   session$setInputs(x = 2)
 #'   stopifnot(myreactive() == 4)
 #'   stopifnot(output$txt == "I am 4")
-#' })
+#' }, !!multiplier_arg_name := 2, !!!more_args)
 #' @export
 testModule <- function(module, expr, ...) {
   expr <- substitute(expr)

--- a/R/test-module.R
+++ b/R/test-module.R
@@ -46,7 +46,7 @@ testModule <- function(module, expr, args, ...) {
 
 #' @noRd
 #' @importFrom withr with_options
-.testModule <- function(module, expr, args, ...) {
+.testModule <- function(module, expr, ...) {
   # Capture the environment from the module
   # Inserts `session$env <- environment()` at the top of the function
   body(module) <- rlang::expr({
@@ -58,8 +58,7 @@ testModule <- function(module, expr, args, ...) {
   session <- MockShinySession$new()
 
   # Parse the additional arguments
-  args <- if (missing(args)) list() else args
-  args <- append(rlang::list2(..., input = session$input, output = session$output, session = session), args)
+  args <- rlang::list2(..., input = session$input, output = session$output, session = session)
 
   # Initialize the module
   isolate(

--- a/man/testModule.Rd
+++ b/man/testModule.Rd
@@ -17,8 +17,8 @@ in the module's environment, meaning that the module's parameters (e.g.
 \code{input}, \code{output}, and \code{session}) will be available along with any other
 values created inside of the module.}
 
-\item{...}{Additional named arguments to be passed on to the module function.
-These arguments are processed with \code{\link[rlang:list2]{rlang::list2()}} and so are
+\item{...}{Additional arguments to pass to the module function. These
+arguments are processed with \code{\link[rlang:list2]{rlang::list2()}} and so are
 \emph{\link[rlang:dyn-dots]{dynamic}}.}
 
 \item{appDir}{The directory root of the Shiny application. If \code{NULL}, this function

--- a/man/testModule.Rd
+++ b/man/testModule.Rd
@@ -5,7 +5,7 @@
 \alias{testServer}
 \title{Integration testing for Shiny modules or server functions}
 \usage{
-testModule(module, expr, args, ...)
+testModule(module, expr, ...)
 
 testServer(expr, appDir = NULL)
 }
@@ -17,10 +17,9 @@ in the module's environment, meaning that the module's parameters (e.g.
 \code{input}, \code{output}, and \code{session}) will be available along with any other
 values created inside of the module.}
 
-\item{args}{A list of arguments to pass into the module beyond \code{input},
-\code{output}, and \code{session}.}
-
-\item{...}{Additional named arguments to be passed on to the module function.}
+\item{...}{Additional named arguments to be passed on to the module function.
+These arguments are processed with \code{\link[rlang:list2]{rlang::list2()}} and so are
+\emph{\link[rlang:dyn-dots]{dynamic}}.}
 
 \item{appDir}{The directory root of the Shiny application. If \code{NULL}, this function
 will work up the directory hierarchy --- starting with the current directory ---
@@ -32,14 +31,19 @@ modules or in the server portion of a Shiny application. For more
 information, visit \href{https://shiny.rstudio.com/articles/integration-testing.html}{the Shiny Dev Center article on integration testing}.
 }
 \examples{
-module <- function(input, output, session) {
+module <- function(input, output, session, multiplier = 2, prefix = "I am ") {
   myreactive <- reactive({
-    input$x * 2
+    input$x * multiplier
   })
   output$txt <- renderText({
-    paste0("I am ", myreactive())
+    paste0(prefix, myreactive())
   })
 }
+
+# !!/:= and !!! from rlang are used below to programmatically splice
+# these into the testModule() argument list.
+multiplier_arg_name = "multiplier"
+more_args <- list(prefix = "I am ")
 
 testModule(module, {
   session$setInputs(x = 1)
@@ -52,5 +56,5 @@ testModule(module, {
   session$setInputs(x = 2)
   stopifnot(myreactive() == 4)
   stopifnot(output$txt == "I am 4")
-})
+}, !!multiplier_arg_name := 2, !!!more_args)
 }

--- a/man/withMathJax.Rd
+++ b/man/withMathJax.Rd
@@ -17,7 +17,7 @@ unless the content is rendered \emph{after} the page is loaded, e.g. via
 time we write math expressions to the output.
 }
 \examples{
-withMathJax(helpText("Some math here $$\\alpha+\\beta$$"))
+withMathJax(helpText("Some math here $$\\\\alpha+\\\\beta$$"))
 # now we can just write "static" content without withMathJax()
-div("more math here $$\\sqrt{2}$$")
+div("more math here $$\\\\sqrt{2}$$")
 }

--- a/tests/test-helpers/app4-both/R/upper.R
+++ b/tests/test-helpers/app4-both/R/upper.R
@@ -1,1 +1,0 @@
-upperHelper <- 'abc'

--- a/tests/test-helpers/app4-both/R/upper.R
+++ b/tests/test-helpers/app4-both/R/upper.R
@@ -1,0 +1,1 @@
+upperHelper <- 'abc'

--- a/tests/testthat/test-app.R
+++ b/tests/testthat/test-app.R
@@ -49,9 +49,14 @@ test_that("nested helpers are not loaded", {
 
 test_that("app with both r/ and R/ prefers R/", {
   ## App 4 already has a lower-case r/ directory. Try to create an upper.
-  tryCatch(dir.create("../test-helpers/app4-both/R"),
-           warning=function(w){testthat::skip("File system is not case-sensitive")})
-  writeLines("upperHelper <- 'abc'", file.path("../test-helpers/app4-both/R", "upper.R"))
+  dir <- "../test-helpers/app4-both/R"
+  tryCatch({
+    dir.create(dir)
+    teardown(unlink(dir, recursive = TRUE))
+  }, warning = function(w) {
+    testthat::skip("File system is not case-sensitive")
+  })
+  writeLines("upperHelper <- 'abc'", file.path(dir, "upper.R"))
 
   renv <- loadSupport("../test-helpers/app4-both")
 

--- a/tests/testthat/test-test-module.R
+++ b/tests/testthat/test-test-module.R
@@ -4,12 +4,22 @@ library(promises)
 library(future)
 plan(multisession)
 
-test_that("testModule passes args", {
+test_that("testModule passes dots", {
   module <- function(input, output, session, someArg) {
     expect_false(missing(someArg))
     expect_equal(someArg, 123)
   }
-  testModule(module, {}, args = list(someArg = 123))
+  testModule(module, {}, someArg = 123)
+})
+
+test_that("testModule passes dynamic dots", {
+  module <- function(input, output, session, someArg) {
+    expect_false(missing(someArg))
+    expect_equal(someArg, 123)
+  }
+
+  moreArgs <- list(someArg = 123)
+  testModule(module, {}, !!!moreArgs)
 })
 
 test_that("testModule handles observers", {

--- a/tests/testthat/test-test-module.R
+++ b/tests/testthat/test-test-module.R
@@ -18,7 +18,14 @@ test_that("testModule passes dynamic dots", {
     expect_equal(someArg, 123)
   }
 
+  # Test with !!! to splice in a whole named list constructed with base::list()
   moreArgs <- list(someArg = 123)
+  testModule(module, {}, !!!moreArgs)
+
+  # Test by splicing in a list constructed with rlang::list2() that uses := to
+  # splice in an argument name
+  argName <- "someArg"
+  moreArgs <- rlang::list2(!!argName := 123)
   testModule(module, {}, !!!moreArgs)
 })
 

--- a/tests/testthat/test-test-module.R
+++ b/tests/testthat/test-test-module.R
@@ -4,6 +4,14 @@ library(promises)
 library(future)
 plan(multisession)
 
+test_that("testModule passes args", {
+  module <- function(input, output, session, someArg) {
+    expect_false(missing(someArg))
+    expect_equal(someArg, 123)
+  }
+  testModule(module, {}, args = list(someArg = 123))
+})
+
 test_that("testModule handles observers", {
   module <- function(input, output, session) {
     rv <- reactiveValues(x = 0, y = 0)

--- a/tests/testthat/test-test-module.R
+++ b/tests/testthat/test-test-module.R
@@ -22,11 +22,9 @@ test_that("testModule passes dynamic dots", {
   moreArgs <- list(someArg = 123)
   testModule(module, {}, !!!moreArgs)
 
-  # Test by splicing in a list constructed with rlang::list2() that uses := to
-  # splice in an argument name
+  # Test with !!/:= to splice in an argument name
   argName <- "someArg"
-  moreArgs <- rlang::list2(!!argName := 123)
-  testModule(module, {}, !!!moreArgs)
+  testModule(module, {}, !!argName := 123)
 })
 
 test_that("testModule handles observers", {


### PR DESCRIPTION
This PR does 2 things:

1. **Improvement**: Simplifies synthesis of a modified module function body by leveraging `rlang::expr()` and `!!!`
1. **Improvement**: Uses `rlang::list2()` instead of `list()` to incorporate `...` into the module's arg list. Consequently, the dots are now *dynamic*, and the `args` argument was removed. Docs and tests around dynamic dots were added.

I didn't edit NEWS.md since this fixes a bug in an unreleased feature.