### PR TITLE
Remove test for date object length>1 (Closes #2936)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -48,7 +48,7 @@ shiny 1.5.0.9000
 
 * Fixed #3033: When a `DiskCache` was created with both `max_n` and `max_size`, too many items could get pruned when `prune()` was called. (#3034)
 
-* Fixed #2936: `dateYMD` was giving a warning when passed a vector of dates from `dateInput` which was greater than length 1. Used `sapply` to apply `dateYMD` once per value in vector.
+* Fixed #2936: `dateYMD` was giving a warning when passed a vector of dates from `dateInput` which was greater than length 1. Removed check.
 
 ### Library updates
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -48,6 +48,8 @@ shiny 1.5.0.9000
 
 * Fixed #3033: When a `DiskCache` was created with both `max_n` and `max_size`, too many items could get pruned when `prune()` was called. (#3034)
 
+* Fixed #2936: `dateYMD` was giving a warning when passed a vector of dates from `dateInput` which was greater than length 1. Used `sapply` to apply `dateYMD` once per value in vector.
+
 ### Library updates
 
 * Removed html5shiv and respond.js, which were used for IE 8 and IE 9 compatibility. (#2973)

--- a/NEWS.md
+++ b/NEWS.md
@@ -48,7 +48,7 @@ shiny 1.5.0.9000
 
 * Fixed #3033: When a `DiskCache` was created with both `max_n` and `max_size`, too many items could get pruned when `prune()` was called. (#3034)
 
-* Fixed #2936: `dateYMD` was giving a warning when passed a vector of dates from `dateInput` which was greater than length 1. Removed check.
+* Fixed #2936: `dateYMD` was giving a warning when passed a vector of dates from `dateInput` which was greater than length 1. The length check was removed because it was not needed. (#3061)
 
 ### Library updates
 

--- a/R/input-date.R
+++ b/R/input-date.R
@@ -99,7 +99,7 @@ dateInput <- function(inputId, label, value = NULL, min = NULL, max = NULL,
   value <- dateYMD(value, "value")
   min <- dateYMD(min, "min")
   max <- dateYMD(max, "max")
-  datestisabled <- sapply(datesdisabled, dateYMD, "datesdisabled", USE.NAMES = FALSE)
+  datesdisabled <- sapply(datesdisabled, dateYMD, "datesdisabled", USE.NAMES = FALSE)
 
   value <- restoreInput(id = inputId, default = value)
 

--- a/R/input-date.R
+++ b/R/input-date.R
@@ -99,7 +99,7 @@ dateInput <- function(inputId, label, value = NULL, min = NULL, max = NULL,
   value <- dateYMD(value, "value")
   min <- dateYMD(min, "min")
   max <- dateYMD(max, "max")
-  datesdisabled <- sapply(datesdisabled, dateYMD, "datesdisabled", USE.NAMES = FALSE)
+  datesdisabled <- dateYMD(datesdisabled, "datesdisabled")
 
   value <- restoreInput(id = inputId, default = value)
 

--- a/R/input-date.R
+++ b/R/input-date.R
@@ -99,7 +99,7 @@ dateInput <- function(inputId, label, value = NULL, min = NULL, max = NULL,
   value <- dateYMD(value, "value")
   min <- dateYMD(min, "min")
   max <- dateYMD(max, "max")
-  datesdisabled <- dateYMD(datesdisabled, "datesdisabled")
+  datestisabled <- sapply(datesdisabled, dateYMD, "datesdisabled", USE.NAMES = FALSE)
 
   value <- restoreInput(id = inputId, default = value)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1594,7 +1594,6 @@ URLencode <- function(value, reserved = FALSE) {
 # so that strings like "2016-08-9" are expanded to "2016-08-09"
 dateYMD <- function(date = NULL, argName = "value") {
   if (!length(date)) return(NULL)
-  if (length(date) > 1) warning("Expected `", argName, "` to be of length 1.")
   tryCatch(date <- format(as.Date(date), "%Y-%m-%d"),
     error = function(e) {
       warning(


### PR DESCRIPTION
This does the alternative fix to the issue of `dateInput` warning about date objects length>1. @cpsievert @wch in case that helps! 