### PR TITLE
Closes #2936 - `dateInput` iterating over vector of dates to avoid warning from `dateYMD`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -48,6 +48,8 @@ shiny 1.5.0.9000
 
 * Fixed #3033: When a `DiskCache` was created with both `max_n` and `max_size`, too many items could get pruned when `prune()` was called. (#3034)
 
+* Fixed #2936: `dateYMD` was giving a warning when passed a vector of dates from `dateInput` which was greater than length 1. Used `sapply` to apply `dateYMD` once per value in vector.
+
 ### Library updates
 
 * Removed html5shiv and respond.js, which were used for IE 8 and IE 9 compatibility. (#2973)

--- a/R/input-date.R
+++ b/R/input-date.R
@@ -99,7 +99,7 @@ dateInput <- function(inputId, label, value = NULL, min = NULL, max = NULL,
   value <- dateYMD(value, "value")
   min <- dateYMD(min, "min")
   max <- dateYMD(max, "max")
-  datestisabled <- sapply(datesdisabled, dateYMD, "datesdisabled", USE.NAMES = FALSE)
+  datesdisabled <- sapply(datesdisabled, dateYMD, "datesdisabled", USE.NAMES = FALSE)
 
   value <- restoreInput(id = inputId, default = value)
 

--- a/R/input-date.R
+++ b/R/input-date.R
@@ -99,7 +99,7 @@ dateInput <- function(inputId, label, value = NULL, min = NULL, max = NULL,
   value <- dateYMD(value, "value")
   min <- dateYMD(min, "min")
   max <- dateYMD(max, "max")
-  datesdisabled <- dateYMD(datesdisabled, "datesdisabled")
+  datestisabled <- sapply(datesdisabled, dateYMD, "datesdisabled", USE.NAMES = FALSE)
 
   value <- restoreInput(id = inputId, default = value)
 


### PR DESCRIPTION
Fix for Issue #2936. `dateYMD` expects object of length 1 and runs test before returning warning if >1. `dateInput` allows a vector of dates. Have changed `dateInput` to iterate over dates using `sapply` so as to not produce the warning which is not needed here (whilst preserving it for other cases).

Edit:
have run tests etc. as per Contribution guidelines. Also first pull request so do advise of parts omitted/incomplete!