### PR TITLE
Add sort_c function for sorting in C locale

### DIFF
--- a/R/app.R
+++ b/R/app.R
@@ -291,8 +291,9 @@ initAutoReloadMonitor <- function(dir) {
   lastValue <- NULL
   observeLabel <- paste0("File Auto-Reload - '", basename(dir), "'")
   obs <- observe(label = observeLabel, {
-    files <- sort(list.files(dir, pattern = filePattern, recursive = TRUE,
-      ignore.case = TRUE))
+    files <- sort_c(
+      list.files(dir, pattern = filePattern, recursive = TRUE, ignore.case = TRUE)
+    )
     times <- file.info(files)$mtime
     names(times) <- files
 
@@ -367,7 +368,7 @@ loadSupport <- function(appDir=NULL, renv=new.env(parent=globalenv()), globalren
   # Ensure files in R/ are sorted according to the 'C' locale before sourcing.
   # This convention is based on the default for packages. For details, see:
   # https://cran.r-project.org/doc/manuals/r-release/R-exts.html#The-DESCRIPTION-file
-  helpers <- sort(helpers, method = "radix")
+  helpers <- sort_c(helpers)
   helpers <- normalizePath(helpers)
 
   withr::with_dir(appDir, {

--- a/R/utils.R
+++ b/R/utils.R
@@ -210,6 +210,12 @@ sortByName <- function(x) {
   x[order(names(x))]
 }
 
+# Sort a vector. If a character vector, sort using C locale, which is consistent
+# across platforms. Note that radix sort uses C locale according to ?sort.
+sort_c <- function(x, ...) {
+  sort(x, method = "radix", ...)
+}
+
 # Wrapper around list2env with a NULL check. In R <3.2.0, if an empty unnamed
 # list is passed to list2env(), it errors. But an empty named list is OK. For
 # R >=3.2.0, this wrapper is not necessary.


### PR DESCRIPTION
We want to use consistent sorting when sourcing files in the R/ directory. 