### PR TITLE
Used withr for applying datepicker patches

### DIFF
--- a/tools/applyDatepickerPatches.R
+++ b/tools/applyDatepickerPatches.R
@@ -8,11 +8,15 @@ patch_dir <- rprojroot::find_package_root_file("tools/datepicker-patches")
 
 for (patch in list.files(patch_dir, full.names = TRUE)) {
   tryCatch({
-      message(sprintf("Applying %s", basename(patch)))
-      system(sprintf("git apply '%s'", patch))
-    },
+    message(sprintf("Applying %s", basename(patch)))
+    withr::with_dir(rprojroot::find_package_root_file(), system(sprintf("git apply %s", patch)))
+  },
     error = function(e) {
       quit(save = "no", status = 1)
     }
   )
 }
+
+# =============================================================================
+# Generate minified js
+withr::with_dir(rprojroot::find_package_root_file("tools"), system("yarn grunt"))


### PR DESCRIPTION
Similar to #2995.

One discussion point is whether we want to have a separate script file for applying patches. IonRangeSlider, for example, does include both downloading and applying scripts within a single file.