### PR TITLE
testServer(): Properly capture module return values

### DIFF
--- a/R/modules.R
+++ b/R/modules.R
@@ -134,10 +134,12 @@ moduleServer <- function(id, module, session = getDefaultReactiveDomain()) {
   if (inherits(session, "MockShinySession")) {
     body(module) <- rlang::expr({
       session$setEnv(base::environment())
-      session$setReturned({ !!!body(module) })
+      !!body(module)
     })
+    session$setReturned(callModule(module, id, session = session))
+  } else {
+    callModule(module, id, session = session)
   }
-  callModule(module, id, session = session)
 }
 
 

--- a/tests/testthat/test-test-server.R
+++ b/tests/testthat/test-test-server.R
@@ -651,3 +651,42 @@ test_that("session flush handlers work", {
 
   })
 })
+
+test_that("module return value captured", {
+  module_implicit_return <- function(id) {
+    moduleServer(id, function(input, output, session) {
+      123
+    })
+  }
+
+  testServer(module_implicit_return, {
+    expect_equal(session$returned, 123)
+  })
+
+  module_early_returns <- function(id, n) {
+    retval <<- NULL
+    moduleServer(id, function(input, output, session) {
+      if (n == 0) return(n)
+      if (n %% 2 == 0) {
+        retval <<- "even"
+      } else {
+        return(FALSE)
+      }
+      retval
+    })
+  }
+
+  testServer(module_early_returns, {
+    expect_equal(session$returned, 0)
+  }, args = list(n = 0))
+
+  testServer(module_early_returns, {
+    expect_equal(session$returned, FALSE)
+  }, args = list(n = 1))
+
+  testServer(module_early_returns, {
+    expect_equal(session$returned, "even")
+  }, args = list(n = 2))
+})
+
+#test_that("server return value captured", {})


### PR DESCRIPTION
Previously, the return value of a module under test via `testServer()` was captured by modifying the module function body. The expression value of the function body was retained. However, this doesn't work when module function body includes early `return()` calls. `session$returned` in these cases is `NULL`.

In this PR, we introduce a different technique for retaining module function return values. We wrap the call to the module function in a call to `session$setReturned()`.

Note that the value of app server functions is not retained, because we [document](https://shiny.rstudio.com/reference/shiny/0.12.2/shinyServer.html) that server function return values are discarded. We may consider producing an error if `session$returned` is referenced in the test expression associated with an app server function.