### PR TITLE
Allow to create progress bar without a close button

### DIFF
--- a/R/progress.R
+++ b/R/progress.R
@@ -72,9 +72,14 @@ Progress <- R6Class(
     #'   the progress indicator will show using Shiny's notification API. If
     #'   `"old"`, use the same HTML and CSS used in Shiny 0.13.2 and below (this
     #'   is for backward-compatibility).
-    initialize = function(session = getDefaultReactiveDomain(),
+    #' @param closeButton If `TRUE`, display a button which will make the
+    #'   progress disappear when clicked. If `FALSE` do not display.
+    initialize = function(
+      session = getDefaultReactiveDomain(),
       min = 0, max = 1,
-      style = getShinyOption("progress.style", default = "notification"))
+      style = getShinyOption("progress.style", default = "notification"),
+      closeButton = TRUE
+    )
     {
       if (is.null(session$progressStack))
         stop("'session' is not a ShinySession object.")
@@ -87,7 +92,7 @@ Progress <- R6Class(
       private$style <- match.arg(style, choices = c("notification", "old"))
       private$closed <- FALSE
 
-      session$sendProgress('open', list(id = private$id, style = private$style))
+      session$sendProgress('open', list(id = private$id, style = private$style, closeButton = closeButton))
     },
 
     #' @description Updates the progress panel. When called the first time, the
@@ -152,7 +157,7 @@ Progress <- R6Class(
       }
 
       private$session$sendProgress('close',
-        list(id = private$id, style = private$style)
+                                   list(id = private$id, style = private$style)
       )
       private$closed <- TRUE
     }
@@ -226,7 +231,8 @@ Progress <- R6Class(
 #'   (this is for backward-compatibility).
 #' @param value Single-element numeric vector; the value at which to set the
 #'   progress bar, relative to `min` and `max`.
-#'
+#' @param closeButton If `TRUE`, display a button which will make the
+#'   progress disappear when clicked. If `FALSE` do not display.
 #' @return The result of `expr`.
 #' @examples
 #' ## Only run examples in interactive R sessions
@@ -255,12 +261,16 @@ Progress <- R6Class(
 #' @seealso [Progress()]
 #' @rdname withProgress
 #' @export
-withProgress <- function(expr, min = 0, max = 1,
+withProgress <- function(
+  expr, min = 0, max = 1,
   value = min + (max - min) * 0.1,
   message = NULL, detail = NULL,
   style = getShinyOption("progress.style", default = "notification"),
   session = getDefaultReactiveDomain(),
-  env = parent.frame(), quoted = FALSE)
+  env = parent.frame(),
+  quoted = FALSE,
+  closeButton = TRUE
+)
 {
 
   if (!quoted)
@@ -271,7 +281,7 @@ withProgress <- function(expr, min = 0, max = 1,
 
   style <- match.arg(style, c("notification", "old"))
 
-  p <- Progress$new(session, min = min, max = max, style = style)
+  p <- Progress$new(session, min = min, max = max, style = style, closeButton = closeButton)
 
   session$progressStack$push(p)
   on.exit({

--- a/R/progress.R
+++ b/R/progress.R
@@ -156,8 +156,9 @@ Progress <- R6Class(
         return()
       }
 
-      private$session$sendProgress('close',
-                                   list(id = private$id, style = private$style)
+      private$session$sendProgress(
+        'close',
+        list(id = private$id, style = private$style)
       )
       private$closed <- TRUE
     }

--- a/srcjs/shinyapp.js
+++ b/srcjs/shinyapp.js
@@ -1070,7 +1070,8 @@ var ShinyApp = function() {
               '</div>' +
             '</div>',
           id: message.id,
-          duration: null
+          duration: null,
+          closeButton: message.closeButton
         });
 
       } else if (message.style === "old") {


### PR DESCRIPTION
will close #2979

Demo apps:

```r
system("cd tools && yarn build")
pkgload::load_all()

ui <- fluidPage(
  plotOutput("plot")
)

server <- function(input, output) {
  output$plot <- renderPlot({
    withProgress(
      closeButton = FALSE, 
      message = 'Calculation in progress',
      detail = 'This may take a while...', 
      value = 0, 
      {
        for (i in 1:15) {
          incProgress(1/15)
          Sys.sleep(0.25)
        }
      }
    )
    plot(cars)
  })
}

shinyApp(ui, server)

ui <- fluidPage(
  plotOutput("plot")
)

server <- function(input, output, session) {
  output$plot <- renderPlot({
    progress <- Progress$new(session, min=1, max=15, closeButton = FALSE)
    on.exit(progress$close())
    
    progress$set(message = 'Calculation in progress',
                 detail = 'This may take a while...')
    
    for (i in 1:15) {
      progress$set(value = i)
      Sys.sleep(0.5)
    }
    plot(cars)
  })
}

shinyApp(ui, server)

```