### PR TITLE
Add parameter `args` to `testServer()`. Remove `../` from `loadSupport('../')` calls

### DIFF
--- a/R/test-server.R
+++ b/R/test-server.R
@@ -18,10 +18,9 @@ isModuleServer <- function(x) {
 #'   in the server function environment, meaning that the parameters of the
 #'   server function (e.g. `input`, `output`, and `session`) will be available
 #'   along with any other values created inside of the server function.
-#' @param ... Additional arguments to pass to the module function. These
-#'   arguments are processed with [rlang::list2()] and so are
-#'   _[dynamic][rlang::dyn-dots]_. If `app` is a module, and no `id` argument is
-#'   provided, one will be generated and supplied automatically.
+#' @param args Additional arguments to pass to the module function.
+#'   If `app` is a module, and no `id` argument is provided, one will be
+#'   generated and supplied automatically.
 #' @return The result of evaluating `expr`.
 #' @include mock-session.R
 #' @rdname testServer
@@ -37,7 +36,7 @@ isModuleServer <- function(x) {
 #'   })
 #' }
 #'
-#' testServer(server, {
+#' testServer(server, args = list(multiplier = 2), {
 #'   session$setInputs(x = 1)
 #'   # You're also free to use third-party
 #'   # testing packages like testthat:
@@ -49,14 +48,13 @@ isModuleServer <- function(x) {
 #'   stopifnot(myreactive() == 4)
 #'   stopifnot(output$txt == "I am 4")
 #'   # Any additional arguments, below, are passed along to the module.
-#' }, multiplier = 2)
+#' })
 #' @export
-testServer <- function(app = NULL, expr, ...) {
+testServer <- function(app = NULL, expr, args = rlang::list2()) {
 
   require(shiny)
 
   quosure <- rlang::enquo(expr)
-  args <- rlang::list2(...)
   session <- getDefaultReactiveDomain()
 
   if (inherits(session, "MockShinySession"))

--- a/R/test-server.R
+++ b/R/test-server.R
@@ -140,4 +140,6 @@ testServer <- function(app = NULL, expr, args = list()) {
       )
     )
   }
+
+  invisible()
 }

--- a/R/test-server.R
+++ b/R/test-server.R
@@ -50,7 +50,7 @@ isModuleServer <- function(x) {
 #'   # Any additional arguments, below, are passed along to the module.
 #' })
 #' @export
-testServer <- function(app = NULL, expr, args = rlang::list2()) {
+testServer <- function(app = NULL, expr, args = list()) {
 
   require(shiny)
 

--- a/inst/app_template/tests/testthat.R
+++ b/inst/app_template/tests/testthat.R
@@ -3,7 +3,7 @@ library(testthat)
 test_dir(
   "./testthat",
   # Run in the app's environment containing all support methods.
-  env = shiny::loadSupport("../"),
+  env = shiny::loadSupport(),
   # Display the regular progress output and throw an error if any test error is found
   reporter = c("progress", "fail")
 )

--- a/man/testServer.Rd
+++ b/man/testServer.Rd
@@ -4,7 +4,7 @@
 \alias{testServer}
 \title{Reactive testing for Shiny server functions and modules}
 \usage{
-testServer(app = NULL, expr, args = rlang::list2())
+testServer(app = NULL, expr, args = list())
 }
 \arguments{
 \item{app}{The path to an application or module to test. In addition to

--- a/man/testServer.Rd
+++ b/man/testServer.Rd
@@ -4,7 +4,7 @@
 \alias{testServer}
 \title{Reactive testing for Shiny server functions and modules}
 \usage{
-testServer(app = NULL, expr, ...)
+testServer(app = NULL, expr, args = rlang::list2())
 }
 \arguments{
 \item{app}{The path to an application or module to test. In addition to
@@ -19,10 +19,9 @@ in the server function environment, meaning that the parameters of the
 server function (e.g. \code{input}, \code{output}, and \code{session}) will be available
 along with any other values created inside of the server function.}
 
-\item{...}{Additional arguments to pass to the module function. These
-arguments are processed with \code{\link[rlang:list2]{rlang::list2()}} and so are
-\emph{\link[rlang:dyn-dots]{dynamic}}. If \code{app} is a module, and no \code{id} argument is
-provided, one will be generated and supplied automatically.}
+\item{args}{Additional arguments to pass to the module function.
+If \code{app} is a module, and no \code{id} argument is provided, one will be
+generated and supplied automatically.}
 }
 \value{
 The result of evaluating \code{expr}.
@@ -44,7 +43,7 @@ server <- function(id, multiplier = 2, prefix = "I am ") {
   })
 }
 
-testServer(server, {
+testServer(server, args = list(multiplier = 2), {
   session$setInputs(x = 1)
   # You're also free to use third-party
   # testing packages like testthat:
@@ -56,5 +55,5 @@ testServer(server, {
   stopifnot(myreactive() == 4)
   stopifnot(output$txt == "I am 4")
   # Any additional arguments, below, are passed along to the module.
-}, multiplier = 2)
+})
 }

--- a/tests/test-helpers/app1-standard/tests/runner2.R
+++ b/tests/test-helpers/app1-standard/tests/runner2.R
@@ -2,7 +2,7 @@
 
 
 withr::with_environment(
-  shiny::loadSupport("../"),
+  shiny::loadSupport(),
   {
     runner2_B <- 2
 

--- a/tests/test-modules/107_scatterplot/tests/testthat.R
+++ b/tests/test-modules/107_scatterplot/tests/testthat.R
@@ -2,6 +2,6 @@ library(testthat)
 
 test_dir(
   "./testthat",
-  env = shiny::loadSupport("../"),
+  env = shiny::loadSupport(),
   reporter = c("progress", "fail")
 )

--- a/tests/test-modules/107_scatterplot/tests/testthat/test-linked-scatterplot-module.R
+++ b/tests/test-modules/107_scatterplot/tests/testthat/test-linked-scatterplot-module.R
@@ -3,9 +3,11 @@ context("linkedScatterServer")
 
 testServer(
   linkedScatterServer,
-  data = reactive(ggplot2::mpg),
-  left = reactive(c("cty", "hwy")),
-  right = reactive(c("drv", "hwy")),
+  args = list(
+    data = reactive(ggplot2::mpg),
+    left = reactive(c("cty", "hwy")),
+    right = reactive(c("drv", "hwy"))
+  ),
   {
 
     # Init count... 0

--- a/tests/test-modules/12_counter/tests/testthat.R
+++ b/tests/test-modules/12_counter/tests/testthat.R
@@ -5,6 +5,6 @@ library(testthat)
 # the supporting files that were already loaded into that env.
 testthat::test_dir(
   "./testthat",
-  env = shiny::loadSupport("../"),
+  env = shiny::loadSupport(),
   reporter = c("summary", "fail")
 )

--- a/tests/testthat/test-test-server-app.R
+++ b/tests/testthat/test-test-server-app.R
@@ -104,5 +104,5 @@ test_that("a Shiny app object with a module inside can be tested", {
 })
 
 test_that("It's an error to pass arguments to a server", {
-  expect_error(testServer(test_path("..", "test-modules", "06_tabsets"), {}, an_arg = 123))
+  expect_error(testServer(test_path("..", "test-modules", "06_tabsets"), {}, args = list(an_arg = 123)))
 })

--- a/tests/testthat/test-test-server-nesting.R
+++ b/tests/testthat/test-test-server-nesting.R
@@ -17,9 +17,9 @@ test_that("Nested modules", {
     })
   }
 
-  testServer(parent, {
+  testServer(parent, args = list(id = "parent-id"), {
     expect_equal(output$txt, "foo")
-  }, id = "parent-id")
+  })
 
 })
 
@@ -30,9 +30,9 @@ test_that("Lack of ID", {
     })
   }
 
-  testServer(module, {
+  testServer(module, args = list(id = "foo"), {
     expect_equal(output$txt, "foo-x")
-  }, id = "foo")
+  })
 })
 
 test_that("testServer works with nested module servers", {
@@ -50,10 +50,10 @@ test_that("testServer works with nested module servers", {
     })
   }
 
-  testServer(outerModule, {
+  testServer(outerModule, args = list(id = "foo"), {
     session$setInputs(x = 1)
     expect_equal(output$someVar, "a value: 2")
-  }, id = "foo")
+  })
 })
 
 test_that("testServer calls do not nest in module functions", {

--- a/tests/testthat/test-test-server-scope.R
+++ b/tests/testthat/test-test-server-scope.R
@@ -14,12 +14,12 @@ test_that("Variables outside of the module are inaccessible", {
     }
   }, envir = new.env(parent = globalenv()))
 
-  testServer(module, {
+  testServer(module, args = list(x = 0), {
     expect_equal(x, 0)
     expect_equal(y, 1)
     expect_equal(z, 2)
     expect_equal(exists("outside"), FALSE)
-  }, x = 0)
+  })
 })
 
 test_that("Variables outside the testServer() have correct visibility", {
@@ -34,11 +34,11 @@ test_that("Variables outside the testServer() have correct visibility", {
   x <- 99
   z <- 123
 
-  testServer(module, {
+  testServer(module, args = list(x = 0), {
     expect_equal(x, 0)
     expect_equal(y, 1)
     expect_equal(z, 123)
-  }, x = 0)
+  })
 })
 
 test_that("testServer allows lexical environment access through session$env", {

--- a/tests/testthat/test-test-server.R
+++ b/tests/testthat/test-test-server.R
@@ -11,24 +11,7 @@ test_that("testServer passes dots", {
       expect_equal(someArg, 123)
     })
   }
-  testServer(module, {}, someArg = 123)
-})
-
-test_that("testServer passes dynamic dots", {
-  module <- function(id, someArg) {
-    expect_false(missing(someArg))
-    moduleServer(id, function(input, output, session) {
-      expect_equal(someArg, 123)
-    })
-  }
-
-  # Test with !!! to splice in a whole named list constructed with base::list()
-  moreArgs <- list(someArg = 123)
-  testServer(module, {}, !!!moreArgs)
-
-  # Test with !!/:= to splice in an argument name
-  argName <- "someArg"
-  testServer(module, {}, !!argName := 123)
+  testServer(module, {}, args = list(someArg = 123))
 })
 
 test_that("testServer handles observers", {
@@ -399,7 +382,7 @@ test_that("testServer handles modules with additional arguments", {
   testServer(module, {
     expect_equal(output$txt1, "val1")
     expect_equal(output$txt2, "val2")
-  }, arg1="val1", arg2="val2")
+  }, list(arg1="val1", arg2="val2"))
 })
 
 test_that("testServer captures htmlwidgets", {
@@ -550,7 +533,7 @@ test_that("accessing a non-existent output gives an informative message", {
 
   testServer(module, {
     expect_error(output$dontexist, "hasn't been defined yet: output\\$server1-dontexist")
-  }, id = "server1")
+  }, list(id = "server1"))
 
   testServer(module, {
     expect_error(output$dontexist, "hasn't been defined yet: output\\$.*-dontexist")


### PR DESCRIPTION
* Removes the parameter of `../` from `loadSupport()` calls as the app will be found automatically now
* Moves `...` parameters in `testServer()` to `args` to avoid name clashing.  
  * Removed dynamic arg test as that is not needed anymore
  * Users can still create "dynamic args" using `rlang::list2()` mixed with `!!` or `!!!` when creating `args`.  This is why the default value for `args = rlang::list2()`