### PR TITLE
testServer does not return results. Do not test for it.

### DIFF
--- a/tests/testthat/test-test-server.R
+++ b/tests/testthat/test-test-server.R
@@ -555,18 +555,6 @@ test_that("accessing a non-existent output gives an informative message", {
   })
 })
 
-test_that("testServer returns a meaningful result", {
-  result <- testServer(function(id) {
-    moduleServer(id, function(input, output, session) {
-      reactive({ input$x * 2 })
-    })
-  }, {
-    session$setInputs(x = 2)
-    session$getReturned()()
-  })
-  expect_equal(result, 4)
-})
-
 test_that("assigning an output in a module function with a non-function errors", {
   module <- function(id) {
     moduleServer(id, function(input, output, session) {


### PR DESCRIPTION
`testServer` now returns `invisible()`. Changed here: https://github.com/rstudio/shiny/commit/ca9a72d25c3b321bcec2379143575f12bd87b9fe