### PR TITLE
Fix broken timer tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ matrix:
       r: release
       r_packages:
         - devtools
+        - rprojroot
       script: ./tools/checkDocsCurrent.sh
     - name: "Javascript check"
       language: node_js

--- a/man/HTML.Rd
+++ b/man/HTML.Rd
@@ -2,13 +2,18 @@
 \alias{HTML}
 \title{Mark Characters as HTML}
 \usage{
-HTML(text, ...)
+HTML(text, ..., .noWS = NULL)
 }
 \arguments{
 \item{text}{The text value to mark with HTML}
 
 \item{...}{Any additional values to be converted to character and
 concatenated together}
+
+\item{.noWS}{Character vector used to omit some of the whitespace that would
+normally be written around this HTML. Valid options include \code{before},
+\code{after}, and \code{outside} (equivalent to \code{before} and
+\code{end}).}
 }
 \value{
 The same value, but marked as HTML.

--- a/man/validateCssUnit.Rd
+++ b/man/validateCssUnit.Rd
@@ -29,6 +29,7 @@ If the number has a suffix, it must be valid: \code{px},
 \code{vmax}.
 If the number has no suffix, the suffix \code{"px"} is appended.
 
+
 Any other value will cause an error to be thrown.
 }
 \examples{

--- a/tests/testthat/test-timer.R
+++ b/tests/testthat/test-timer.R
@@ -72,11 +72,11 @@ test_that("mockableTimer works", {
 })
 
 test_that("getDomainTimeMs works", {
-  start <- Sys.time()
+  start <- as.numeric(Sys.time()) * 1000
   t1 <- getDomainTimeMs(NULL)
   t2 <- getDomainTimeMs(list())
   t3 <- getDomainTimeMs(list(.now = function(){456}))
-  end <- Sys.time()
+  end <- as.numeric(Sys.time()) * 1000
 
   expect_gte(t1, start)
   expect_gte(t2, start)

--- a/tools/checkDocsCurrent.sh
+++ b/tools/checkDocsCurrent.sh
@@ -14,3 +14,17 @@ then
 else
   echo "No difference detected; Roxygen docs are current."
 fi
+
+
+# Update htmltools docs
+Rscript './tools/updateHtmltoolsMan.R'
+
+if [ -n "$(git status --porcelain)" ]
+then
+  git status --porcelain
+  >&2 echo "Please generate the htmltools documentation and commit the updates."
+  >&2 echo "The above files changed when we generated the htmltools documentation. This most often occurs when the documentation re-exported by shiny does not match the htmltools documentation."
+  exit 1
+else
+  echo "No difference detected; re-exported htmltools docs are current."
+fi


### PR DESCRIPTION
Adjusted MS time value by a factor of 1000 to compare to seconds.

Also, for some reason...

``` r
testthat::expect_lte(as.numeric(Sys.time()), Sys.time())
#> Error in `-.POSIXt`(act$val, exp$val): can only subtract from "POSIXt" objects
```

<sup>Created on 2020-02-13 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

So switching test style to 

``` r
testthat::expect_true(as.numeric(Sys.time()) <= Sys.time())
```

<sup>Created on 2020-02-13 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>