### PR TITLE
Timer functions always use ms

### DIFF
--- a/R/mock-session.R
+++ b/R/mock-session.R
@@ -238,8 +238,8 @@ MockShinySession <- R6Class(
 
     #' @description An internal method which shouldn't be used by others.
     .now = function() {
-      # Contract is to return Sys.time, which is seconds, not millis.
-      private$timer$getElapsed()/1000
+      # Returns elapsed time in milliseconds
+      private$timer$getElapsed()
     },
 
     #' @description An internal method which shouldn't be used by others.

--- a/R/reactives.R
+++ b/R/reactives.R
@@ -2379,7 +2379,7 @@ debounce <- function(r, millis, priority = 100, domain = getDefaultReactiveDomai
     r()
 
     # The value (or possibly millis) changed. Start or reset the timer.
-    v$when <- getTime(domain) + millis()/1000
+    v$when <- getDomainTimeMs(domain) + millis()
   }, label = "debounce tracker", domain = domain, priority = priority)
 
   # This observer is the timer. It rests until v$when elapses, then touches
@@ -2388,13 +2388,13 @@ debounce <- function(r, millis, priority = 100, domain = getDefaultReactiveDomai
     if (is.null(v$when))
       return()
 
-    now <- getTime(domain)
+    now <- getDomainTimeMs(domain)
     if (now >= v$when) {
       # Mod by 999999999 to get predictable overflow behavior
       v$trigger <- isolate(v$trigger %OR% 0) %% 999999999 + 1
       v$when <- NULL
     } else {
-      invalidateLater((v$when - now) * 1000)
+      invalidateLater(v$when - now)
     }
   }, label = "debounce timer", domain = domain, priority = priority)
 
@@ -2439,12 +2439,12 @@ throttle <- function(r, millis, priority = 100, domain = getDefaultReactiveDomai
     if (is.null(v$lastTriggeredAt)) {
       0
     } else {
-      max(0, (v$lastTriggeredAt + millis()/1000) - getTime(domain)) * 1000
+      max(0, v$lastTriggeredAt + millis() - getDomainTimeMs(domain))
     }
   }
 
   trigger <- function() {
-    v$lastTriggeredAt <- getTime(domain)
+    v$lastTriggeredAt <- getDomainTimeMs(domain)
     # Mod by 999999999 to get predictable overflow behavior
     v$trigger <- isolate(v$trigger) %% 999999999 + 1
     v$pending <- FALSE

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -727,7 +727,7 @@ ShinySession <- R6Class(
       scheduleTask(millis, callback)
     },
     .now = function(){
-      getNow()
+      getTimeMs()
     },
     rootScope = function() {
       self

--- a/tests/testthat/test-timer.R
+++ b/tests/testthat/test-timer.R
@@ -71,11 +71,11 @@ test_that("mockableTimer works", {
   expect_true(called)
 })
 
-test_that("getTime works", {
+test_that("getDomainTimeMs works", {
   start <- Sys.time()
-  t1 <- getTime(NULL)
-  t2 <- getTime(list())
-  t3 <- getTime(list(.now = function(){456}))
+  t1 <- getDomainTimeMs(NULL)
+  t2 <- getDomainTimeMs(list())
+  t3 <- getDomainTimeMs(list(.now = function(){456}))
   end <- Sys.time()
 
   expect_gte(t1, start)


### PR DESCRIPTION
This fixes #2725. The problem was that `getTime()` sometimes returned `Sys.time()`, and other times returned `as.numeric(Sys.time()) * 1000`. Now it always uses the latter. These functions have also been renamed for clarity -- it was pretty confusing before:

* `getTime` -> `getDomainTimeMs`
* `getNow` -> `getTimeMs`


