### PR TITLE
Small changes to testModule()/testServer() semantics

### DIFF
--- a/R/mock-session.R
+++ b/R/mock-session.R
@@ -381,6 +381,8 @@ MockShinySession <- R6Class(
     flushReact = function(){
       private$flush()
     },
+    #' @description Create and return a namespace-specific session proxy.
+    #' @param namespace Character vector indicating a namespace.
     makeScope = function(namespace) {
       ns <- NS(namespace)
       createSessionProxy(

--- a/R/test-module.R
+++ b/R/test-module.R
@@ -93,14 +93,14 @@ testModule <- function(module, expr, ...) {
   # Evaluate `quosure` in a reactive context, and in the provided `env`, but
   # with `env` masked by a shallow view of `session$env`, the environment that
   # was saved when the module function was invoked. flush is not needed before
-  # entering the loop because the first expr execute is `{`.
+  # entering the loop because the first expr executed is `{`.
   isolate({
     withReactiveDomain(
       session,
       withr::with_options(list(`shiny.allowoutputreads`=TRUE), {
         rlang::eval_tidy(
           quosure,
-          data = rlang::new_data_mask(as.list(session$env)),
+          data = rlang::as_data_mask(as.list(session$env)),
           env = env
         )
       })

--- a/R/test-module.R
+++ b/R/test-module.R
@@ -14,6 +14,7 @@
 #' @param ... Additional arguments to pass to the module function. These
 #'   arguments are processed with [rlang::list2()] and so are
 #'   _[dynamic][rlang::dyn-dots]_.
+#' @return The result of evaluating `expr`.
 #' @include mock-session.R
 #' @rdname testModule
 #' @examples
@@ -78,6 +79,7 @@ testModule <- function(module, expr, ...) {
   })
 
   session <- MockShinySession$new()
+  on.exit(if (!session$isClosed()) session$close())
   args <- append(dots, list(input = session$input, output = session$output, session = session))
 
   isolate(
@@ -106,9 +108,6 @@ testModule <- function(module, expr, ...) {
       })
     )
   })
-
-  # TODO Should we be closing this via on.exit() in case the test expression throws?
-  if (!session$isClosed()) session$close()
 }
 
 #' Test an app's server-side logic

--- a/man/MockShinySession.Rd
+++ b/man/MockShinySession.Rd
@@ -618,10 +618,18 @@ Trigger a reactive flush right now.
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-makeScope"></a>}}
 \subsection{Method \code{makeScope()}}{
+Create and return a namespace-specific session proxy.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{MockShinySession$makeScope(namespace)}\if{html}{\out{</div>}}
 }
 
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{namespace}}{Character vector indicating a namespace.}
+}
+\if{html}{\out{</div>}}
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-clone"></a>}}

--- a/man/testModule.Rd
+++ b/man/testModule.Rd
@@ -25,6 +25,9 @@ arguments are processed with \code{\link[rlang:list2]{rlang::list2()}} and so ar
 will work up the directory hierarchy --- starting with the current directory ---
 looking for a directory that contains an \code{app.R} or \code{server.R} file.}
 }
+\value{
+The result of evaluating \code{expr}.
+}
 \description{
 Offer a way to test the reactive interactions in Shiny --- either in Shiny
 modules or in the server portion of a Shiny application. For more

--- a/tests/testthat/test-test-module.R
+++ b/tests/testthat/test-test-module.R
@@ -601,6 +601,25 @@ test_that("testModule allows lexical environment access through session$env", {
   })
 })
 
