### PR TITLE
Skip debounce/throttle tests on CRAN

### DIFF
--- a/tests/testthat/test-reactivity.r
+++ b/tests/testthat/test-reactivity.r
@@ -1098,7 +1098,7 @@ test_that("event handling helpers take correct dependencies", {
 
 run_debounce_throttle <- function(do_priming) {
   # Some of the CRAN test machines are heavily loaded and so the timing for
-  # these tests isn't reliable.
+  # these tests isn't reliable. https://github.com/rstudio/shiny/pull/2789
   skip_on_cran()
 
   # The changing of rv$a will be the (chatty) source of reactivity.

--- a/tests/testthat/test-reactivity.r
+++ b/tests/testthat/test-reactivity.r
@@ -1097,6 +1097,10 @@ test_that("event handling helpers take correct dependencies", {
 })
 
 run_debounce_throttle <- function(do_priming) {
+  # Some of the CRAN test machines are heavily loaded and so the timing for
+  # these tests isn't reliable.
+  skip_on_cran()
+
   # The changing of rv$a will be the (chatty) source of reactivity.
   rv <- reactiveValues(a = 0)
 


### PR DESCRIPTION
These tests rely on timing and do not run reliably on some of the heavily-loaded CRAN test machines, so this PR skips them on CRAN.

Example output from https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-fedora-gcc/shiny-00check.html :

```
checking tests ... [20s/83s] ERROR
  Running ‘test-all.R’ [20s/82s]
Running the tests in ‘tests/test-all.R’ failed.
Complete output:
  > library(testthat)
  > library(shiny)
  >
  > test_check("shiny")
  ── 1. Failure: debounce/throttle work properly (with priming) (@test-reactivity.
  isolate(tr()) not identical to 10.
  1/1 mismatches
  [1] 8 - 10 == -2
  
  ── 2. Failure: debounce/throttle work properly (without priming) (@test-reactivi
  isolate(tr()) not identical to 10.
  1/1 mismatches
  [1] 9 - 10 == -1
  
  ══ testthat results ═══════════════════════════════════════════════════════════
  [ OK: 828 | SKIPPED: 3 | WARNINGS: 0 | FAILED: 2 ]
  1. Failure: debounce/throttle work properly (with priming) (@test-reactivity.r#1173)
  2. Failure: debounce/throttle work properly (without priming) (@test-reactivity.r#1176)
  
  Error: testthat unit tests failed
  Execution halted
```