### PR TITLE
Add `./revdep` folder output and script

### DIFF
--- a/revdep/.gitignore
+++ b/revdep/.gitignore
@@ -1,0 +1,3 @@
+*.noindex*
+data.sqlite
+failures.md

--- a/revdep/README.md
+++ b/revdep/README.md
@@ -21,11 +21,3 @@
 
 # Revdeps
 
-## Failed to check (3)
-
-|package        |version  |error |warning |note |
-|:--------------|:--------|:-----|:-------|:----|
-|MissingDataGUI |0.2-5    |1     |        |     |
-|rgl            |0.100.50 |1     |        |1    |
-|RQuantLib      |0.4.11   |1     |        |1    |
-

--- a/revdep/README.md
+++ b/revdep/README.md
@@ -1,0 +1,31 @@
+# Platform
+
+|field    |value                        |
+|:--------|:----------------------------|
+|version  |R version 3.6.1 (2019-07-05) |
+|os       |macOS Catalina 10.15.3       |
+|system   |x86_64, darwin15.6.0         |
+|ui       |X11                          |
+|language |(EN)                         |
+|collate  |en_US.UTF-8                  |
+|ctype    |en_US.UTF-8                  |
+|tz       |America/New_York             |
+|date     |2020-03-05                   |
+
+# Dependencies
+
+|package |old   |new     |Δ  |
+|:-------|:-----|:-------|:--|
+|shiny   |1.4.0 |1.4.0.1 |*  |
+|rlang   |NA    |0.4.5   |*  |
+
+# Revdeps
+
+## Failed to check (3)
+
+|package        |version  |error |warning |note |
+|:--------------|:--------|:-----|:-------|:----|
+|MissingDataGUI |0.2-5    |1     |        |     |
+|rgl            |0.100.50 |1     |        |1    |
+|RQuantLib      |0.4.11   |1     |        |1    |
+

--- a/revdep/problems.md
+++ b/revdep/problems.md
@@ -1,0 +1,1 @@
+*Wow, no problems at all. :)*

--- a/revdep/revdep-cran-comments.md
+++ b/revdep/revdep-cran-comments.md
@@ -2,9 +2,5 @@
 
 We checked 836 reverse dependencies (719 from CRAN + 117 from BioConductor), comparing R CMD check results across CRAN and dev versions of this package.
 
-* We saw 0 new problems
-* We failed to check 3 packages
-
-  * MissingDataGUI - RGtk2 issues
-  * rgl - gcc / clang issues
-  * RQuantLib - Needs rgl
+ * We saw 0 new problems
+ * We failed to check 0 packages

--- a/revdep/revdep-cran-comments.md
+++ b/revdep/revdep-cran-comments.md
@@ -1,0 +1,10 @@
+## revdepcheck results
+
+We checked 836 reverse dependencies (719 from CRAN + 117 from BioConductor), comparing R CMD check results across CRAN and dev versions of this package.
+
+* We saw 0 new problems
+* We failed to check 3 packages
+
+  * MissingDataGUI - RGtk2 issues
+  * rgl - gcc / clang issues
+  * RQuantLib - Needs rgl

--- a/tools/revdep.R
+++ b/tools/revdep.R
@@ -1,0 +1,9 @@
+
+# revdepcheck::revdep_reset()
+
+# maximize output width
+options(width = as.numeric(system2("tput", "cols", stdout = TRUE)) - 10)
+revdepcheck::revdep_check(pkgload::pkg_path("."), num_workers = detectCores() - 2, bioc = TRUE, timeout = as.difftime(30, units = "mins"))
+
+# save cran comments to a file
+cat(file = file.path(pkgload::pkg_path("."), "revdep", "revdep-cran-comments.md"), paste0(collapse = "\n", capture.output({revdepcheck::revdep_report_cran()})))


### PR DESCRIPTION
I would like for us to maintain the latest revdep output. It makes checking future revdep feel like a cleaner process