### PR TITLE
Set plot brush programmatically

### DIFF
--- a/R/mock-session.R
+++ b/R/mock-session.R
@@ -334,6 +334,13 @@ MockShinySession <- R6Class(
     reload = function() {},
     #' @description No-op
     #' @param brushId Not used
+    #' @param coords Not used
+    #' @param panel Not used
+    setBrush = function(brushId, coords, panel = 1) {
+      warning("session$brush isn't meaningfully mocked on the MockShinySession")
+    },
+    #' @description No-op
+    #' @param brushId Not used
     resetBrush = function(brushId) {
       warning("session$brush isn't meaningfully mocked on the MockShinySession")
     },

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -1663,6 +1663,15 @@ ShinySession <- R6Class(
       private$sendMessage(updateQueryString = list(
         queryString = queryString, mode = mode))
     },
+    setBrush = function(brushId, coords, panel = 1) {
+      private$sendMessage(
+        setBrush = list(
+          brushId = brushId,
+          coords = coords,
+          panel = panel
+        )
+      )
+    },
     resetBrush = function(brushId) {
       private$sendMessage(
         resetBrush = list(

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -205,6 +205,13 @@ workerId <- local({
 #'   An environment for app authors and module/package authors to store whatever
 #'   session-specific data they want.
 #' }
+#' \item{setBrush(brushId, coords, panel=1)}{
+#'   Sets the brush with the given `brushId`, if it exists on
+#'   any `imageOutput` or `plotOutput` in the app. The `coords` should be a
+#'   list with `xmin`, `xmax`, `ymin`, `ymax` single-element numerics that
+#'   specify the desired brush position (in the plot scale). `panel` should
+#'   be a single-element integer that defines the panel that should be brushed.
+#' }
 #' \item{resetBrush(brushId)}{
 #'   Resets/clears the brush with the given `brushId`, if it exists on
 #'   any `imageOutput` or `plotOutput` in the app.
@@ -1664,6 +1671,9 @@ ShinySession <- R6Class(
         queryString = queryString, mode = mode))
     },
     setBrush = function(brushId, coords, panel = 1) {
+      if (!all(c("xmin", "xmax", "ymin", "ymax") %in% names(coords))){
+        stop("coords must have xmin, xmax, ymin and ymax fields")
+      }
       private$sendMessage(
         setBrush = list(
           brushId = brushId,

--- a/srcjs/output_binding_image.js
+++ b/srcjs/output_binding_image.js
@@ -872,26 +872,30 @@ imageutils.createBrushHandler = function(inputId, $el, opts, coordmap, outputId)
     brushInfoSender = new Debouncer(null, sendBrushInfo, opts.brushDelay);
   }
 
+  // event to set brush programmatically
   $el.on("shiny-internal:setbrush.image_output", function(e, payload) {
     if (payload.brushId === inputId){
       var panel = coordmap.panels[payload.panel];
-      var imgCoords = panel.scaleDataToImg({
-        xmin: payload.coords.xmin,
-        xmax: payload.coords.xmax,
-        ymin: payload.coords.ymin,
-        ymax: payload.coords.ymax
-      });
 
-      var cssCoords = coordmap.scaleImgToCss(imgCoords);
+      if (panel){
+        var imgCoords = panel.scaleDataToImg({
+          xmin: payload.coords.xmin,
+          xmax: payload.coords.xmax,
+          ymin: payload.coords.ymin,
+          ymax: payload.coords.ymax
+        });
 
-      brush.reset();
-      brush.down({x: cssCoords.xmin, y: cssCoords.ymin}); // click at start
-      brush.startBrushing();
-      brush.brushTo({x: cssCoords.xmax, y: cssCoords.ymax}); // go to end
-      brush.up({x: cssCoords.xmax, y: cssCoords.ymax});  // mouseup
-      brush.stopBrushing();
+        var cssCoords = coordmap.scaleImgToCss(imgCoords);
 
-      brushInfoSender.immediateCall(); // push to backend
+        brush.reset();
+        brush.down({x: cssCoords.xmin, y: cssCoords.ymin});
+        brush.startBrushing();
+        brush.brushTo({x: cssCoords.xmax, y: cssCoords.ymax});
+        brush.up({x: cssCoords.xmax, y: cssCoords.ymax});
+        brush.stopBrushing();
+
+        brushInfoSender.immediateCall(); // push info to the backend
+      }
     }
   });
 

--- a/srcjs/shinyapp.js
+++ b/srcjs/shinyapp.js
@@ -1031,6 +1031,10 @@ var ShinyApp = function() {
     if (what === "hash") $(document).trigger("hashchange");
   });
 
+
+  addMessageHandler("setBrush", function (message) {
+    exports.setBrush(message.brushId, message.coords, message.panel - 1);
+  });
   addMessageHandler("resetBrush", function(message) {
     exports.resetBrush(message.brushId);
   });

--- a/tests/testthat/test-mock-session.R
+++ b/tests/testthat/test-mock-session.R
@@ -218,6 +218,11 @@ test_that("session supports userData", {
   expect_equal(session$userData$x, 123)
 })
 
+test_that("session supports setBrush", {
+  session <- MockShinySession$new()
+  expect_warning(session$setBrush(1), "isn't meaningfully mocked")
+})
+
 test_that("session supports resetBrush", {
   session <- MockShinySession$new()
   expect_warning(session$resetBrush(1), "isn't meaningfully mocked")


### PR DESCRIPTION
This PR allows to set a plot brush programmatically. It resolves #1456. 

It is possible to set the brush from the backend using:
```
session$setBrush(
  brushId = "plot_brush", 
  coords = list(xmin=1, xmax=3, ymin=2, ymax=4), # domain scale
  panel = 1
)
```
or from JS:
```
Shiny.setBrush('plot_brush', {xmin:1,xmax:3,ymin:2,ymax:4}, 0)
```

All unit tests are passing (1 skipped due to the direct skip in the test):
```
OK:       1125
Failed:   0
Warnings: 0
Skipped:  1
```

Please let me know if anything is missing or requires some changes.