### PR TITLE
Bust appveyor cache every time the DESCRIPTION file updates

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,9 @@ install:
   ps: Bootstrap
 
 cache:
+  # Bust library cache every time the description file changes
+  #   as appveyor cache can not be busted manually
+  # PR: https://github.com/rstudio/shiny/pull/2722
   - C:\RLibrary -> DESCRIPTION
 
 # Adapt as necessary starting from here

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,8 @@ install:
 cache:
   # Bust library cache every time the description file changes
   #   as appveyor cache can not be busted manually
+  # This helps get around errors such as "can't update curl because it's already loaded"
+  #  when trying to update the existing cache
   # PR: https://github.com/rstudio/shiny/pull/2722
   - C:\RLibrary -> DESCRIPTION
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ install:
   ps: Bootstrap
 
 cache:
-  - C:\RLibrary
+  - C:\RLibrary -> DESCRIPTION
 
 # Adapt as necessary starting from here
 


### PR DESCRIPTION
Because not being able to manually bust the cache is annoying.  This will cause it to clear out every once in a while and hopefully get rid of the "can't update curl because it's already loaded" bug.

Original PR to devtools rejected. https://github.com/r-lib/devtools/pull/1961