### PR TITLE
Fix broken option comparison

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -177,6 +177,6 @@ Collate:
     'test-server.R'
     'test.R'
     'update-input.R'
-RoxygenNote: 7.1.0.9000
+RoxygenNote: 7.1.1
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+* `MockShinySession` warns about methods that are currently unimplemented.
+  This means that `testServer()` will now warn if it evaluates functions
+  (like `updateTextInput()` and friends) that require javascript (#2947).
+  You can suppress these messages by setting
+  `options(shiny.mocksession.warn = FALSE)`
+
 shiny 1.5.0
 ===========
 

--- a/man/MockShinySession.Rd
+++ b/man/MockShinySession.Rd
@@ -111,6 +111,10 @@ user. Always \code{NULL} for a \code{MockShinySesion}.}
 \item \href{#method-onSessionEnded}{\code{MockShinySession$onSessionEnded()}}
 \item \href{#method-registerDownload}{\code{MockShinySession$registerDownload()}}
 \item \href{#method-getCurrentOutputInfo}{\code{MockShinySession$getCurrentOutputInfo()}}
+\item \href{#method-reactlog}{\code{MockShinySession$reactlog()}}
+\item \href{#method-registerDataObj}{\code{MockShinySession$registerDataObj()}}
+\item \href{#method-incrementBusyCount}{\code{MockShinySession$incrementBusyCount()}}
+\item \href{#method-decrementBusyCount}{\code{MockShinySession$decrementBusyCount()}}
 \item \href{#method-clone}{\code{MockShinySession$clone()}}
 }
 }
@@ -610,6 +614,42 @@ A list with with the \code{name} of the output. If no output is
 currently being executed, this will return \code{NULL}.
 output, or \code{NULL} if no output is currently executing.
 }
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-reactlog"></a>}}
+\if{latex}{\out{\hypertarget{method-reactlog}{}}}
+\subsection{Method \code{reactlog()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{MockShinySession$reactlog(...)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-registerDataObj"></a>}}
+\if{latex}{\out{\hypertarget{method-registerDataObj}{}}}
+\subsection{Method \code{registerDataObj()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{MockShinySession$registerDataObj(...)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-incrementBusyCount"></a>}}
+\if{latex}{\out{\hypertarget{method-incrementBusyCount}{}}}
+\subsection{Method \code{incrementBusyCount()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{MockShinySession$incrementBusyCount(...)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-decrementBusyCount"></a>}}
+\if{latex}{\out{\hypertarget{method-decrementBusyCount}{}}}
+\subsection{Method \code{decrementBusyCount()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{MockShinySession$decrementBusyCount(...)}\if{html}{\out{</div>}}
+}
+
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-clone"></a>}}

--- a/man/testServer.Rd
+++ b/man/testServer.Rd
@@ -23,7 +23,7 @@ along with any other values created inside of the server function.}
 a module, and no \code{id} argument is provided, one will be generated and
 supplied automatically.}
 
-\item{session}{The \code{\link{MockShinySession}} object to use as the \link[shiny:domains]{reactive domain}. The same session object is used as the domain both
+\item{session}{The \code{\link{MockShinySession}} object to use as the \link[=domains]{reactive domain}. The same session object is used as the domain both
 during invocation of the server or module under test and during evaluation
 of \code{expr}.}
 }

--- a/tests/testthat/test-mock-session.R
+++ b/tests/testthat/test-mock-session.R
@@ -163,12 +163,6 @@ test_that("renderUI supported", {
   })
 })
 
-test_that("session supports allowReconnect", {
-  session <- MockShinySession$new()
-  session$allowReconnect(TRUE)
-  expect_true(TRUE) # testthat insists that every test must have an expectation
-})
-
 test_that("session supports clientData", {
   session <- MockShinySession$new()
   expect_equal(session$clientData$allowDataUriScheme, TRUE)
@@ -192,12 +186,6 @@ test_that("session supports ns", {
   expect_equal(session$ns("hi"), "mock-session-hi")
 })
 
-test_that("session supports reload", {
-  session <- MockShinySession$new()
-  session$reload()
-  expect_true(TRUE) # testthat insists that every test must have an expectation
-})
-
 test_that("session supports close", {
   session <- MockShinySession$new()
   session$close()
@@ -218,89 +206,31 @@ test_that("session supports userData", {
   expect_equal(session$userData$x, 123)
 })
 
-test_that("session supports resetBrush", {
-  session <- MockShinySession$new()
-  withr::with_options(list("shiny.mocksession.warn" = TRUE), {
-    expect_warning(session$resetBrush(1))
-  })
-})
-
 test_that("generated methods signal unused argument errors", {
   expect_error(session$resetBrush(1,2,3))
   expect_error(session$resetBrush(1,2))
 })
 
-test_that("session supports sendCustomMessage", {
+test_that("session mocks important unsupported methods with warning", {
   session <- MockShinySession$new()
-  session$sendCustomMessage(type=1, message=2)
-  expect_true(TRUE) # testthat insists that every test must have an expectation
-})
 
-test_that("session supports sendBinaryMessage", {
-  session <- MockShinySession$new()
-  session$sendBinaryMessage(type=1, message=2)
-  expect_true(TRUE) # testthat insists that every test must have an expectation
-})
+  expect_warning(session$reload(), "MockShinySession")
+  expect_warning(session$allowReconnect(TRUE), "MockShinySession")
+  expect_warning(session$resetBrush(1), "MockShinySession")
 
-test_that("session supports sendInputMessage", {
-  session <- MockShinySession$new()
-  session$sendInputMessage(inputId=1, message=2)
-  expect_true(TRUE) # testthat insists that every test must have an expectation
-})
+  expect_warning(session$sendCustomMessage(type=1, message=2), "MockShinySession")
+  expect_warning(session$sendBinaryMessage(type=1, message=2), "MockShinySession")
+  expect_warning(session$sendInputMessage(inputId=1, message=2), "MockShinySession")
 
-test_that("session supports setBookmarkExclude", {
-  session <- MockShinySession$new()
-  withr::with_options(list("shiny.mocksession.warn" = TRUE), {
-    expect_warning(session$setBookmarkExclude(names=1))
-  })
-})
+  expect_warning(session$setBookmarkExclude(names=1), "MockShinySession")
+  expect_warning(session$getBookmarkExclude(), "MockShinySession")
+  expect_warning(session$doBookmark(), "MockShinySession")
 
-test_that("session supports getBookmarkExclude", {
-  session <- MockShinySession$new()
-  withr::with_options(list("shiny.mocksession.warn" = TRUE), {
-    expect_warning(session$getBookmarkExclude())
-  })
-})
+  expect_warning(session$onBookmark(fun=1), "MockShinySession")
+  expect_warning(session$onBookmarked(fun=1), "MockShinySession")
+  expect_warning(session$onRestore(fun=1), "MockShinySession")
+  expect_warning(session$onRestored(fun=1), "MockShinySession")
 
-test_that("session supports onBookmark", {
-  session <- MockShinySession$new()
-  session$onBookmark(fun=1)
-  expect_true(TRUE) # testthat insists that every test must have an expectation
-})
-
-test_that("session supports onBookmarked", {
-  session <- MockShinySession$new()
-  session$onBookmarked(fun=1)
-  expect_true(TRUE) # testthat insists that every test must have an expectation
-})
-
-test_that("session supports doBookmark", {
-  session <- MockShinySession$new()
-  withr::with_options(list("shiny.mocksession.warn" = TRUE), {
-    expect_warning(session$doBookmark())
-  })
-})
-
-test_that("session supports onRestore", {
-  session <- MockShinySession$new()
-  session$onRestore(fun=1)
-  expect_true(TRUE) # testthat insists that every test must have an expectation
-})
-
-test_that("session supports onRestored", {
-  session <- MockShinySession$new()
-  session$onRestored(fun=1)
-  expect_true(TRUE) # testthat insists that every test must have an expectation
-})
-
-test_that("session supports exportTestValues", {
-  session <- MockShinySession$new()
-  session$exportTestValues()
-  expect_true(TRUE) # testthat insists that every test must have an expectation
-})
-
-test_that("session supports getTestSnapshotUrl", {
-  session <- MockShinySession$new()
-  session$getTestSnapshotUrl(input=1, output=1, export=1, format=1)
-  expect_true(TRUE) # testthat insists that every test must have an expectation
+  expect_warning(session$exportTestValues(), "MockShinySession")
+  expect_warning(session$getTestSnapshotUrl(input=1, output=1, export=1, format=1), "MockShinySession")
 })


### PR DESCRIPTION
And silently ignore unimportant messages. Fixes #2947

I silenced the messages that the tests appeared to expect to be silent, then checked that `testServer()` was silent for a few simple examples. It seems likely that I've missed some methods, but this seems like a reasonable place to start.