### PR TITLE
Tweaked updateIonRangeSlider.R

### DIFF
--- a/tools/updateIonRangeSlider.R
+++ b/tools/updateIonRangeSlider.R
@@ -46,9 +46,6 @@ file.copy(file.path(unzip_dir, "img"), dest_dir, recursive = TRUE)
 
 patch_dir <- rprojroot::find_package_root_file("tools/ion.rangeSlider-patches")
 
-# Need to apply patch in the package root
-setwd(rprojroot::find_package_root_file())
-
 for (patch in list.files(patch_dir, full.names = TRUE)) {
   tryCatch({
     message(sprintf("Applying %s", basename(patch)))

--- a/tools/updateIonRangeSlider.R
+++ b/tools/updateIonRangeSlider.R
@@ -58,4 +58,4 @@ for (patch in list.files(patch_dir, full.names = TRUE)) {
 }
 # =============================================================================
 # Generate minified js
-system("yarn build")
+withr::with_dir(rprojroot::find_package_root_file("tools"), system("yarn build"))

--- a/tools/updateIonRangeSlider.R
+++ b/tools/updateIonRangeSlider.R
@@ -49,7 +49,7 @@ patch_dir <- rprojroot::find_package_root_file("tools/ion.rangeSlider-patches")
 for (patch in list.files(patch_dir, full.names = TRUE)) {
   tryCatch({
     message(sprintf("Applying %s", basename(patch)))
-    system(sprintf("git apply %s", patch))
+    withr::with_dir(rprojroot::find_package_root_file(), system(sprintf("git apply %s", patch)))
   },
     error = function(e) {
       quit(save = "no", status = 1)

--- a/tools/updateIonRangeSlider.R
+++ b/tools/updateIonRangeSlider.R
@@ -46,13 +46,23 @@ file.copy(file.path(unzip_dir, "img"), dest_dir, recursive = TRUE)
 
 patch_dir <- rprojroot::find_package_root_file("tools/ion.rangeSlider-patches")
 
+# Need to apply patch in the package root
+setwd(rprojroot::find_package_root_file())
+
 for (patch in list.files(patch_dir, full.names = TRUE)) {
   tryCatch({
     message(sprintf("Applying %s", basename(patch)))
-    system(sprintf("git apply '%s'", patch))
+    system(sprintf("git apply %s", patch))
   },
     error = function(e) {
       quit(save = "no", status = 1)
     }
   )
 }
+
+# Reset to tools directory to do yarn command
+setwd(rprojroot::find_package_root_file("tools"))
+
+# =============================================================================
+# Generate minified js
+system("yarn build")

--- a/tools/updateIonRangeSlider.R
+++ b/tools/updateIonRangeSlider.R
@@ -56,10 +56,6 @@ for (patch in list.files(patch_dir, full.names = TRUE)) {
     }
   )
 }
-
-# Reset to tools directory to do yarn command
-setwd(rprojroot::find_package_root_file("tools"))
-
 # =============================================================================
 # Generate minified js
 system("yarn build")


### PR DESCRIPTION
I see few issues [in this `git apply` command](https://github.com/rstudio/shiny/blob/master/tools/updateIonRangeSlider.R#L52).

1. Don't we have to execute it in the package root directory?
1. `system(sprintf("git apply '%s'", patch))`: I think we need to replace `'%s'` with `%s` (without apostrophies). Otherwise, it will be throwing an error (tested on Windows).
1. We need to include `yarn build` to generate min.js
