### PR TITLE
Move `alt` parameter after `...`

### DIFF
--- a/R/render-cached-plot.R
+++ b/R/render-cached-plot.R
@@ -295,9 +295,9 @@ renderCachedPlot <- function(expr,
   cacheKeyExpr,
   sizePolicy = sizeGrowthRatio(width = 400, height = 400, growthRate = 1.2),
   res = 72,
-  alt = "Plot object",
   cache = "app",
   ...,
+  alt = "Plot object",
   outputArgs = list(),
   width = NULL,
   height = NULL
@@ -406,7 +406,7 @@ renderCachedPlot <- function(expr,
           width  <- fitDims$width
           height <- fitDims$height
           # Make sure alt text to be reactive function
-          alt <- altWrapper() 
+          alt <- altWrapper()
         })
 
         pixelratio <- session$clientData$pixelratio %OR% 1

--- a/R/render-plot.R
+++ b/R/render-plot.R
@@ -38,7 +38,7 @@
 #'   rendering in R; it won't change the actual ppi of the browser.
 #' @param alt Alternate text for the HTML `<img>` tag
 #'   if it cannot be displayed or viewed (i.e., the user uses a screen reader).
-#'   In addition to a character string, the value may be a reactive expression 
+#'   In addition to a character string, the value may be a reactive expression
 #'   (or a function referencing reactive values) that returns a character string.
 #'   NULL or "" is not recommended because those should be limited to decorative images
 #'   (the default is "Plot object").
@@ -57,9 +57,10 @@
 #'   call to [plotOutput()] when `renderPlot` is used in an
 #'   interactive R Markdown document.
 #' @export
-renderPlot <- function(expr, width='auto', height='auto', res=72, alt="Plot object", ...,
-                       env=parent.frame(), quoted=FALSE,
-                       execOnResize=FALSE, outputArgs=list()
+renderPlot <- function(expr, width = 'auto', height = 'auto', res = 72, ...,
+                       alt = "Plot object",
+                       env = parent.frame(), quoted = FALSE,
+                       execOnResize = FALSE, outputArgs = list()
 ) {
   # This ..stacktraceon is matched by a ..stacktraceoff.. when plotFunc
   # is called

--- a/man/renderCachedPlot.Rd
+++ b/man/renderCachedPlot.Rd
@@ -9,9 +9,9 @@ renderCachedPlot(
   cacheKeyExpr,
   sizePolicy = sizeGrowthRatio(width = 400, height = 400, growthRate = 1.2),
   res = 72,
-  alt = "Plot object",
   cache = "app",
   ...,
+  alt = "Plot object",
   outputArgs = list(),
   width = NULL,
   height = NULL
@@ -33,13 +33,6 @@ information on the default sizing policy.}
 
 \item{res}{The resolution of the PNG, in pixels per inch.}
 
-\item{alt}{Alternate text for the HTML \verb{<img>} tag
-if it cannot be displayed or viewed (i.e., the user uses a screen reader).
-In addition to a character string, the value may be a reactive expression
-(or a function referencing reactive values) that returns a character string.
-NULL or "" is not recommended because those should be limited to decorative images
-(the default is "Plot object").}
-
 \item{cache}{The scope of the cache, or a cache object. This can be
 \code{"app"} (the default), \code{"session"}, or a cache object like
 a \code{\link[=diskCache]{diskCache()}}. See the Cache Scoping section for more
@@ -47,6 +40,13 @@ information.}
 
 \item{...}{Arguments to be passed through to \code{\link[grDevices:png]{grDevices::png()}}.
 These can be used to set the width, height, background color, etc.}
+
+\item{alt}{Alternate text for the HTML \verb{<img>} tag
+if it cannot be displayed or viewed (i.e., the user uses a screen reader).
+In addition to a character string, the value may be a reactive expression
+(or a function referencing reactive values) that returns a character string.
+NULL or "" is not recommended because those should be limited to decorative images
+(the default is "Plot object").}
 
 \item{outputArgs}{A list of arguments to be passed through to the implicit
 call to \code{\link[=plotOutput]{plotOutput()}} when \code{renderPlot} is used in an

--- a/man/renderPlot.Rd
+++ b/man/renderPlot.Rd
@@ -9,8 +9,8 @@ renderPlot(
   width = "auto",
   height = "auto",
   res = 72,
-  alt = "Plot object",
   ...,
+  alt = "Plot object",
   env = parent.frame(),
   quoted = FALSE,
   execOnResize = FALSE,
@@ -38,15 +38,15 @@ to both \code{width} and \code{height}.}
 passed to \code{\link[grDevices:png]{grDevices::png()}}. Note that this affects the resolution of PNG
 rendering in R; it won't change the actual ppi of the browser.}
 
+\item{...}{Arguments to be passed through to \code{\link[grDevices:png]{grDevices::png()}}.
+These can be used to set the width, height, background color, etc.}
+
 \item{alt}{Alternate text for the HTML \verb{<img>} tag
 if it cannot be displayed or viewed (i.e., the user uses a screen reader).
 In addition to a character string, the value may be a reactive expression
 (or a function referencing reactive values) that returns a character string.
 NULL or "" is not recommended because those should be limited to decorative images
 (the default is "Plot object").}
-
-\item{...}{Arguments to be passed through to \code{\link[grDevices:png]{grDevices::png()}}.
-These can be used to set the width, height, background color, etc.}
 
 \item{env}{The environment in which to evaluate \code{expr}.}
 


### PR DESCRIPTION
This moves the new `alt` parameter to after `...`. This will avoid possible breakage of existing code, and lets us not commit to a specific order in the future.