### PR TITLE
Safer default file deletion behavior for renderImage

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@ shiny 1.4.0.9001
 
 ### Breaking changes
 
-* Until this release, `renderImage()` had a dangerous default of `deleteFile = TRUE`. (Sorry!) Going forward, calls to `renderImage()` will need an explicit `deleteFile` argument; for now, failing to provide one will result in a warning message, and the file will be deleted if it appears to be within the `tempdir()`.
+* Until this release, `renderImage()` had a dangerous default of `deleteFile = TRUE`. (Sorry!) Going forward, calls to `renderImage()` will need an explicit `deleteFile` argument; for now, failing to provide one will result in a warning message, and the file will be deleted if it appears to be within the `tempdir()`. ([#2881](https://github.com/rstudio/shiny/pull/2881))
 
 ### New features
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@ shiny 1.4.0.9001
 
 ### Breaking changes
 
+* Until this release, `renderImage()` had a dangerous default of `deleteFile = TRUE`. (Sorry!) Going forward, calls to `renderImage()` will need an explicit `deleteFile` argument; for now, failing to provide one will result in a warning message, and the file will be deleted if it appears to be within the `tempdir()`.
+
 ### New features
 
 * The new `shinyAppTemplate()` function creates a new template Shiny application, where components are optional, such as helper files in an R/ subdirectory, a module, and various kinds of tests. ([#2704](https://github.com/rstudio/shiny/pull/2704))

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@ shiny 1.4.0.9001
 
 ### Breaking changes
 
-* Until this release, `renderImage()` had a dangerous default of `deleteFile = TRUE`. (Sorry!) Going forward, calls to `renderImage()` will need an explicit `deleteFile` argument; for now, failing to provide one will result in a warning message, and the file will be deleted if it appears to be within the `tempdir()`. ([#2881](https://github.com/rstudio/shiny/pull/2881))
+* Fixed [#2869](https://github.com/rstudio/shiny/issues/2869): Until this release, `renderImage()` had a dangerous default of `deleteFile = TRUE`. (Sorry!) Going forward, calls to `renderImage()` will need an explicit `deleteFile` argument; for now, failing to provide one will result in a warning message, and the file will be deleted if it appears to be within the `tempdir()`. ([#2881](https://github.com/rstudio/shiny/pull/2881))
 
 ### New features
 

--- a/R/shinywrappers.R
+++ b/R/shinywrappers.R
@@ -293,7 +293,7 @@ renderImage <- function(expr, env=parent.frame(), quoted=FALSE,
 
       # jcheng 2020-05-08
       #
-      # Until Shiny 1.4.1, the default for deleteFile was, incredibly, TRUE.
+      # Until Shiny 1.5.0, the default for deleteFile was, incredibly, TRUE.
       # Changing it to default to FALSE might cause existing Shiny apps to pile
       # up images in their temp directory (for long lived R processes). Not
       # having a default (requiring explicit value) is the right long-term move,
@@ -308,9 +308,9 @@ renderImage <- function(expr, env=parent.frame(), quoted=FALSE,
           warned <<- TRUE
           warning("The renderImage output named '",
             getCurrentOutputInfo()$name,
-            "' is missing the deleteFile argument; please provide TRUE or ",
-            "FALSE. (This warning will become an error in a future version of ",
-            "Shiny.)",
+            "' is missing the deleteFile argument; as of Shiny 1.5.0, you must ",
+            "use deleteFile=TRUE or deleteFile=FALSE. (This warning will ",
+            "become an error in a future version of Shiny.)",
             call. = FALSE
           )
         }
@@ -339,9 +339,7 @@ isTempFile <- function(path, tempDir = tempdir(), default = FALSE) {
     return(default)
   }
   tempDir <- normalizePath(tempDir, winslash = "/", mustWork = FALSE)
-  if (substr(tempDir, nchar(tempDir), nchar(tempDir)) != .Platform$file.sep) {
-    tempDir <- paste0(tempDir, .Platform$file.sep)
-  }
+  tempDir <- ensure_trailing_slash(tempDir)
 
   path <- normalizePath(path, winslash = "/", mustWork = FALSE)
 

--- a/R/shinywrappers.R
+++ b/R/shinywrappers.R
@@ -198,7 +198,10 @@ markOutputAttrs <- function(renderFunc, snapshotExclude = NULL,
 #' @param deleteFile Should the file in `func()$src` be deleted after
 #'   it is sent to the client browser? Generally speaking, if the image is a
 #'   temp file generated within `func`, then this should be `TRUE`;
-#'   if the image is not a temp file, this should be `FALSE`.
+#'   if the image is not a temp file, this should be `FALSE`. (For backward
+#'   compatibility reasons, if this argument is missing, a warning will be
+#'   emitted, and if the file is in the temp directory it will be deleted. In
+#'   the future, this warning will become an error.)
 #' @param outputArgs A list of arguments to be passed through to the implicit
 #'   call to [imageOutput()] when `renderImage` is used in an
 #'   interactive R Markdown document.
@@ -271,15 +274,50 @@ markOutputAttrs <- function(renderFunc, snapshotExclude = NULL,
 #' shinyApp(ui, server)
 #' }
 renderImage <- function(expr, env=parent.frame(), quoted=FALSE,
-                        deleteFile=TRUE, outputArgs=list()) {
+                        deleteFile, outputArgs=list()) {
   installExprFunction(expr, "func", env, quoted)
+
+  # missing() must be used directly within the function with the given arg
+  if (missing(deleteFile)) {
+    deleteFile <- NULL
+  }
+
+  # Tracks whether we've reported the `deleteFile` warning yet; we don't want to
+  # do it on every invalidation (though we will end up doing it at least once
+  # per output per session).
+  warned <- FALSE
 
   createRenderFunction(func,
     transform = function(imageinfo, session, name, ...) {
-      # Should the file be deleted after being sent? If .deleteFile not set or if
-      # TRUE, then delete; otherwise don't delete.
-      if (deleteFile) {
-        on.exit(unlink(imageinfo$src))
+      shouldDelete <- deleteFile
+
+      # jcheng 2020-05-08
+      #
+      # Until Shiny 1.4.1, the default for deleteFile was, incredibly, TRUE.
+      # Changing it to default to FALSE might cause existing Shiny apps to pile
+      # up images in their temp directory (for long lived R processes). Not
+      # having a default (requiring explicit value) is the right long-term move,
+      # but would break today's apps.
+      #
+      # Compromise we decided on was to eventually require TRUE/FALSE, but for
+      # now, change the default behavior to only delete temp files; and emit a
+      # warning encouraging people to not rely on the default.
+      if (is.null(shouldDelete)) {
+        shouldDelete <- isTempFile(imageinfo$src)
+        if (!warned) {
+          warned <<- TRUE
+          warning("The renderImage output named '",
+            getCurrentOutputInfo()$name,
+            "' is missing the deleteFile argument; please provide TRUE or ",
+            "FALSE. (This warning will become an error in a future version of ",
+            "Shiny.)",
+            call. = FALSE
+          )
+        }
+      }
+
+      if (shouldDelete) {
+        on.exit(unlink(imageinfo$src), add = TRUE)
       }
 
       # If contentType not specified, autodetect based on extension
@@ -295,6 +333,20 @@ renderImage <- function(expr, env=parent.frame(), quoted=FALSE,
     imageOutput, outputArgs)
 }
 
+isTempFile <- function(path, tempDir = tempdir(), default = FALSE) {
+  if (nchar(tempDir) == 0) {
+    # This should never happen, but just to be super paranoid...
+    return(default)
+  }
+  tempDir <- normalizePath(tempDir, winslash = "/", mustWork = FALSE)
+  if (substr(tempDir, nchar(tempDir), nchar(tempDir)) != .Platform$file.sep) {
+    tempDir <- paste0(tempDir, .Platform$file.sep)
+  }
+
+  path <- normalizePath(path, winslash = "/", mustWork = FALSE)
+
+  return(substr(path, 1, nchar(tempDir)) == tempDir)
+}
 
 #' Printable Output
 #'

--- a/man/renderImage.Rd
+++ b/man/renderImage.Rd
@@ -8,7 +8,7 @@ renderImage(
   expr,
   env = parent.frame(),
   quoted = FALSE,
-  deleteFile = TRUE,
+  deleteFile,
   outputArgs = list()
 )
 }
@@ -23,7 +23,10 @@ is useful if you want to save an expression in a variable.}
 \item{deleteFile}{Should the file in \code{func()$src} be deleted after
 it is sent to the client browser? Generally speaking, if the image is a
 temp file generated within \code{func}, then this should be \code{TRUE};
-if the image is not a temp file, this should be \code{FALSE}.}
+if the image is not a temp file, this should be \code{FALSE}. (For backward
+compatibility reasons, if this argument is missing, a warning will be
+emitted, and if the file is in the temp directory it will be deleted. In
+the future, this warning will become an error.)}
 
 \item{outputArgs}{A list of arguments to be passed through to the implicit
 call to \code{\link[=imageOutput]{imageOutput()}} when \code{renderImage} is used in an

--- a/tests/testthat/test-shinywrappers.R
+++ b/tests/testthat/test-shinywrappers.R
@@ -1,0 +1,27 @@
+context("shinywrappers")
+
+test_that("isTempFile passes sanity checks", {
+  expect_true(isTempFile(tempfile()))
+  expect_false(isTempFile(path.expand("~")))
+  expect_false(isTempFile("."))
+
+  # Malformed temp dir isn't a problem
+  expect_false(isTempFile(path.expand("~"), tempDir = ""))
+
+  # Tolerant of trailing slashes
+  expect_true(isTempFile("/foo/bar", tempDir = "/foo"))
+  expect_true(isTempFile("/foo/bar", tempDir = "/foo/"))
+
+  expect_false(isTempFile("/foo/bar", tempDir = "/foo/bar"))
+
+  # Short filenames are OK
+  expect_false(isTempFile("/foo", tempDir = "/foo/bar"))
+
+  # path normalization
+  expect_true(isTempFile(".", tempDir = normalizePath("..")))
+  expect_true(isTempFile(normalizePath("."), tempDir = ".."))
+  expect_true(isTempFile(".", tempDir = ".."))
+
+  # not based on simple string matching
+  expect_false(isTempFile("/foo/barbaz", tempDir = "/foo/bar"))
+})


### PR DESCRIPTION
## Testing notes

```r
library(shiny)

ui <- fluidPage(
  imageOutput("img")
)

server <- function(input, output, session) {
  output$img <- renderImage({
    list(src = "~/Desktop/image.png")
  })
}

shinyApp(ui, server)
```

In previous versions of Shiny, running this app would cause `~/Desktop/image.png` to be deleted (!!).

With this change, instead, the file will not be deleted; but you will get a warning asking that an explicit `deleteFile` argument be passed.

If however, you replace `src` with a file path that's under `tempdir()`, then the file WILL be deleted (you'll still get a warning).

If you pass `deleteFile=TRUE`/`FALSE` then it should do that, regardless of where the file lives, and no warning should be emitted.