### PR TITLE
Do not flush when setting a returned value for a mock shiny session

### DIFF
--- a/R/mock-session.R
+++ b/R/mock-session.R
@@ -420,7 +420,6 @@ MockShinySession <- R6Class(
     #' @param value The value returned from the module
     setReturned = function(value) {
       self$returned <- value
-      private$flush()
       value
     },
     #' @description Get the value returned by the module call.
@@ -461,4 +460,3 @@ MockShinySession <- R6Class(
     }
   )
 )
-

--- a/R/test-server.R
+++ b/R/test-server.R
@@ -120,7 +120,7 @@ testServer <- function(app = NULL, expr, ...) {
         withReactiveDomain(
           session,
           withr::with_options(list(`shiny.allowoutputreads` = TRUE), {
-            session$setReturned(server(input = session$input, output = session$output, session = session))
+            server(input = session$input, output = session$output, session = session)
           })
         )
       )

--- a/tests/testthat/test-test-server.R
+++ b/tests/testthat/test-test-server.R
@@ -165,6 +165,7 @@ test_that("testServer handles reactivePoll", {
   }
 
   testServer(module, {
+    session$flushReact()
     expect_equal(rv$x, 1)
 
     for (i in 1:4){
@@ -189,6 +190,7 @@ test_that("testServer handles reactiveTimer", {
   }
 
   testServer(module, {
+    session$flushReact()
     expect_equal(rv$x, 1)
 
     session$elapse(200)
@@ -593,6 +595,7 @@ test_that("testServer handles invalidateLater", {
   }
 
   testServer(module, {
+    session$flushReact()
     # Should have run once
     expect_equal(rv$x, 1)
 


### PR DESCRIPTION
* Do not flush when setting the returned value in a mocked shiny session. This requires `$flushReact()` to be called when wanting to access reactive values that do not require inputs to be set.
* Do not set a returned value for an app. An app never has access to the returned value of a server function.  This **does** makes sense for modules, but not shiny apps.