### PR TITLE
Support shiny.autoreload even when there are errors

### DIFF
--- a/R/app.R
+++ b/R/app.R
@@ -297,9 +297,7 @@ initAutoReloadMonitor <- function(dir) {
     } else if (!identical(lastValue, times)) {
       # We've changed!
       lastValue <<- times
-      for (session in appsByToken$values()) {
-        session$reload()
-      }
+      autoReloadCallbacks$invoke()
     }
 
     invalidateLater(getOption("shiny.autoreload.interval", 500))

--- a/R/app.R
+++ b/R/app.R
@@ -227,7 +227,6 @@ shinyAppDir_serverR <- function(appDir, options=list()) {
   onStart <- function() {
     oldwd <<- getwd()
     setwd(appDir)
-    monitorHandle <<- initAutoReloadMonitor(appDir)
     # TODO: we should support hot reloading on global.R and R/*.R changes.
     if (getOption("shiny.autoload.r", TRUE)) {
       loadSupport(appDir, renv=sharedEnv, globalrenv=globalenv())
@@ -235,6 +234,7 @@ shinyAppDir_serverR <- function(appDir, options=list()) {
       if (file.exists(file.path.ci(appDir, "global.R")))
         sourceUTF8(file.path.ci(appDir, "global.R"))
     }
+    monitorHandle <<- initAutoReloadMonitor(appDir)
   }
   onStop <- function() {
     setwd(oldwd)
@@ -302,6 +302,8 @@ initAutoReloadMonitor <- function(dir) {
 
     invalidateLater(getOption("shiny.autoreload.interval", 500))
   })
+
+  onStop(obs$destroy)
 
   obs$destroy
 }
@@ -427,8 +429,9 @@ shinyAppDir_appR <- function(fileName, appDir, options=list())
     if (getOption("shiny.autoload.r", TRUE)) {
       loadSupport(appDir, renv=sharedEnv, globalrenv=NULL)
     }
-    monitorHandle <<- initAutoReloadMonitor(appDir)
     if (!is.null(appObj()$onStart)) appObj()$onStart()
+    monitorHandle <<- initAutoReloadMonitor(appDir)
+    invisible()
   }
   onStop <- function() {
     setwd(oldwd)

--- a/R/middleware.R
+++ b/R/middleware.R
@@ -311,16 +311,32 @@ HandlerManager <- R6Class("HandlerManager",
         },
         call = .httpServer(
           function (req) {
-            withCallingHandlers(withLogErrors(handlers$invoke(req)),
-              error = function(cond) {
-                sanitizeErrors <- getOption('shiny.sanitize.errors', FALSE)
-                if (inherits(cond, 'shiny.custom.error') || !sanitizeErrors) {
-                  stop(cond$message, call. = FALSE)
-                } else {
-                  stop(paste("An error has occurred. Check your logs or",
-                             "contact the app author for clarification."),
-                       call. = FALSE)
+            hybrid_chain(
+              hybrid_chain(
+                withCallingHandlers(withLogErrors(handlers$invoke(req)),
+                  error = function(cond) {
+                    sanitizeErrors <- getOption('shiny.sanitize.errors', FALSE)
+                    if (inherits(cond, 'shiny.custom.error') || !sanitizeErrors) {
+                      stop(cond$message, call. = FALSE)
+                    } else {
+                      stop(paste("An error has occurred. Check your logs or",
+                                 "contact the app author for clarification."),
+                           call. = FALSE)
+                    }
+                  }
+                ),
+                catch = function(err) {
+                  httpResponse(status = 500L,
+                    content_type = "text/html",
+                    content = as.character(htmltools::htmlTemplate(
+                      system.file("template", "error.html", package = "shiny"),
+                      message = conditionMessage(err)
+                    ))
+                  )
                 }
+              ),
+              function(resp) {
+                maybeInjectAutoreload(resp)
               }
             )
           },
@@ -389,6 +405,22 @@ HandlerManager <- R6Class("HandlerManager",
     }
   )
 )
+
+maybeInjectAutoreload <- function(resp) {
+  if (getOption("shiny.autoreload", FALSE) &&
+      isTRUE(grepl("^text/html($|;)", resp$content_type)) &&
+      is.character(resp$content)) {
+
+    resp$content <- gsub(
+      "</head>",
+      "<script src=\"shared/shiny-autoreload.js\"></script>\n</head>",
+      resp$content,
+      fixed = TRUE
+    )
+  }
+
+  resp
+}
 
 # Safely get the Content-Length of a Rook response, or NULL if the length cannot
 # be determined for whatever reason (probably malformed response$content).

--- a/R/server.R
+++ b/R/server.R
@@ -279,6 +279,8 @@ decodeMessage <- function(data) {
   return(mainMessage)
 }
 
+autoReloadCallbacks <- Callbacks$new()
+
 createAppHandlers <- function(httpHandlers, serverFuncSource) {
   appvars <- new.env()
   appvars$server <- NULL
@@ -301,6 +303,22 @@ createAppHandlers <- function(httpHandlers, serverFuncSource) {
     ws = function(ws) {
       if (!checkSharedSecret(ws$request$HTTP_SHINY_SHARED_SECRET)) {
         ws$close()
+        return(TRUE)
+      }
+
+      if (identical(ws$request$PATH_INFO, "/autoreload/")) {
+        if (!getOption("shiny.autoreload", FALSE)) {
+          ws$close()
+          return(TRUE)
+        }
+
+        callbackHandle <- autoReloadCallbacks$register(function() {
+          ws$send("autoreload")
+          ws$close()
+        })
+        ws$onClose(function() {
+          callbackHandle()
+        })
         return(TRUE)
       }
 

--- a/inst/template/error.html
+++ b/inst/template/error.html
@@ -1,0 +1,13 @@
+<html>
+
+<head>
+  <title>An error has occurred</title>
+</head>
+
+<body>
+
+<h1>An error has occurred!</h1>
+<p>{{message}}</p>
+
+</body>
+</html>

--- a/inst/www/shared/shiny-autoreload.js
+++ b/inst/www/shared/shiny-autoreload.js
@@ -1,0 +1,17 @@
+(function() {
+  var protocol = 'ws:';
+  if (window.location.protocol === 'https:')
+    protocol = 'wss:';
+
+  var defaultPath = window.location.pathname;
+  if (!/\/$/.test(defaultPath))
+    defaultPath += '/';
+  defaultPath += 'autoreload/';
+
+  var ws = new WebSocket(protocol + '//' + window.location.host + defaultPath);
+  ws.onmessage = function(event) {
+    if (event.data === "autoreload") {
+      window.location.reload()
+    }
+  }
+})();


### PR DESCRIPTION
Previously, `options(shiny.autoreload = TRUE)` had limited usefulness because any error in the UI would cause autoreload to stop working, or any error which caused a session disconnected. This is because the autoreload functionality was built around Shiny sessions, so a live and working session had to be active to initiate an autoreload.

This PR solves the problem by opening a dedicated websocket connection for file monitoring, and using this connection both for successful UI loads and for error pages.

Also, error pages look quite different, they need to be HTML now instead of the previous text/plain httpuv default.