### PR TITLE
UI errors with Unicode characters rendered poorly

### DIFF
--- a/inst/template/error.html
+++ b/inst/template/error.html
@@ -2,6 +2,7 @@
 
 <head>
   <title>An error has occurred</title>
+  <meta charset="UTF-8">
 </head>
 
 <body>


### PR DESCRIPTION
Repro:

```r
library(shiny)

ui <- function(req) {
  # Throws an error
  match.arg("one", c("two", "three"))
}

server <- function(input, output, session) {
}

shinyApp(ui, server)
```

Without this fix, you get incorrectly encoded characters.

![image](https://user-images.githubusercontent.com/129551/92151078-5b12d800-edd5-11ea-9032-bf225b7eb683.png)

Fix was tested on Ubuntu and Windows.