### PR TITLE
Fix for close ShinySession on on.exit

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -2166,6 +2166,13 @@ flushPendingSessions <- function() {
 }
 
 .globals$onStopCallbacks <- Callbacks$new()
+# Close ShinySession on.exit event (SIGINT signal)
+.globals$onStopCallbacks$register(function() {
+  lapply(appsByToken$keys(), function(session) {
+    session <- appsByToken$get(session)
+    if (isFALSE(session$closed)) session$wsClosed()
+  })
+})
 
 #' Run code after an application or session ends
 #'


### PR DESCRIPTION
The onSessionEnd is probably triggered by `later` loop and is never trigger on `SIGINT` signal. There is a difference between interactive and not interactive R process.  In not interactive R process after global onStop callback, the R process is terminated immediately.

The minimal example:
```R
library(shiny)

ui <- fluidPage(

)

server <- function(input, output, session) {
  onSessionEnded(function() {
    print("close ShinySession session")
  })
}

onStop(function() {
  # Custom code that was used before this PR.
  lapply(shiny:::appsByToken$keys(), function(session) {
    session <- shiny:::appsByToken$get(session)
    if (isFALSE(session$closed)) session$wsClosed()
  })
})

shinyApp(ui, server)
```

The gif example shows the difference.
![Peek 2020-01-09 10-11](https://user-images.githubusercontent.com/4296390/73403409-a7ea7980-42ef-11ea-99f8-97c01bfd54f4.gif)

If I can do some more in this case or you need more clarification, please let me know.