### PR TITLE
Considers the possibility that _inputs_ has an equals sign after it.

### DIFF
--- a/R/bookmark-state.R
+++ b/R/bookmark-state.R
@@ -318,7 +318,7 @@ RestoreContext <- R6Class("RestoreContext",
         stop("Invalid state string: more than one '_values_' found")
 
       # Look for _inputs_ and store following content in inputStr
-      splitStr <- strsplit(queryString, "(^|&)_inputs_(&|$)")[[1]]
+      splitStr <- strsplit(queryString, "(^|&)_inputs_=?(&|$)")[[1]]
       if (length(splitStr) == 2) {
         inputStr <- splitStr[2]
         # Remove any _values_ (and content after _values_) that may come after
@@ -453,7 +453,7 @@ hasCurrentRestoreContext <- function() {
   domain <- getDefaultReactiveDomain()
   if (!is.null(domain) && !is.null(domain$restoreContext))
     return(TRUE)
-  
+
   return(FALSE)
 }
 


### PR DESCRIPTION
Currently, when using URL-based bookmarking, the URL is of the form `url/?_inputs_&n=200`, which is valid and legal but somewhat nonstandard because of the absence of an equals sign `=` after `_inputs_`. 

Some applications add the equals sign by default, which breaks bookmarking. With this 2 character change, `{shiny}` would also work with `url/?_inputs_=&n=200`. Fixes #2576