### PR TITLE
Add miscellaneous MockShinySession stubs

### DIFF
--- a/R/mock-session.R
+++ b/R/mock-session.R
@@ -172,7 +172,7 @@ MockShinySession <- R6Class(
     #FIXME: this is wrong. Will need to be more complex.
     #' @description Unsophisticated mock implementation that merely invokes
     #'   the given callback immediately.
-    #' @param callback The callback ato be invoked.
+    #' @param callback The callback to be invoked.
     cycleStartAction = function(callback){ callback() },
 
     #' @description Base64-encode the given file. Needed for image rendering.
@@ -354,6 +354,10 @@ MockShinySession <- R6Class(
     setBookmarkExclude = function(names) {
       warning("Bookmarking isn't meaningfully mocked in MockShinySession")
     },
+    #' @description No-op
+    #' @param type Not used
+    #' @param message Not used
+    sendModal = function(type, message) {},
     #' @description No-op
     getBookmarkExclude = function() {
       warning("Bookmarking isn't meaningfully mocked in MockShinySession")

--- a/man/MockShinySession.Rd
+++ b/man/MockShinySession.Rd
@@ -73,6 +73,7 @@ session$setInputs(x=1, y=2)
 \item \href{#method-sendBinaryMessage}{\code{MockShinySession$sendBinaryMessage()}}
 \item \href{#method-sendInputMessage}{\code{MockShinySession$sendInputMessage()}}
 \item \href{#method-setBookmarkExclude}{\code{MockShinySession$setBookmarkExclude()}}
+\item \href{#method-sendModal}{\code{MockShinySession$sendModal()}}
 \item \href{#method-getBookmarkExclude}{\code{MockShinySession$getBookmarkExclude()}}
 \item \href{#method-onBookmark}{\code{MockShinySession$onBookmark()}}
 \item \href{#method-onBookmarked}{\code{MockShinySession$onBookmarked()}}
@@ -226,7 +227,7 @@ the given callback immediately.
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{callback}}{The callback ato be invoked.}
+\item{\code{callback}}{The callback to be invoked.}
 }
 \if{html}{\out{</div>}}
 }
@@ -501,6 +502,25 @@ No-op
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{names}}{Not used}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-sendModal"></a>}}
+\if{latex}{\out{\hypertarget{method-sendModal}{}}}
+\subsection{Method \code{sendModal()}}{
+No-op
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{MockShinySession$sendModal(type, message)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{type}}{Not used}
+
+\item{\code{message}}{Not used}
 }
 \if{html}{\out{</div>}}
 }


### PR DESCRIPTION
I was working on testing the `server` function of https://github.com/alandipert/memory-hex today and it didn't work, and I boiled it down to the fact that `MockShinySession` was missing a `session$sendModal()` which is called in `shiny::showModal()`.

I looked around and spotted a few others that we should probably add. I'll do a more thorough audit ASAP.

- [x] `sendModal`
- [ ] `showProgress`
- [ ] `sendProgress`