### PR TITLE
Make sure cache logging appends to file

### DIFF
--- a/R/cache-disk.R
+++ b/R/cache-disk.R
@@ -555,7 +555,7 @@ DiskCache <- R6Class("DiskCache",
       if (is.null(private$logfile)) return()
 
       text <- paste0(format(Sys.time(), "[%Y-%m-%d %H:%M:%OS3] DiskCache "), text)
-      writeLines(text, private$logfile)
+      cat(text, sep = "\n", file = private$logfile, append = TRUE)
     }
   )
 )

--- a/R/cache-memory.R
+++ b/R/cache-memory.R
@@ -359,7 +359,7 @@ MemoryCache <- R6Class("MemoryCache",
       if (is.null(private$logfile)) return()
 
       text <- paste0(format(Sys.time(), "[%Y-%m-%d %H:%M:%OS3] MemoryCache "), text)
-      writeLines(text, private$logfile)
+      cat(text, sep = "\n", file = private$logfile, append = TRUE)
     }
   )
 )


### PR DESCRIPTION
Before this change, if a DiskCache or MemoryCache was logging to a file, then the file would get overwritten each text was logged. This change makes it append to the file.

(Note that if logging to `stdout()`, this wasn't an issue.)