### PR TITLE
Minor updates to shinyAppTemplate

### DIFF
--- a/R/app_template.R
+++ b/R/app_template.R
@@ -29,7 +29,6 @@
 #'     |   `- mytest.R
 #'     |- testthat.R
 #'     `- testthat
-#'         |- helper-load.R
 #'         |- test-mymodule.R
 #'         |- test-server.R
 #'         `- test-sort.R

--- a/R/app_template.R
+++ b/R/app_template.R
@@ -3,9 +3,19 @@
 #' This function populates a directory with files for a Shiny application.
 #'
 #' In an interactive R session, this function will, by default, prompt the user
-#' which components to add to the application.
+#' to select which components to add to the application. Choices are
 #'
-#' The full example application includes the following files and directories:
+#' ```
+#' 1: All
+#' 2: app.R            : Main application file
+#' 3: R/sort.R         : Helper file with R code
+#' 4: R/my-module.R    : Example module
+#' 5: tests/shinytest/ : Tests using the shinytest package
+#' 6: tests/testthat/  : Tests using the testthat package
+#' ```
+#'
+#' If option 1 is selected, the full example application including the
+#' following files and directories is created:
 #'
 #' ```
 #' appdir/
@@ -73,8 +83,8 @@ shinyAppTemplate <- function(path = NULL, examples = "default", dryrun = FALSE)
     app       = "app.R            : Main application file",
     rdir      = "R/sort.R         : Helper file with R code",
     module    = "R/my-module.R    : Example module",
-    shinytest = "tests/shinytest/ : Tests using shinytest package",
-    testthat  = "tests/testthat/  : Tests using testthat"
+    shinytest = "tests/shinytest/ : Tests using the shinytest package",
+    testthat  = "tests/testthat/  : Tests using the testthat package"
   )
 
   if (identical(examples, "default")) {

--- a/man/shinyAppTemplate.Rd
+++ b/man/shinyAppTemplate.Rd
@@ -45,7 +45,6 @@ following files and directories is created:\preformatted{appdir/
     |   `- mytest.R
     |- testthat.R
     `- testthat
-        |- helper-load.R
         |- test-mymodule.R
         |- test-server.R
         `- test-sort.R

--- a/man/shinyAppTemplate.Rd
+++ b/man/shinyAppTemplate.Rd
@@ -25,9 +25,16 @@ This function populates a directory with files for a Shiny application.
 }
 \details{
 In an interactive R session, this function will, by default, prompt the user
-which components to add to the application.
+to select which components to add to the application. Choices are\preformatted{1: All
+2: app.R            : Main application file
+3: R/sort.R         : Helper file with R code
+4: R/my-module.R    : Example module
+5: tests/shinytest/ : Tests using the shinytest package
+6: tests/testthat/  : Tests using the testthat package
+}
 
-The full example application includes the following files and directories:\preformatted{appdir/
+If option 1 is selected, the full example application including the
+following files and directories is created:\preformatted{appdir/
 |- app.R
 |- R
 |   |- my-module.R


### PR DESCRIPTION
This is just a minor update to shinyAppTemplate, mostly in the docs:

- More detail on how shinyAppTemplate choices 
- Streamline shinytest/testthat listing in the choices presented

I think the following might be an improvement on renaming still, and docs would need to be updated accordingly:

```
appdir/
|- app.R                    
|- R                       
|   |- my-module.R         -> sample-module.R
|   `- sort.R              -> sample-helper-function.R
`- tests
    |- shinytest.R         
    |- shinytest
    |   `- mytest.R        -> sample-test.R
    |- testthat.R          
    `- testthat
        |- test-mymodule.R -> test-sample-module.R
        |- test-server.R   
        `- test-sort.R     -> test-sample-helper-function.R
```
 

