### PR TITLE
Trying to reconnect when $socket is null in ShinyApp.$sendMsg

### DIFF
--- a/srcjs/shinyapp.js
+++ b/srcjs/shinyapp.js
@@ -282,6 +282,9 @@ var ShinyApp = function() {
   };
 
   this.$sendMsg = function(msg) {
+    if (!this.$socket) {
+      this.reconnect();
+    }
     if (!this.$socket.readyState) {
       this.$pendingMessages.push(msg);
     }


### PR DESCRIPTION
I ran into this error below from time to time.

Uncaught TypeError: Cannot read property 'readyState' of null
    at ShinyApp.$sendMsg (shinyapp.js:288)
    at ShinyApp.sendInput (shinyapp.js:140)
    at InputBatchSender.$sendNow (input_rate.js:220)

Maybe in this method, we could check for $socket first, if it null then we try to reconnect.

![2020-06-01 23_50_38-Window](https://user-images.githubusercontent.com/3866678/83489083-c067cd80-a462-11ea-87c5-8cc2dd3cc592.png)
This error cause the shiny application to have a grey overlay and no error message show. This cause some user doesn't know what to do with that error.

Thank you.