### PR TITLE
loadSupport(): fix global.R support, run global.R in appropriate dir

### DIFF
--- a/R/app.R
+++ b/R/app.R
@@ -359,6 +359,10 @@ loadSupport <- function(appDir=NULL, renv=new.env(parent=globalenv()), globalren
   }
 
   helpers <- list.files(helpersDir, pattern="\\.[rR]$", recursive=FALSE, full.names=TRUE)
+  # Ensure files in R/ are sorted according to the 'C' locale before sourcing.
+  # This convention is based on the default for packages. For details, see:
+  # https://cran.r-project.org/doc/manuals/r-release/R-exts.html#The-DESCRIPTION-file
+  helpers <- sort(helpers, method = "radix")
   helpers <- normalizePath(helpers)
 
   withr::with_dir(appDir, {

--- a/R/app.R
+++ b/R/app.R
@@ -342,9 +342,10 @@ loadSupport <- function(appDir=NULL, renv=new.env(parent=globalenv()), globalren
 
   if (!is.null(globalrenv)){
     # Evaluate global.R, if it exists.
-    if (file.exists(file.path.ci(appDir, "global.R"))){
+    globalPath <- file.path.ci(appDir, "global.R")
+    if (file.exists(globalPath)){
       withr::with_dir(appDir, {
-        sourceUTF8("global.R", envir=globalrenv)
+        sourceUTF8(basename(globalPath), envir=globalrenv)
       })
     }
   }

--- a/R/app.R
+++ b/R/app.R
@@ -343,9 +343,8 @@ loadSupport <- function(appDir=NULL, renv=new.env(parent=globalenv()), globalren
   if (!is.null(globalrenv)){
     # Evaluate global.R, if it exists.
     if (file.exists(file.path.ci(appDir, "global.R"))){
-      with_save_wd({
-        setwd(appDir)
-        sourceUTF8(file.path.ci(appDir, "global.R"), envir=globalrenv)
+      withr::with_dir(appDir, {
+        sourceUTF8("global.R", envir=globalrenv)
       })
     }
   }

--- a/R/app.R
+++ b/R/app.R
@@ -358,8 +358,11 @@ loadSupport <- function(appDir=NULL, renv=new.env(parent=globalenv()), globalren
   }
 
   helpers <- list.files(helpersDir, pattern="\\.[rR]$", recursive=FALSE, full.names=TRUE)
+  helpers <- normalizePath(helpers)
 
-  lapply(helpers, sourceUTF8, envir=renv)
+  withr::with_dir(appDir, {
+    lapply(helpers, sourceUTF8, envir=renv)
+  })
 
   invisible(renv)
 }

--- a/R/app.R
+++ b/R/app.R
@@ -334,16 +334,22 @@ initAutoReloadMonitor <- function(dir) {
 #'   `NULL`, `global.R` will not be evaluated at all.
 #' @export
 loadSupport <- function(appDir=NULL, renv=new.env(parent=globalenv()), globalrenv=globalenv()){
+  require(shiny)
+
+  if (is.null(appDir)) {
+    appDir <- findEnclosingApp(".")
+  }
+
   if (!is.null(globalrenv)){
     # Evaluate global.R, if it exists.
     if (file.exists(file.path.ci(appDir, "global.R"))){
-      sourceUTF8(file.path.ci(appDir, "global.R"), envir=globalrenv)
+      with_save_wd({
+        setwd(appDir)
+        sourceUTF8(file.path.ci(appDir, "global.R"), envir=globalrenv)
+      })
     }
   }
 
-  if (is.null(appDir)) {
-    appDir <- findEnclosingApp(appDir)
-  }
 
   helpersDir <- file.path(appDir, "R")
 

--- a/R/test.R
+++ b/R/test.R
@@ -102,19 +102,15 @@ runTests <- function(
 
   renv <- new.env(parent = envir)
 
-  oldwd <- getwd()
-  on.exit({
-    setwd(oldwd)
-  }, add = TRUE)
-  setwd(testsDir)
-
   # Otherwise source all the runners -- each in their own environment.
   ret <- do.call(rbind, lapply(runners, function(r) {
     pass <- FALSE
     result <-
       tryCatch({
         env <- new.env(parent = renv)
-        ret <- sourceUTF8(r, envir = env)
+        withr::with_dir(testsDir, {
+          ret <- sourceUTF8(r, envir = env)
+        })
         pass <- TRUE
         ret
       }, error = function(err) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -1873,3 +1873,11 @@ findEnclosingApp <- function(path = ".") {
     path <- dirname(path)
   }
 }
+
+# Reverts working dir to that when called.
+#' @noRd
+with_save_wd <- function(expr) {
+  original_wd <- getwd()
+  on.exit(setwd(original_wd))
+  force(expr)
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -1842,11 +1842,11 @@ select_menu <- function(choices, title = NULL, msg = "Enter one or more numbers 
 #' @noRd
 isAppDir <- function(path) {
 
-  if (file.exists(file.path(path, "app.R")))
+  if (file.exists(file.path.ci(path, "app.R")))
     return(TRUE)
 
-  if (file.exists(file.path(path, "server.R"))
-      && file.exists(file.path(path, "ui.R")))
+  if (file.exists(file.path.ci(path, "server.R"))
+      && file.exists(file.path.ci(path, "ui.R")))
     return(TRUE)
 
   FALSE

--- a/R/utils.R
+++ b/R/utils.R
@@ -1873,11 +1873,3 @@ findEnclosingApp <- function(path = ".") {
     path <- dirname(path)
   }
 }
-
-# Reverts working dir to that when called.
-#' @noRd
-with_save_wd <- function(expr) {
-  original_wd <- getwd()
-  on.exit(setwd(original_wd))
-  force(expr)
-}

--- a/tests/test-helpers/app1-standard/R/helperCap.R
+++ b/tests/test-helpers/app1-standard/R/helperCap.R
@@ -1,2 +1,2 @@
-
+source_wd <- getwd()
 helper1 <- 123

--- a/tests/test-helpers/app1-standard/global.R
+++ b/tests/test-helpers/app1-standard/global.R
@@ -1,1 +1,2 @@
 global <- "ABC"
+global_wd <- getwd()

--- a/tests/testthat/test-app.R
+++ b/tests/testthat/test-app.R
@@ -197,3 +197,16 @@ test_that("app.R is loaded after R/ helpers and into the right envs", {
   # app.R is sourced into a child environment of the helpers
   expect_identical(parent.env(calls[[2]]$envir), helperEnv1)
 })
+
+test_that("global.R and sources in R/ are sourced in the app directory", {
+  appDir <- normalizePath(test_path("../test-helpers/app1-standard"))
+  appGlobalEnv <- new.env(parent = globalenv())
+  appEnv <- new.env(parent = appGlobalEnv)
+  loadSupport(appDir, renv = appEnv, globalrenv = appGlobalEnv)
+
+  # Set by ../test-helpers/app1-standard/global.R
+  expect_equal(appGlobalEnv$global_wd, appDir)
+
+  # Set by ../test-helpers/app1-standard/R/helperCap.R
+  expect_equal(appEnv$source_wd, appDir)
+})

--- a/tests/testthat/test-app.R
+++ b/tests/testthat/test-app.R
@@ -71,7 +71,7 @@ test_that("With ui/server.R, global.R is loaded before R/ helpers and into the r
 
   # Should have seen three calls -- first to global then to the helpers
   expect_length(calls, 3)
-  expect_match(calls[[1]][[1]], "/global\\.R$", perl=TRUE)
+  expect_match(calls[[1]][[1]], "global\\.R$", perl=TRUE)
   expect_match(calls[[2]][[1]], "/helperCap\\.R$", perl=TRUE)
   expect_match(calls[[3]][[1]], "/helperLower\\.r$", perl=TRUE)
 
@@ -129,7 +129,7 @@ test_that("Loading supporting R files is opt-out", {
 
   # Should have seen three calls from global.R -- helpers are enabled
   expect_length(calls, 3)
-  expect_match(calls[[1]][[1]], "/global\\.R$", perl=TRUE)
+  expect_match(calls[[1]][[1]], "global\\.R$", perl=TRUE)
 })
 
 

--- a/tests/testthat/test-app.R
+++ b/tests/testthat/test-app.R
@@ -199,14 +199,14 @@ test_that("app.R is loaded after R/ helpers and into the right envs", {
 })
 
 test_that("global.R and sources in R/ are sourced in the app directory", {
-  appDir <- normalizePath(test_path("../test-helpers/app1-standard"))
+  appDir <- test_path("../test-helpers/app1-standard")
   appGlobalEnv <- new.env(parent = globalenv())
   appEnv <- new.env(parent = appGlobalEnv)
   loadSupport(appDir, renv = appEnv, globalrenv = appGlobalEnv)
 
   # Set by ../test-helpers/app1-standard/global.R
-  expect_equal(appGlobalEnv$global_wd, appDir)
+  expect_equal(appGlobalEnv$global_wd, normalizePath(appDir))
 
   # Set by ../test-helpers/app1-standard/R/helperCap.R
-  expect_equal(appEnv$source_wd, appDir)
+  expect_equal(appEnv$source_wd, normalizePath(appDir))
 })


### PR DESCRIPTION
* `global.R` support was broken as a result our changes to the `appDir` argument; this fixes it.
* I added ye olde `require(shiny)` so `shiny::loadSupport()` works.
* Ensures `global.R` is evaluated in the app directory instead of whichever directory `loadSupport()` was called in.
* Replace use of `on.exit()/setwd()` with a `withr::with_dir()`
* The order of files in `R/` is sourced is now given by `sort(..., method="radix")` which aligns with R conventions
* `findEnclosingApp()` now uses `file.path.ci()` internally so it now works on case-insensitive file systems (tested by mounting fat32 loopback disk on Linux)

These items came up preparing https://github.com/CRI-iAtlas/shiny-iatlas for module testing.