### PR TITLE
Use a frozen lock file within CI

### DIFF
--- a/tools/checkJSCurrent.sh
+++ b/tools/checkJSCurrent.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Run JS build process
-(cd "$(dirname "$0")" && yarn && yarn build)
+(cd "$(dirname "$0")" && yarn --frozen-lockfile && yarn build)
 
 if [ -n "$(git status --porcelain)" ]
 then

--- a/tools/checkJSCurrent.sh
+++ b/tools/checkJSCurrent.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Run JS build process
-(cd "$(dirname "$0")" && yarn --frozen-lockfile && yarn build)
+(cd "$(dirname "$0")" && yarn install --frozen-lockfile && yarn build)
 
 if [ -n "$(git status --porcelain)" ]
 then


### PR DESCRIPTION
I ran into yarn.lock being updated in this repo and/or another repo.  The updated lock file would cause a failure.

-------------------------------

https://yarnpkg.com/lang/en/docs/cli/install/
> If you need reproducible dependencies, which is usually the case with the continuous integration systems, you should pass --frozen-lockfile flag.

https://yarnpkg.com/lang/en/docs/cli/install/#toc-yarn-install-frozen-lockfile
> Don’t generate a yarn.lock lockfile and fail if an update is needed.

