### PR TITLE
Use as.raw instead of charToRaw

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -1230,5 +1230,5 @@ inShinyServer <- function() {
 # This check was moved out of the main function body because of an issue with
 # the RStudio debugger. (#1474)
 isEmptyMessage <- function(msg) {
-  identical(charToRaw("\003\xe9"), msg)
+  identical(as.raw(c(0x03, 0xe9)), msg)
 }


### PR DESCRIPTION
When the package is built, the string with odd characters is marked with the encoding of the build system. When the build system uses the `C` locale and the running system uses a UTF-8 locale (like `en_US.UTF-8`), this results in a warning when this function is first accessed. Using `as.raw()` lets us avoid using a string altogether, so the encoding is no longer an issue.

For more info, see https://github.com/rstudio/package-manager/issues/3606.