### PR TITLE
Add MockShinySession$makeScope()

### DIFF
--- a/R/mock-session.R
+++ b/R/mock-session.R
@@ -373,6 +373,15 @@ MockShinySession <- R6Class(
     #' @description Trigger a reactive flush right now.
     flushReact = function(){
       private$flush()
+    },
+    makeScope = function(namespace) {
+      ns <- NS(namespace)
+      createSessionProxy(
+        self,
+        input = .createReactiveValues(private$.input, readonly = TRUE, ns = ns),
+        output = structure(.createOutputWriter(self, ns = ns), class = "shinyoutput"),
+        makeScope = function(namespace) self$makeScope(ns(namespace))
+      )
     }
   ),
   private = list(

--- a/R/mock-session.R
+++ b/R/mock-session.R
@@ -247,9 +247,16 @@ MockShinySession <- R6Class(
     #' @param func The render definition
     #' @param label Not used
     defineOutput = function(name, func, label) {
+      force(name)
+
       if (!is.null(private$outs[[name]]$obs)) {
         private$outs[[name]]$obs$destroy()
       }
+
+      if (is.null(func)) func <- missingOutput
+
+      if (!is.function(func))
+        stop(paste("Unexpected", class(func), "output for", name))
 
       obs <- observe({
         # We could just stash the promise, but we get an "unhandled promise error". This bypasses

--- a/tests/testthat/test-test-module.R
+++ b/tests/testthat/test-test-module.R
@@ -500,7 +500,7 @@ test_that("testModule works with nested modules", {
   })
 })
 
-test_that("Assigning an output in a module function with a non-function errors", {
+test_that("assigning an output in a module function with a non-function errors", {
   module <- function(input, output, session) {
     output$someVar <- 123
   }

--- a/tests/testthat/test-test-module.R
+++ b/tests/testthat/test-test-module.R
@@ -500,6 +500,14 @@ test_that("testModule works with nested modules", {
   })
 })
 
+test_that("Assigning an output in a module function with a non-function errors", {
+  module <- function(input, output, session) {
+    output$someVar <- 123
+  }
+
+  expect_error(testModule(module, {}), "^Unexpected")
+})
+
 test_that("testServer works", {
   # app.R
   testServer({

--- a/tests/testthat/test-test-module.R
+++ b/tests/testthat/test-test-module.R
@@ -487,16 +487,18 @@ test_that("accessing a non-existant output gives an informative message", {
 
 test_that("testModule works with nested modules", {
   outerModule <- function(input, output, session) {
-    output$someVar <- renderText("rendered text")
-    expect_equal(callModule(innerModule, "innerModule"), "a return value")
+    r1 <- reactive({ input$x + 1})
+    r2 <- callModule(innerModule, "innerModule", r1)
+    output$someVar <- renderText(r2())
   }
 
-  innerModule <- function(input, output, session) {
-    "a return value"
+  innerModule <- function(input, output, session, r) {
+    reactive(paste("a value:", r()))
   }
 
   testModule(outerModule, {
-    expect_equal(output$someVar, "rendered text")
+    session$setInputs(x = 1)
+    expect_equal(output$someVar, "a value: 2")
   })
 })
 

--- a/tests/testthat/test-test-module.R
+++ b/tests/testthat/test-test-module.R
@@ -485,6 +485,21 @@ test_that("accessing a non-existant output gives an informative message", {
   })
 })
 
+test_that("testModule works with nested modules", {
+  outerModule <- function(input, output, session) {
+    output$someVar <- renderText("rendered text")
+    expect_equal(callModule(innerModule, "innerModule"), "a return value")
+  }
+
+  innerModule <- function(input, output, session) {
+    "a return value"
+  }
+
+  testModule(outerModule, {
+    expect_equal(output$someVar, "rendered text")
+  })
+})
+
 test_that("testServer works", {
   # app.R
   testServer({


### PR DESCRIPTION
This PR adds a missing method to `MockShinySession` and ports several checks from `ShinySession$defineOutput()` to `MockShinySession$defineOutput()`.

- [x] Implement
- [x] Test

## Nested modules

I took some time on this one to explore the case for nesting modules, to see if a test could be added that was representative of some expected usage, or usage pattern.

@akgold was kind enough to share his nested module usage, and we concluded that using `callModule()` in a module function doesn't provide any affordance that a regular function call does not. However, it should definitely work, and it didn't until this PR, which adds `MockShinySession$makeScope()`.

I ultimately decided to keep the nested module test short and sweet.

## defineOutput() checks

In the #2712 comments Alex ran into a confusing error message resulting from the fact that `MockShinySession$defineOutput()` was missing various checks performed by `ShinySession`. So, I ported the checks from ShinySession over to MockShinySession.

## QA Notes

It should now be possible to use `callModule()` from within a module function without error, and a unit test was added to ensure this.

Assigning to an output in a module function called by `testModule()` or `testServer()` should now also produce an error. For example, `output$var <- 123` should fail (`output$var <- renderText("123")` is the correct way). A unit test was added for this as well.

There should be no other behavior changes to `testModule()`/`testServer()`.