### PR TITLE
Safeguard monitorHandle function call

### DIFF
--- a/R/app.R
+++ b/R/app.R
@@ -238,8 +238,13 @@ shinyAppDir_serverR <- function(appDir, options=list()) {
   }
   onStop <- function() {
     setwd(oldwd)
-    monitorHandle()
-    monitorHandle <<- NULL
+    # It is possible that while calling appObj()$onStart() or loadingSupport, an error occured
+    # This will cause `onStop` to be called.
+    #   The `oldwd` will exist, but `monitorHandle` is not a function yet.
+    if (!is.null(monitorHandle)) {
+      monitorHandle()
+      monitorHandle <<- NULL
+    }
   }
 
   structure(
@@ -447,8 +452,13 @@ shinyAppDir_appR <- function(fileName, appDir, options=list())
   }
   onStop <- function() {
     setwd(oldwd)
-    monitorHandle()
-    monitorHandle <<- NULL
+    # It is possible that while calling appObj()$onStart() or loadingSupport, an error occured
+    # This will cause `onStop` to be called.
+    #   The `oldwd` will exist, but `monitorHandle` is not a function yet.
+    if (!is.null(monitorHandle)) {
+      monitorHandle()
+      monitorHandle <<- NULL
+    }
   }
 
   structure(

--- a/R/app.R
+++ b/R/app.R
@@ -241,7 +241,7 @@ shinyAppDir_serverR <- function(appDir, options=list()) {
     # It is possible that while calling appObj()$onStart() or loadingSupport, an error occured
     # This will cause `onStop` to be called.
     #   The `oldwd` will exist, but `monitorHandle` is not a function yet.
-    if (!is.null(monitorHandle)) {
+    if (is.function(monitorHandle)) {
       monitorHandle()
       monitorHandle <<- NULL
     }
@@ -455,7 +455,7 @@ shinyAppDir_appR <- function(fileName, appDir, options=list())
     # It is possible that while calling appObj()$onStart() or loadingSupport, an error occured
     # This will cause `onStop` to be called.
     #   The `oldwd` will exist, but `monitorHandle` is not a function yet.
-    if (!is.null(monitorHandle)) {
+    if (is.function(monitorHandle)) {
       monitorHandle()
       monitorHandle <<- NULL
     }


### PR DESCRIPTION
If an app source code fails to source, `monitorHandle` is not set as a function.  In the app cleanup, `monitorHandle()` is called.  

Now we check if it is a function and only call it if it is a function.



Before:
```r
tryCatch({
  # app 
  shiny::runApp("missing_highcharter_pkg")
}, error = function(e) { message("", e)})
Error in monitorHandle(): could not find function "monitorHandle"
```

With PR:
```r
tryCatch({shiny::runApp("missing_highcharter_pkg")}, error = function(e) { message("", e)})
Error in library(highcharter): there is no package called ‘highcharter’
```

(Used a `tryCatch` to capture the last error produced.  The `monitorHandle` error was stomping the true error of `highcharter` is missing.)