### PR TITLE
Added alt param

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 shiny 1.5.0.9000
 ================
 
+## Full changelog
+
 ### Accessibility
 
 * Added [bootstrap accessibility plugin](https://github.com/paypal/bootstrap-accessibility-plugin) under the hood to improve accessibility of shiny apps for screen-reader and keyboard users: the enhancements include better navigations for alert, tooltip, popover, modal dialog, dropdown, tab Panel, collapse, and carousel elements. (#2911)
@@ -13,6 +15,8 @@ shiny 1.5.0.9000
 * Fixed #2951: screen readers correctly announce labels and date formats for `dateInput()` and `dateRangeInput()` widgets. (#2978)
 
 * Closed #2847: `selectInput()` is reasonably accessible for screen readers even when `selectize` option is set to TRUE. To improve `selectize.js` accessibility, We have added [selectize-plugin-a11y](https://github.com/SLMNBJ/selectize-plugin-a11y) by default. (#2993)
+
+* Closed #612: Added `alt` argument to `renderPlot()` and `renderCachedPlot()` to specify descriptive texts for `plotOutput()` objects, which is essential for screen readers. By default, alt text is set to the static text, "Plot object," but even dynamic text can be made with reactive function. (#3006, thanks @trafficonese and @leonawicz for the original PR and discussion via #2494)
 
 ### Minor new features and improvements
 

--- a/R/render-cached-plot.R
+++ b/R/render-cached-plot.R
@@ -446,6 +446,7 @@ renderCachedPlot <- function(expr,
       function(userCacheKeyResult) {
         width  <- fitDims$width
         height <- fitDims$height
+        alt <- altWrapper()
         pixelratio <- session$clientData$pixelratio %OR% 1
 
         key <- digest::digest(list(outputName, userCacheKeyResult, width, height, res, pixelratio), "xxhash64")
@@ -461,6 +462,7 @@ renderCachedPlot <- function(expr,
             plotObj = plotObj,
             width = width,
             height = height,
+            alt = alt,
             pixelratio = pixelratio
           ))
         }

--- a/R/render-cached-plot.R
+++ b/R/render-cached-plot.R
@@ -150,7 +150,9 @@
 #'   `"app"` (the default), `"session"`, or a cache object like
 #'   a [diskCache()]. See the Cache Scoping section for more
 #'   information.
-#' @param alt Optional parameter to pass `alt` to the img-tag.
+#' @param alt Descriptive text for a plot object. The default is "Plot object".
+#'   Dynamic alt text can be made when reactive function is passed.
+#'   (NULL or "" is not recommended because those should be limited to decorative images)
 #'
 #' @seealso See [renderPlot()] for the regular, non-cached version of
 #'   this function. For more about configuring caches, see

--- a/R/render-cached-plot.R
+++ b/R/render-cached-plot.R
@@ -343,6 +343,14 @@ renderCachedPlot <- function(expr,
   # values get filled by an observer below.
   fitDims <- reactiveValues(width = NULL, height = NULL)
 
+  # Make sure alt param to be reactive function
+  if (is.reactive(alt))
+    altWrapper <- alt
+  else if (is.function(alt))
+    altWrapper <- reactive({ alt() })
+  else
+    altWrapper <- function() { alt }
+
   resizeObserver <- NULL
   ensureResizeObserver <- function() {
     if (!is.null(resizeObserver))
@@ -389,6 +397,8 @@ renderCachedPlot <- function(expr,
         isolate({
           width  <- fitDims$width
           height <- fitDims$height
+          # Make sure alt text to be reactive function
+          alt <- altWrapper() 
         })
 
         pixelratio <- session$clientData$pixelratio %OR% 1
@@ -400,7 +410,6 @@ renderCachedPlot <- function(expr,
             func = isolatedFunc,
             width = width,
             height = height,
-#jy: default to title when NULL
             alt = alt,
             pixelratio = pixelratio,
             res = res
@@ -475,7 +484,6 @@ renderCachedPlot <- function(expr,
               plotObj = drawReactiveResult,
               width = width,
               height = height,
-#jy: default to title when NULL
               alt = alt,
               pixelratio = pixelratio
             )
@@ -486,6 +494,7 @@ renderCachedPlot <- function(expr,
         hybrid_chain(possiblyAsyncResult, function(result) {
           width      <- result$width
           height     <- result$height
+          alt     <- result$alt
           pixelratio <- result$pixelratio
 
           # Three possibilities when we get here:

--- a/R/render-cached-plot.R
+++ b/R/render-cached-plot.R
@@ -476,7 +476,7 @@ renderCachedPlot <- function(expr,
               width = width,
               height = height,
 #jy: default to title when NULL
-            alt = alt,
+              alt = alt,
               pixelratio = pixelratio
             )
           }

--- a/R/render-cached-plot.R
+++ b/R/render-cached-plot.R
@@ -150,9 +150,6 @@
 #'   `"app"` (the default), `"session"`, or a cache object like
 #'   a [diskCache()]. See the Cache Scoping section for more
 #'   information.
-#' @param alt Descriptive text for a plot object. The default is "Plot object".
-#'   Dynamic alt text can be made when reactive function is passed.
-#'   (NULL or "" is not recommended because those should be limited to decorative images)
 #'
 #' @seealso See [renderPlot()] for the regular, non-cached version of
 #'   this function. For more about configuring caches, see

--- a/R/render-cached-plot.R
+++ b/R/render-cached-plot.R
@@ -493,7 +493,7 @@ renderCachedPlot <- function(expr,
         hybrid_chain(possiblyAsyncResult, function(result) {
           width      <- result$width
           height     <- result$height
-          alt     <- result$alt
+          alt        <- result$alt
           pixelratio <- result$pixelratio
 
           # Three possibilities when we get here:

--- a/R/render-cached-plot.R
+++ b/R/render-cached-plot.R
@@ -150,6 +150,7 @@
 #'   `"app"` (the default), `"session"`, or a cache object like
 #'   a [diskCache()]. See the Cache Scoping section for more
 #'   information.
+#' @param alt Optional parameter to pass `alt` to the img-tag.
 #'
 #' @seealso See [renderPlot()] for the regular, non-cached version of
 #'   this function. For more about configuring caches, see
@@ -293,6 +294,7 @@ renderCachedPlot <- function(expr,
   cacheKeyExpr,
   sizePolicy = sizeGrowthRatio(width = 400, height = 400, growthRate = 1.2),
   res = 72,
+  alt = "Plot object",
   cache = "app",
   ...,
   outputArgs = list()
@@ -398,6 +400,8 @@ renderCachedPlot <- function(expr,
             func = isolatedFunc,
             width = width,
             height = height,
+#jy: default to title when NULL
+            alt = alt,
             pixelratio = pixelratio,
             res = res
           ),
@@ -471,6 +475,8 @@ renderCachedPlot <- function(expr,
               plotObj = drawReactiveResult,
               width = width,
               height = height,
+#jy: default to title when NULL
+            alt = alt,
               pixelratio = pixelratio
             )
           }
@@ -500,6 +506,7 @@ renderCachedPlot <- function(expr,
                 result$plotObj,
                 width,
                 height,
+                alt,
                 pixelratio,
                 res
               ),

--- a/R/render-plot.R
+++ b/R/render-plot.R
@@ -113,7 +113,7 @@ renderPlot <- function(expr, width='auto', height='auto', res=72, alt="Plot obje
             func = func,
             width = dims$width,
             height = dims$height,
-            alt = alt,
+            alt = altWrapper(),
             pixelratio = pixelratio,
             res = res
           ), args))

--- a/R/render-plot.R
+++ b/R/render-plot.R
@@ -36,6 +36,7 @@
 #' @param res Resolution of resulting plot, in pixels per inch. This value is
 #'   passed to [grDevices::png()]. Note that this affects the resolution of PNG
 #'   rendering in R; it won't change the actual ppi of the browser.
+#' @param alt Optional parameter to pass `alt` to the img-tag.
 #' @param ... Arguments to be passed through to [grDevices::png()].
 #'   These can be used to set the width, height, background color, etc.
 #' @param env The environment in which to evaluate `expr`.
@@ -51,7 +52,7 @@
 #'   call to [plotOutput()] when `renderPlot` is used in an
 #'   interactive R Markdown document.
 #' @export
-renderPlot <- function(expr, width='auto', height='auto', res=72, ...,
+renderPlot <- function(expr, width='auto', height='auto', res=72, alt="Plot object", ...,
                        env=parent.frame(), quoted=FALSE,
                        execOnResize=FALSE, outputArgs=list()
 ) {
@@ -112,6 +113,7 @@ renderPlot <- function(expr, width='auto', height='auto', res=72, ...,
             func = func,
             width = dims$width,
             height = dims$height,
+            alt = alt,
             pixelratio = pixelratio,
             res = res
           ), args))
@@ -140,7 +142,7 @@ renderPlot <- function(expr, width='auto', height='auto', res=72, ...,
         dims <- getDims()
         pixelratio <- session$clientData$pixelratio %OR% 1
         result <- do.call("resizeSavedPlot", c(
-          list(name, shinysession, result, dims$width, dims$height, pixelratio, res),
+          list(name, shinysession, result, dims$width, dims$height, alt, pixelratio, res),
           args
         ))
 
@@ -159,7 +161,7 @@ renderPlot <- function(expr, width='auto', height='auto', res=72, ...,
   markRenderFunction(outputFunc, renderFunc, outputArgs = outputArgs)
 }
 
-resizeSavedPlot <- function(name, session, result, width, height, pixelratio, res, ...) {
+resizeSavedPlot <- function(name, session, result, width, height, alt, pixelratio, res, ...) {
   if (result$img$width == width && result$img$height == height &&
       result$pixelratio == pixelratio && result$res == res) {
     return(result)
@@ -181,6 +183,7 @@ resizeSavedPlot <- function(name, session, result, width, height, pixelratio, re
     src = session$fileUrl(name, outfile, contentType = "image/png"),
     width = width,
     height = height,
+    alt = alt,
     coordmap = coordmap,
     error = attr(coordmap, "error", exact = TRUE)
   )
@@ -188,7 +191,7 @@ resizeSavedPlot <- function(name, session, result, width, height, pixelratio, re
   result
 }
 
-drawPlot <- function(name, session, func, width, height, pixelratio, res, ...) {
+drawPlot <- function(name, session, func, width, height, alt, pixelratio, res, ...) {
   #  1. Start PNG
   #  2. Enable displaylist recording
   #  3. Call user-defined func
@@ -272,6 +275,7 @@ drawPlot <- function(name, session, func, width, height, pixelratio, res, ...) {
         src = session$fileUrl(name, outfile, contentType='image/png'),
         width = width,
         height = height,
+        alt = alt,
         coordmap = result$coordmap,
         # Get coordmap error message if present
         error = attr(result$coordmap, "error", exact = TRUE)

--- a/R/render-plot.R
+++ b/R/render-plot.R
@@ -36,7 +36,9 @@
 #' @param res Resolution of resulting plot, in pixels per inch. This value is
 #'   passed to [grDevices::png()]. Note that this affects the resolution of PNG
 #'   rendering in R; it won't change the actual ppi of the browser.
-#' @param alt Optional parameter to pass `alt` to the img-tag.
+#' @param alt Descriptive text for a plot object. The default is "Plot object".
+#'   Dynamic alt text can be made when reactive function is passed.
+#'   (NULL or "" is not recommended because those should be limited to decorative images)
 #' @param ... Arguments to be passed through to [grDevices::png()].
 #'   These can be used to set the width, height, background color, etc.
 #' @param env The environment in which to evaluate `expr`.

--- a/R/render-plot.R
+++ b/R/render-plot.R
@@ -36,9 +36,12 @@
 #' @param res Resolution of resulting plot, in pixels per inch. This value is
 #'   passed to [grDevices::png()]. Note that this affects the resolution of PNG
 #'   rendering in R; it won't change the actual ppi of the browser.
-#' @param alt Descriptive text for a plot object. The default is "Plot object".
-#'   Dynamic alt text can be made when reactive function is passed.
-#'   (NULL or "" is not recommended because those should be limited to decorative images)
+#' @param alt Alternate text for the HTML `<img>` tag
+#'   if it cannot be displayed or viewed (i.e., the user uses a screen reader).
+#'   In addition to a character string, the value may be a reactive expression 
+#'   (or a function referencing reactive values) that returns a character string.
+#'   NULL or "" is not recommended because those should be limited to decorative images
+#'   (the default is "Plot object").
 #' @param ... Arguments to be passed through to [grDevices::png()].
 #'   These can be used to set the width, height, background color, etc.
 #' @param env The environment in which to evaluate `expr`.

--- a/R/render-plot.R
+++ b/R/render-plot.R
@@ -142,7 +142,7 @@ renderPlot <- function(expr, width='auto', height='auto', res=72, alt="Plot obje
         dims <- getDims()
         pixelratio <- session$clientData$pixelratio %OR% 1
         result <- do.call("resizeSavedPlot", c(
-          list(name, shinysession, result, dims$width, dims$height, alt, pixelratio, res),
+          list(name, shinysession, result, dims$width, dims$height, altWrapper(), pixelratio, res),
           args
         ))
 

--- a/R/render-plot.R
+++ b/R/render-plot.R
@@ -76,6 +76,13 @@ renderPlot <- function(expr, width='auto', height='auto', res=72, alt="Plot obje
   else
     heightWrapper <- function() { height }
 
+  if (is.reactive(alt))
+    altWrapper <- alt
+  else if (is.function(alt))
+    altWrapper <- reactive({ alt() })
+  else
+    altWrapper <- function() { alt }
+
   getDims <- function() {
     width <- widthWrapper()
     height <- heightWrapper()

--- a/man/renderCachedPlot.Rd
+++ b/man/renderCachedPlot.Rd
@@ -31,9 +31,12 @@ information on the default sizing policy.}
 
 \item{res}{The resolution of the PNG, in pixels per inch.}
 
-\item{alt}{Descriptive text for a plot object. The default is "Plot object".
-Dynamic alt text can be made when reactive function is passed.
-(NULL or "" is not recommended because those should be limited to decorative images)}
+\item{alt}{Alternate text for the HTML \verb{<img>} tag
+if it cannot be displayed or viewed (i.e., the user uses a screen reader).
+In addition to a character string, the value may be a reactive expression
+(or a function referencing reactive values) that returns a character string.
+NULL or "" is not recommended because those should be limited to decorative images
+(the default is "Plot object").}
 
 \item{cache}{The scope of the cache, or a cache object. This can be
 \code{"app"} (the default), \code{"session"}, or a cache object like

--- a/man/renderCachedPlot.Rd
+++ b/man/renderCachedPlot.Rd
@@ -31,7 +31,9 @@ information on the default sizing policy.}
 
 \item{res}{The resolution of the PNG, in pixels per inch.}
 
-\item{alt}{Optional parameter to pass \code{alt} to the img-tag.}
+\item{alt}{Descriptive text for a plot object. The default is "Plot object".
+Dynamic alt text can be made when reactive function is passed.
+(NULL or "" is not recommended because those should be limited to decorative images)}
 
 \item{cache}{The scope of the cache, or a cache object. This can be
 \code{"app"} (the default), \code{"session"}, or a cache object like

--- a/man/renderCachedPlot.Rd
+++ b/man/renderCachedPlot.Rd
@@ -9,6 +9,7 @@ renderCachedPlot(
   cacheKeyExpr,
   sizePolicy = sizeGrowthRatio(width = 400, height = 400, growthRate = 1.2),
   res = 72,
+  alt = "Plot object",
   cache = "app",
   ...,
   outputArgs = list()
@@ -29,6 +30,8 @@ possible pixel dimension. See \code{\link[=sizeGrowthRatio]{sizeGrowthRatio()}} 
 information on the default sizing policy.}
 
 \item{res}{The resolution of the PNG, in pixels per inch.}
+
+\item{alt}{Optional parameter to pass \code{alt} to the img-tag.}
 
 \item{cache}{The scope of the cache, or a cache object. This can be
 \code{"app"} (the default), \code{"session"}, or a cache object like

--- a/man/renderPlot.Rd
+++ b/man/renderPlot.Rd
@@ -38,7 +38,9 @@ to both \code{width} and \code{height}.}
 passed to \code{\link[grDevices:png]{grDevices::png()}}. Note that this affects the resolution of PNG
 rendering in R; it won't change the actual ppi of the browser.}
 
-\item{alt}{Optional parameter to pass \code{alt} to the img-tag.}
+\item{alt}{Descriptive text for a plot object. The default is "Plot object".
+Dynamic alt text can be made when reactive function is passed.
+(NULL or "" is not recommended because those should be limited to decorative images)}
 
 \item{...}{Arguments to be passed through to \code{\link[grDevices:png]{grDevices::png()}}.
 These can be used to set the width, height, background color, etc.}

--- a/man/renderPlot.Rd
+++ b/man/renderPlot.Rd
@@ -38,9 +38,12 @@ to both \code{width} and \code{height}.}
 passed to \code{\link[grDevices:png]{grDevices::png()}}. Note that this affects the resolution of PNG
 rendering in R; it won't change the actual ppi of the browser.}
 
-\item{alt}{Descriptive text for a plot object. The default is "Plot object".
-Dynamic alt text can be made when reactive function is passed.
-(NULL or "" is not recommended because those should be limited to decorative images)}
+\item{alt}{Alternate text for the HTML \verb{<img>} tag
+if it cannot be displayed or viewed (i.e., the user uses a screen reader).
+In addition to a character string, the value may be a reactive expression
+(or a function referencing reactive values) that returns a character string.
+NULL or "" is not recommended because those should be limited to decorative images
+(the default is "Plot object").}
 
 \item{...}{Arguments to be passed through to \code{\link[grDevices:png]{grDevices::png()}}.
 These can be used to set the width, height, background color, etc.}

--- a/man/renderPlot.Rd
+++ b/man/renderPlot.Rd
@@ -9,6 +9,7 @@ renderPlot(
   width = "auto",
   height = "auto",
   res = 72,
+  alt = "Plot object",
   ...,
   env = parent.frame(),
   quoted = FALSE,
@@ -36,6 +37,8 @@ to both \code{width} and \code{height}.}
 \item{res}{Resolution of resulting plot, in pixels per inch. This value is
 passed to \code{\link[grDevices:png]{grDevices::png()}}. Note that this affects the resolution of PNG
 rendering in R; it won't change the actual ppi of the browser.}
+
+\item{alt}{Optional parameter to pass \code{alt} to the img-tag.}
 
 \item{...}{Arguments to be passed through to \code{\link[grDevices:png]{grDevices::png()}}.
 These can be used to set the width, height, background color, etc.}


### PR DESCRIPTION
This ready-for-review PR attempts to follow up with the PR #2494 to address the alt text issue #612.

We have to make sure `alt` attribute to be dynamic (beyond static).

Adding `alt` param to `render*()` instead of `*Output()` makes more sense to me (the actual screen reader user) given that we may want to have dynamic `alt` text depending on graph changes.

## Reprex

* Confirmed the following dynamic alt text works very well for screen readers

``` r
library(shiny)

shinyApp(
  ui = fluidPage(
    actionButton("btn1", "Update plots"),
    plotOutput("plot1", width = "400px")
  ),
  server = function(input, output, session) {
    dt <- reactive({
      invalidateLater(3 * 1000)
      rnorm(30)
    })
    output$plot1 <- renderPlot(
      {
        hist(dt())
      },
      alt = reactive({
        paste("Dynamic alt text. Mean(x):", round(mean(dt()), 3))
      })
    )
  }
)
```