### PR TITLE
Remove context() calls from example app

### DIFF
--- a/inst/app_template/tests/testthat/test-examplemodule.R
+++ b/inst/app_template/tests/testthat/test-examplemodule.R
@@ -1,5 +1,3 @@
-context("exampleModuleServer")
-
 # See ?testServer for more information
 testServer(exampleModuleServer, {
   # Set initial value of a button

--- a/inst/app_template/tests/testthat/test-server.R
+++ b/inst/app_template/tests/testthat/test-server.R
@@ -1,5 +1,3 @@
-context("app")
-
 testServer(expr = {
   # Set the `size` slider and check the output
   session$setInputs(size = 6)

--- a/inst/app_template/tests/testthat/test-sort.R
+++ b/inst/app_template/tests/testthat/test-sort.R
@@ -1,6 +1,4 @@
 # Test the lexical_sort function from R/example.R
-context("sort")
-
 test_that("Lexical sorting works", {
   expect_equal(lexical_sort(c(1, 2, 3)), c(1, 2, 3))
   expect_equal(lexical_sort(c(1, 2, 3, 13, 11, 21)), c(1, 11, 13, 2, 21, 3))


### PR DESCRIPTION
`context()` is no longer recommended by the testthat package, so this PR removes it from the app template.