### PR TITLE
Add css class examples for actionButton and actionLink

### DIFF
--- a/R/input-action.R
+++ b/R/input-action.R
@@ -36,6 +36,10 @@
 #'
 #' }
 #'
+#' ## Example of adding extra class values
+#' actionButton("goButton", "Go!", class = "go")
+#' actionLink("goLink", "Go!", class = "go link")
+#'
 #' @seealso [observeEvent()] and [eventReactive()]
 #'
 #' @section Server value:

--- a/man/actionButton.Rd
+++ b/man/actionButton.Rd
@@ -63,6 +63,10 @@ shinyApp(ui, server)
 
 }
 
+## Example of adding extra class values
+actionButton("goButton", "Go!", class = "go")
+actionLink("goLink", "Go!", class = "go link")
+
 }
 \seealso{
 \code{\link[=observeEvent]{observeEvent()}} and \code{\link[=eventReactive]{eventReactive()}}

--- a/tests/testthat/test-actionButton.R
+++ b/tests/testthat/test-actionButton.R
@@ -1,0 +1,59 @@
+context("actionButton")
+
+test_that("Action button accepts class arguments", {
+  make_button <- function(class) {
+    if (missing(class)) {
+      actionButton("id", "label")
+    } else {
+      actionButton("id", "label", class = class)
+    }
+  }
+  act <- make_button()
+  get_class <- function(act) {
+    act_html <- format(act)
+    regmatches(act_html, regexec("class=\"[^\"]\"", act_html))[[1]]
+  }
+  act_class <- get_class(act)
+  expect_equal(
+    get_class(make_button(NULL)), act_class
+  )
+  expect_equal(
+    get_class(make_button(NA)), act_class
+  )
+  expect_equal(
+    get_class(make_button("extra")), sub("\"$", " extra\"", act_class)
+  )
+  expect_equal(
+    get_class(make_button("extra extra2")), sub("\"$", " extra extra2\"", act_class)
+  )
+})
+
+
+
+test_that("Action link accepts class arguments", {
+  make_link <- function(class) {
+    if (missing(class)) {
+      actionLink("id", "label")
+    } else {
+      actionLink("id", "label", class = class)
+    }
+  }
+  act <- make_link()
+  get_class <- function(act) {
+    act_html <- format(act)
+    regmatches(act_html, regexec("class=\"[^\"]\"", act_html))[[1]]
+  }
+  act_class <- get_class(act)
+  expect_equal(
+    get_class(make_link(NULL)), act_class
+  )
+  expect_equal(
+    get_class(make_link(NA)), act_class
+  )
+  expect_equal(
+    get_class(make_link("extra")), sub("\"$", " extra\"", act_class)
+  )
+  expect_equal(
+    get_class(make_link("extra extra2")), sub("\"$", " extra extra2\"", act_class)
+  )
+})


### PR DESCRIPTION
Fixes https://github.com/rstudio/shiny/issues/2730

Had written up unit tests for the new parameter, but in [the Issue](https://github.com/rstudio/shiny/issues/2730#issuecomment-600202873), we decided to not use it. I kept the tests. 