+test_that("Module shadowing can be mitigated with unquote", {
+  i <- 0
+  inc <- function() i <<- i+1
+
+  m <- local({
+    function(input, output, session) {
+      inc <- function() stop("I should never be called")
+    }
+  })
+
+  testModule(m, {
+    expect_is(inc, "function")
+    expect_false(identical(inc, !!inc))
+    !!inc()
+  })
+
+  expect_equal(i, 1)
+})
+
 test_that("testModule handles invalidateLater", {
   module <- function(input, output, session) {
     rv <- reactiveValues(x = 0)

--- a/tests/testthat/test-test-module.R
+++ b/tests/testthat/test-test-module.R
@@ -525,6 +525,33 @@ test_that("testModule works with nested modules", {
   })
 })
 
+test_that("testModule calls can be nested", {
+  outerModule <- function(input, output, session) {
+    doubled <- reactive({ input$x * 2 })
+    innerModule <- function(input, output, session) {
+      quadrupled <- reactive({ doubled() * 2 })
+    }
+  }
+
+  testModule(outerModule, {
+    session$setInputs(x = 1)
+    expect_equal(doubled(), 2)
+    testModule(innerModule, {
+      expect_equal(quadrupled(), 4)
+    })
+  })
+})
+
+test_that("testModule returns a meaningful result", {
+  result <- testModule(function(input, output, session) {
+    reactive({ input$x * 2 })
+  }, {
+    session$setInputs(x = 2)
+    session$returned()
+  })
+  expect_equal(result, 4)
+})
+
 test_that("assigning an output in a module function with a non-function errors", {
   module <- function(input, output, session) {
     output$someVar <- 123

--- a/tests/testthat/test-test-module.R
+++ b/tests/testthat/test-test-module.R
@@ -594,7 +594,7 @@ test_that("testModule allows lexical environment access through session$env", {
       b_var <- 321
     }
   })
-  expect_error(a_var, "not found")
+  expect_false(exists("a_var", inherits = FALSE))
   testModule(m, {
     expect_equal(b_var, 321)
     expect_equal(get("a_var", session$env), 123)

--- a/tests/testthat/test-test-module.R
+++ b/tests/testthat/test-test-module.R
@@ -556,7 +556,7 @@ test_that("testServer works", {
 test_that("testServer works when referencing external globals", {
   # If global is defined at the top of app.R outside of the server function.
   testServer({
-    expect_equal(global, 123)
+    expect_equal(get("global", session$env), 123)
   }, appDir=test_path("..", "test-modules", "06_tabsets"))
 })
 

--- a/tests/testthat/test-test-module.R
+++ b/tests/testthat/test-test-module.R
@@ -587,6 +587,20 @@ test_that("testServer works when referencing external globals", {
   }, appDir=test_path("..", "test-modules", "06_tabsets"))
 })
 
+test_that("testModule allows lexical environment access through session$env", {
+  m <- local({
+    a_var <- 123
+    function(input, output, session) {
+      b_var <- 321
+    }
+  })
+  expect_error(a_var, "not found")
+  testModule(m, {
+    expect_equal(b_var, 321)
+    expect_equal(get("a_var", session$env), 123)
+  })
+})
+
 test_that("testModule handles invalidateLater", {
   module <- function(input, output, session) {
     rv <- reactiveValues(x = 0)


### PR DESCRIPTION
This PR makes a few changes to `.testModule()`, the private function that powers `testModule()` and `testServer()`. The changes should make the behavior of `testModule()` and `testServer()` more intuitive.

1. **`.testModule()` returns a meaningful value.** Previously, `.testModule()` returned a meaningless value derived from implementation detail. Now, `.testModule()` returns the value the test expression evaluates to.
1. **Test expression is masked by the module environment**. Previously, the test expression was evaluated in the dynamic environment obtained from inside the module function after invoking it and stored as `session$env`. The parent of this environment included the lexical environment in which the module function was defined. Therefore, `session$env` and the environment in which `testModule()`/`testServer()` were called were potentially disjoint. Now, `.testModule()` *masks* the dynamic environment surrounding any `testModule()/testServer()` call with `session$env`. This ensures that definitions in the test environment are available within the test expression, regardless of where the module was defined. While this behavior is generally more intuitive, it gives rise to two cases that may require mitigation:
    1. **Module lexical environment required for testing** When the full lexical environment of the module is required it can be referred to explicitly in test expressions with `session$env`. 
    1. **Variables in module shadow testing dynamic environment** When the `session$env` mask shadows definitions in the dynamic testing environment, tidy eval unquote (`!!`/`!!!`) can be used to splice shadowed definitions into the test expression. A contrived example of this would be if for some reason a module defined an `expect_equal` variable. This could be circumvented in tests by referring to `!!expect_equal` in the test expression.