### PR TITLE
Add session-level shinyOptions()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -117,13 +117,14 @@ Remotes:
 URL: http://shiny.rstudio.com
 BugReports: https://github.com/rstudio/shiny/issues
 Collate:
+    'globals.R'
+    'app-state.R'
     'app_template.R'
     'bookmark-state-local.R'
     'stack.R'
     'bookmark-state.R'
     'bootstrap-deprecated.R'
     'bootstrap-layout.R'
-    'globals.R'
     'conditions.R'
     'map.R'
     'utils.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -40,6 +40,8 @@ shiny 1.5.0.9000
 
 * `testServer()` can accept a single server function as input (#2965).
 
+* `shinyOptions()` now has session-level scoping, in addition to global and application-level scoping. (#3080)
+
 ### Bug fixes
 
 * Fixed #2859: `renderPlot()` wasn't correctly setting `showtext::showtext_opts()`'s `dpi` setting with the correct resolution on high resolution displays; which means, if the font was rendered by showtext, font sizes would look smaller than they should on such displays. (#2941)

--- a/R/app-state.R
+++ b/R/app-state.R
@@ -1,8 +1,6 @@
 #' @include globals.R
 NULL
 
-# TODO: implement for mock session?
-
 # The current app state is a place to read and hang state for the
 # currently-running application. This is useful for setting options that will
 # last as long as the application is running.

--- a/R/app-state.R
+++ b/R/app-state.R
@@ -15,7 +15,8 @@ initCurrentAppState <- function(appobj) {
   }
   .globals$appState <- new.env(parent = emptyenv())
   .globals$appState$app <- appobj
-  .globals$appState$options <- list()
+  # Copy over global options
+  .globals$appState$options <- .globals$options
 }
 
 getCurrentAppState <- function() {

--- a/R/app-state.R
+++ b/R/app-state.R
@@ -1,0 +1,27 @@
+#' @include globals.R
+NULL
+
+# TODO: implement for mock session?
+
+# The current app state is a place to read and hang state for the
+# currently-running application. This is useful for setting options that will
+# last as long as the application is running.
+
+.globals$appState <- NULL
+
+initCurrentAppState <- function(appobj) {
+  if (!is.null(.globals$appState)) {
+    stop("Can't initialize current app state when another is currently active.")
+  }
+  .globals$appState <- new.env(parent = emptyenv())
+  .globals$appState$app <- appobj
+  .globals$appState$options <- list()
+}
+
+getCurrentAppState <- function() {
+  .globals$appState
+}
+
+clearCurrentAppState <- function() {
+  .globals$appState <- NULL
+}

--- a/R/mock-session.R
+++ b/R/mock-session.R
@@ -249,6 +249,8 @@ MockShinySession <- R6Class(
     #' @field user The username of an authenticated user. Always `NULL` for a
     #'   `MockShinySession`.
     user = NULL,
+    #' @field options A list containing session-level shinyOptions.
+    options = list(),
 
     #' @description Create a new MockShinySession.
     initialize = function() {

--- a/R/mock-session.R
+++ b/R/mock-session.R
@@ -250,7 +250,7 @@ MockShinySession <- R6Class(
     #'   `MockShinySession`.
     user = NULL,
     #' @field options A list containing session-level shinyOptions.
-    options = list(),
+    options = NULL,
 
     #' @description Create a new MockShinySession.
     initialize = function() {
@@ -275,6 +275,10 @@ MockShinySession <- R6Class(
       self$input <- .createReactiveValues(private$.input, readonly = TRUE)
 
       self$token <- createUniqueId(16)
+
+      # Copy app-level options
+      self$options <- getCurrentAppState()$options
+
       self$cache <- MemoryCache$new()
       self$appcache <- MemoryCache$new()
 

--- a/R/runapp.R
+++ b/R/runapp.R
@@ -102,16 +102,6 @@ runApp <- function(appDir=getwd(),
     .globals$running <- FALSE
   }, add = TRUE)
 
-  # Enable per-app Shiny options, for shinyOptions() and getShinyOption().
-  oldOptionSet <- .globals$options
-  on.exit({
-    .globals$options <- oldOptionSet
-  },add = TRUE)
-
-  # A unique identifier associated with this run of this application. It is
-  # shared across sessions.
-  shinyOptions(appToken = createUniqueId(8))
-
   # Make warnings print immediately
   # Set pool.scheduler to support pool package
   ops <- options(
@@ -121,11 +111,9 @@ runApp <- function(appDir=getwd(),
   )
   on.exit(options(ops), add = TRUE)
 
-  # Set up default cache for app.
-  if (is.null(getShinyOption("cache"))) {
-    shinyOptions(cache = MemoryCache$new())
-  }
-
+  # ============================================================================
+  # Global onStart/onStop callbacks
+  # ============================================================================
   # Invoke user-defined onStop callbacks, before the application's internal
   # onStop callbacks.
   on.exit({
@@ -135,11 +123,44 @@ runApp <- function(appDir=getwd(),
 
   require(shiny)
 
+  # ============================================================================
+  # Convert to Shiny app object
+  # ============================================================================
   appParts <- as.shiny.appobj(appDir)
 
+  # ============================================================================
+  # Initialize app state object
+  # ============================================================================
+  # This is so calls to getCurrentAppState() can be used to find (A) whether an
+  # app is running and (B), get options and data associated with the app.
+  initCurrentAppState(appParts)
+  on.exit(clearCurrentAppState(), add = TRUE)
+  # Any shinyOptions set after this point will apply to the current app only
+  # (and will not persist after the app stops).
+
+  # ============================================================================
+  # shinyOptions
+  # ============================================================================
+  # A unique identifier associated with this run of this application. It is
+  # shared across sessions.
+  shinyOptions(appToken = createUniqueId(8))
+
+  # Set up default cache for app.
+  if (is.null(getShinyOption("cache"))) {
+    shinyOptions(cache = MemoryCache$new())
+  }
+
+  # Extract appOptions (which is a list) and store them as shinyOptions, for
+  # this app. (This is the only place we have to store settings that are
+  # accessible both the UI and server portion of the app.)
+  applyCapturedAppOptions(appParts$appOptions)
+
+  # ============================================================================
+  # runApp options set via shinyApp(options = list(...))
+  # ============================================================================
   # The lines below set some of the app's running options, which
   # can be:
-  #   - left unspeficied (in which case the arguments' default
+  #   - left unspecified (in which case the arguments' default
   #     values from `runApp` kick in);
   #   - passed through `shinyApp`
   #   - passed through `runApp` (this function)
@@ -176,6 +197,9 @@ runApp <- function(appDir=getwd(),
 
   if (is.null(host) || is.na(host)) host <- '0.0.0.0'
 
+  # ============================================================================
+  # Hosted environment
+  # ============================================================================
   workerId(workerId)
 
   if (inShinyServer()) {
@@ -190,15 +214,21 @@ runApp <- function(appDir=getwd(),
     }
   }
 
-  # Showcase mode is disabled by default; it must be explicitly enabled in
-  # either the DESCRIPTION file for directory-based apps, or via
-  # the display.mode parameter. The latter takes precedence.
-  setShowcaseDefault(0)
-
+  # ============================================================================
+  # Shinytest
+  # ============================================================================
   .globals$testMode <- test.mode
   if (test.mode) {
     message("Running application in test mode.")
   }
+
+  # ============================================================================
+  # Showcase mode
+  # ============================================================================
+  # Showcase mode is disabled by default; it must be explicitly enabled in
+  # either the DESCRIPTION file for directory-based apps, or via
+  # the display.mode parameter. The latter takes precedence.
+  setShowcaseDefault(0)
 
   # If appDir specifies a path, and display mode is specified in the
   # DESCRIPTION file at that path, apply it here.
@@ -248,6 +278,9 @@ runApp <- function(appDir=getwd(),
     setShowcaseDefault(1)
   }
 
+  # ============================================================================
+  # Server port
+  # ============================================================================
   # determine port if we need to
   if (is.null(port)) {
 
@@ -286,11 +319,9 @@ runApp <- function(appDir=getwd(),
     }
   }
 
-  # Extract appOptions (which is a list) and store them as shinyOptions, for
-  # this app. (This is the only place we have to store settings that are
-  # accessible both the UI and server portion of the app.)
-  applyCapturedAppOptions(appParts$appOptions)
-
+  # ============================================================================
+  # onStart/onStop callbacks
+  # ============================================================================
   # Set up the onStop before we call onStart, so that it gets called even if an
   # error happens in onStart.
   if (!is.null(appParts$onStop))
@@ -298,6 +329,9 @@ runApp <- function(appDir=getwd(),
   if (!is.null(appParts$onStart))
     appParts$onStart()
 
+  # ============================================================================
+  # Start/stop httpuv app
+  # ============================================================================
   server <- startApp(appParts, port, host, quiet)
 
   # Make the httpuv server object accessible. Needed for calling
@@ -308,6 +342,9 @@ runApp <- function(appDir=getwd(),
     stopServer(server)
   }, add = TRUE)
 
+  # ============================================================================
+  # Launch web browser
+  # ============================================================================
   if (!is.character(port)) {
     browseHost <- host
     if (identical(host, "0.0.0.0")) {
@@ -330,12 +367,17 @@ runApp <- function(appDir=getwd(),
     appUrl <- NULL
   }
 
-  # call application hooks
+  # ============================================================================
+  # Application hooks
+  # ============================================================================
   callAppHook("onAppStart", appUrl)
   on.exit({
     callAppHook("onAppStop", appUrl)
   }, add = TRUE)
 
+  # ============================================================================
+  # Run event loop via httpuv
+  # ============================================================================
   .globals$reterror <- NULL
   .globals$retval <- NULL
   .globals$stopped <- FALSE

--- a/R/runapp.R
+++ b/R/runapp.R
@@ -289,7 +289,7 @@ runApp <- function(appDir=getwd(),
   # Extract appOptions (which is a list) and store them as shinyOptions, for
   # this app. (This is the only place we have to store settings that are
   # accessible both the UI and server portion of the app.)
-  unconsumeAppOptions(appParts$appOptions)
+  applyCapturedAppOptions(appParts$appOptions)
 
   # Set up the onStop before we call onStart, so that it gets called even if an
   # error happens in onStart.

--- a/R/runapp.R
+++ b/R/runapp.R
@@ -213,7 +213,10 @@ runApp <- function(appDir=getwd(),
   # ============================================================================
   # Shinytest
   # ============================================================================
-  .globals$testMode <- test.mode
+  # Set the testmode shinyoption so that this can be read by both the
+  # ShinySession and the UI code (which executes separately from the
+  # ShinySession code).
+  shinyOptions(testmode = test.mode)
   if (test.mode) {
     message("Running application in test mode.")
   }

--- a/R/runapp.R
+++ b/R/runapp.R
@@ -93,14 +93,10 @@ runApp <- function(appDir=getwd(),
     handlerManager$clear()
   }, add = TRUE)
 
-  if (.globals$running) {
+  if (isRunning()) {
     stop("Can't call `runApp()` from within `runApp()`. If your ",
          "application code contains `runApp()`, please remove it.")
   }
-  .globals$running <- TRUE
-  on.exit({
-    .globals$running <- FALSE
-  }, add = TRUE)
 
   # Make warnings print immediately
   # Set pool.scheduler to support pool package

--- a/R/server.R
+++ b/R/server.R
@@ -474,9 +474,6 @@ serviceApp <- function() {
 
 .shinyServerMinVersion <- '0.3.4'
 
-# Global flag that's TRUE whenever we're inside of the scope of a call to runApp
-.globals$running <- FALSE
-
 #' Check whether a Shiny application is running
 #'
 #' This function tests whether a Shiny application is currently running.
@@ -485,7 +482,7 @@ serviceApp <- function() {
 #'   `FALSE`.
 #' @export
 isRunning <- function() {
-  .globals$running
+  !is.null(getCurrentAppState())
 }
 
 

--- a/R/shiny-options.R
+++ b/R/shiny-options.R
@@ -38,23 +38,55 @@ getShinyOption <- function(name, default = NULL) {
 
 #' Get or set Shiny options
 #'
-#' `getShinyOption()` retrieves the value of a Shiny option. `shinyOptions()`
-#' sets the value of Shiny options; it can also be used to return a list of all
-#' currently-set Shiny options.
+#' @description
+#'
+#' There are two mechanisms for working with options for Shiny. One is the
+#' [options()] function, which is part of base R, and the other is the
+#' `shinyOptions()` function, which is in the Shiny package. The reason for
+#' these two mechanisms is has to do with legacy code and scoping.
+#'
+#' The [options()] function sets options globally, for the duration of an R
+#' session. The [getOption()] function retrieves the value of an option.
+#'
+#' The `shinyOptions()` function sets the value of a shiny option, but unlike
+#' `options()`, it is not always global in scope; the options may be scoped
+#' globally, to an application, or to a user session in an application,
+#' depending on the context. The `getShinyOption()` function retrieves a value
+#' of a shiny option.
 #'
 #' @section Scope:
-#' There is a global option set which is available by default. When a Shiny
-#' application is run with [runApp()], that option set is duplicated and the
-#' new option set is available for getting or setting values. If options
-#' are set from `global.R`, `app.R`, `ui.R`, or `server.R`, or if they are set
-#' from inside the server function, then the options will be scoped to the
-#' application. When the application exits, the new option set is discarded and
-#' the global option set is restored.
 #'
-#' @section Options:
-#' There are a number of global options that affect Shiny's behavior. These can
-#' be set globally with `options()` or locally (for a single app) with
-#' `shinyOptions()`.
+#'   There are three levels of scoping for `shinyOptions()`: global,
+#'   application, and session.
+#'
+#'   The global option set is available by default. Any calls to
+#'   `shinyOptions()` and `getShinyOption()` outside of an app will access the
+#'   global option set.
+#'
+#'   When a Shiny application is run with [runApp()], the global option set is
+#'   duplicated and the new option set is available at the application level. If
+#'   options are set from `global.R`, `app.R`, `ui.R`, or `server.R` (but
+#'   outside of the server function), then the application-level options will be
+#'   modified.
+#'
+#'   Each time a user session is started, the application-level option set is
+#'   duplicated, for that session. If the options are set from inside the server
+#'   function, then they will be scoped to the session.
+#'
+#' @section Options with `shinyOptions()`:
+#'
+#'   There are a number of global options that affect Shiny's behavior. These
+#'   can be set globally with `options()` or locally (for a single app) with
+#'   `shinyOptions()`.
+#'
+#' \describe{
+#' \item{bootstraplib (defaults to `FALSE`)}{When a global **bootstraplib** theme
+#'   is set (via [bootstraplib::bs_theme_new()]), should **shiny** compile it
+#'   (via [bootstraplib::bootstrap()]) and include the result with [bootstrapPage()]
+#'   as well as use it to set better default styles for input widgets (e.g., [selectInput()])?}
+#' }
+#'
+#' @section Options with `options()`:
 #'
 #' \describe{
 #' \item{shiny.autoreload (defaults to `FALSE`)}{If `TRUE` when a Shiny app is launched, the
@@ -73,10 +105,6 @@ getShinyOption <- function(name, default = NULL) {
 #'   The default polling interval is 500 milliseconds. You can change this
 #'   by setting e.g. `options(shiny.autoreload.interval = 2000)` (every
 #'   two seconds).}
-#' \item{bootstraplib (defaults to `FALSE`)}{When a global **bootstraplib** theme
-#'   is set (via [bootstraplib::bs_theme_new()]), should **shiny** compile it
-#'   (via [bootstraplib::bootstrap()]) and include the result with [bootstrapPage()]
-#'   as well as use it to set better default styles for input widgets (e.g., [selectInput()])?}
 #' \item{shiny.deprecation.messages (defaults to `TRUE`)}{This controls whether messages for
 #'   deprecated functions in Shiny will be printed. See
 #'   [shinyDeprecated()] for more information.}
@@ -137,6 +165,7 @@ getShinyOption <- function(name, default = NULL) {
 #'   Cairo package, if it is installed. See [plotPNG()] for more
 #'   information.}
 #' }
+#'
 #' @param ... Options to set, with the form `name = value`.
 #' @aliases shiny-options
 #' @examples

--- a/R/shiny-options.R
+++ b/R/shiny-options.R
@@ -161,6 +161,8 @@ getShinyOption <- function(name, default = NULL) {
 #'   `"recv"` (only print messages received by the server), `TRUE`
 #'   (print all messages), or `FALSE` (default; don't print any of these
 #'   messages).}
+#' \item{shiny.autoload.r (defaults to `TRUE`)}{If `TRUE`, then the R/
+#'   of a shiny app will automatically be sourced.}
 #' \item{shiny.usecairo (defaults to `TRUE`)}{This is used to disable graphical rendering by the
 #'   Cairo package, if it is installed. See [plotPNG()] for more
 #'   information.}

--- a/R/shiny-options.R
+++ b/R/shiny-options.R
@@ -187,15 +187,6 @@ shinyOptions <- function(...) {
 }
 
 
-# Eval an expression with a new option set
-withLocalOptions <- function(expr) {
-  oldOptionSet <- .globals$options
-  on.exit(.globals$options <- oldOptionSet)
-
-  expr
-}
-
-
 # Get specific shiny options and put them in a list, reset those shiny options,
 # and then return the options list. This should be during the creation of a
 # shiny app object. This function "consumes" the options when the shinyApp

--- a/R/shiny-options.R
+++ b/R/shiny-options.R
@@ -80,10 +80,8 @@ getShinyOption <- function(name, default = NULL) {
 #'   `shinyOptions()`.
 #'
 #' \describe{
-#' \item{bootstraplib (defaults to `FALSE`)}{When a global **bootstraplib** theme
-#'   is set (via [bootstraplib::bs_theme_new()]), should **shiny** compile it
-#'   (via [bootstraplib::bootstrap()]) and include the result with [bootstrapPage()]
-#'   as well as use it to set better default styles for input widgets (e.g., [selectInput()])?}
+#' \item{cache}{A caching object that will be used by [renderCachedPlot()]. If
+#'   not specified, a [memoryCache()] will be used.}
 #' }
 #'
 #' @section Options with `options()`:

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -665,7 +665,7 @@ ShinySession <- R6Class(
     cache = NULL,         # A cache object used in the session
     user = NULL,
     groups = NULL,
-    options = list(),     # For session-specific shinyOptions()
+    options = NULL,       # For session-specific shinyOptions()
 
     initialize = function(websocket) {
       private$websocket <- websocket
@@ -695,6 +695,9 @@ ShinySession <- R6Class(
       self$token <- createUniqueId(16)
       private$.outputs <- list()
       private$.outputOptions <- list()
+
+      # Copy app-level options
+      self$options <- getCurrentAppState()$options
 
       self$cache <- MemoryCache$new()
 

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -706,7 +706,7 @@ ShinySession <- R6Class(
       private$restoreCallbacks <- Callbacks$new()
       private$restoredCallbacks <- Callbacks$new()
 
-      private$testMode <- .globals$testMode
+      private$testMode <- getShinyOption("testmode", default = FALSE)
       private$enableTestSnapshot()
 
       private$registerSessionEndCallbacks()

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -665,6 +665,7 @@ ShinySession <- R6Class(
     cache = NULL,         # A cache object used in the session
     user = NULL,
     groups = NULL,
+    options = list(),     # For session-specific shinyOptions()
 
     initialize = function(websocket) {
       private$websocket <- websocket

--- a/R/shinyapp.R
+++ b/R/shinyapp.R
@@ -93,7 +93,6 @@ shinyApp <- function(ui, server, onStart=NULL, options=list(),
 
   # Store the appDir and bookmarking-related options, so that we can read them
   # from within the app.
-  shinyOptions(appDir = getwd())
   appOptions <- captureAppOptions()
 
   structure(

--- a/R/shinyapp.R
+++ b/R/shinyapp.R
@@ -94,7 +94,7 @@ shinyApp <- function(ui, server, onStart=NULL, options=list(),
   # Store the appDir and bookmarking-related options, so that we can read them
   # from within the app.
   shinyOptions(appDir = getwd())
-  appOptions <- consumeAppOptions()
+  appOptions <- captureAppOptions()
 
   structure(
     list(
@@ -408,7 +408,7 @@ shinyAppDir_appR <- function(fileName, appDir, options=list())
       if (!is.shiny.appobj(result))
         stop("app.R did not return a shiny.appobj object.")
 
-      unconsumeAppOptions(result$appOptions)
+      applyCapturedAppOptions(result$appOptions)
 
       return(result)
     }

--- a/R/shinyui.R
+++ b/R/shinyui.R
@@ -120,7 +120,7 @@ uiHttpHandler <- function(ui, uiPattern = "^/$") {
         showcaseMode <- mode
     }
 
-    testMode <- .globals$testMode %OR% FALSE
+    testMode <- getShinyOption("testmode", default = FALSE)
 
     # Create a restore context using query string
     bookmarkStore <- getShinyOption("bookmarkStore", default = "disable")

--- a/R/test-server.R
+++ b/R/test-server.R
@@ -128,11 +128,9 @@ withMockContext <- function(session, expr) {
   isolate(
     withReactiveDomain(session, {
       withr::with_options(list(`shiny.allowoutputreads` = TRUE), {
-        withLocalOptions({
-          # Sets a cache for renderCachedPlot() with cache = "app" to use.
-          shinyOptions("cache" = session$appcache)
-          expr
-        })
+        # Sets a cache for renderCachedPlot() with cache = "app" to use.
+        shinyOptions("cache" = session$appcache)
+        expr
       })
     })
   )

--- a/man/MockShinySession.Rd
+++ b/man/MockShinySession.Rd
@@ -62,6 +62,8 @@ user. Always \code{NULL} for a \code{MockShinySesion}.}
 
 \item{\code{user}}{The username of an authenticated user. Always \code{NULL} for a
 \code{MockShinySession}.}
+
+\item{\code{options}}{A list containing session-level shinyOptions.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/shinyOptions.Rd
+++ b/man/shinyOptions.Rd
@@ -18,26 +18,58 @@ shinyOptions(...)
 \item{...}{Options to set, with the form \code{name = value}.}
 }
 \description{
-\code{getShinyOption()} retrieves the value of a Shiny option. \code{shinyOptions()}
-sets the value of Shiny options; it can also be used to return a list of all
-currently-set Shiny options.
+There are two mechanisms for working with options for Shiny. One is the
+\code{\link[=options]{options()}} function, which is part of base R, and the other is the
+\code{shinyOptions()} function, which is in the Shiny package. The reason for
+these two mechanisms is has to do with legacy code and scoping.
+
+The \code{\link[=options]{options()}} function sets options globally, for the duration of an R
+session. The \code{\link[=getOption]{getOption()}} function retrieves the value of an option.
+
+The \code{shinyOptions()} function sets the value of a shiny option, but unlike
+\code{options()}, it is not always global in scope; the options may be scoped
+globally, to an application, or to a user session in an application,
+depending on the context. The \code{getShinyOption()} function retrieves a value
+of a shiny option.
 }
 \section{Scope}{
 
-There is a global option set which is available by default. When a Shiny
-application is run with \code{\link[=runApp]{runApp()}}, that option set is duplicated and the
-new option set is available for getting or setting values. If options
-are set from \code{global.R}, \code{app.R}, \code{ui.R}, or \code{server.R}, or if they are set
-from inside the server function, then the options will be scoped to the
-application. When the application exits, the new option set is discarded and
-the global option set is restored.
+
+There are three levels of scoping for \code{shinyOptions()}: global,
+application, and session.
+
+The global option set is available by default. Any calls to
+\code{shinyOptions()} and \code{getShinyOption()} outside of an app will access the
+global option set.
+
+When a Shiny application is run with \code{\link[=runApp]{runApp()}}, the global option set is
+duplicated and the new option set is available at the application level. If
+options are set from \code{global.R}, \code{app.R}, \code{ui.R}, or \code{server.R} (but
+outside of the server function), then the application-level options will be
+modified.
+
+Each time a user session is started, the application-level option set is
+duplicated, for that session. If the options are set from inside the server
+function, then they will be scoped to the session.
 }
 
-\section{Options}{
+\section{Options with \code{shinyOptions()}}{
 
-There are a number of global options that affect Shiny's behavior. These can
-be set globally with \code{options()} or locally (for a single app) with
+
+There are a number of global options that affect Shiny's behavior. These
+can be set globally with \code{options()} or locally (for a single app) with
 \code{shinyOptions()}.
+
+\describe{
+\item{bootstraplib (defaults to \code{FALSE})}{When a global \strong{bootstraplib} theme
+is set (via \code{\link[bootstraplib:theming]{bootstraplib::bs_theme_new()}}), should \strong{shiny} compile it
+(via \code{\link[bootstraplib:bootstrap]{bootstraplib::bootstrap()}}) and include the result with \code{\link[=bootstrapPage]{bootstrapPage()}}
+as well as use it to set better default styles for input widgets (e.g., \code{\link[=selectInput]{selectInput()}})?}
+}
+}
+
+\section{Options with \code{options()}}{
+
 
 \describe{
 \item{shiny.autoreload (defaults to \code{FALSE})}{If \code{TRUE} when a Shiny app is launched, the
@@ -56,10 +88,6 @@ shiny.autoreload.pattern option. For example, to monitor only ui.R:
 The default polling interval is 500 milliseconds. You can change this
 by setting e.g. \code{options(shiny.autoreload.interval = 2000)} (every
 two seconds).}
-\item{bootstraplib (defaults to \code{FALSE})}{When a global \strong{bootstraplib} theme
-is set (via \code{\link[bootstraplib:theming]{bootstraplib::bs_theme_new()}}), should \strong{shiny} compile it
-(via \code{\link[bootstraplib:bootstrap]{bootstraplib::bootstrap()}}) and include the result with \code{\link[=bootstrapPage]{bootstrapPage()}}
-as well as use it to set better default styles for input widgets (e.g., \code{\link[=selectInput]{selectInput()}})?}
 \item{shiny.deprecation.messages (defaults to \code{TRUE})}{This controls whether messages for
 deprecated functions in Shiny will be printed. See
 \code{\link[=shinyDeprecated]{shinyDeprecated()}} for more information.}

--- a/man/shinyOptions.Rd
+++ b/man/shinyOptions.Rd
@@ -61,10 +61,8 @@ can be set globally with \code{options()} or locally (for a single app) with
 \code{shinyOptions()}.
 
 \describe{
-\item{bootstraplib (defaults to \code{FALSE})}{When a global \strong{bootstraplib} theme
-is set (via \code{\link[bootstraplib:theming]{bootstraplib::bs_theme_new()}}), should \strong{shiny} compile it
-(via \code{\link[bootstraplib:bootstrap]{bootstraplib::bootstrap()}}) and include the result with \code{\link[=bootstrapPage]{bootstrapPage()}}
-as well as use it to set better default styles for input widgets (e.g., \code{\link[=selectInput]{selectInput()}})?}
+\item{cache}{A caching object that will be used by \code{\link[=renderCachedPlot]{renderCachedPlot()}}. If
+not specified, a \code{\link[=memoryCache]{memoryCache()}} will be used.}
 }
 }
 
@@ -144,6 +142,8 @@ values are \code{"send"} (only print messages sent to the client),
 \code{"recv"} (only print messages received by the server), \code{TRUE}
 (print all messages), or \code{FALSE} (default; don't print any of these
 messages).}
+\item{shiny.autoload.r (defaults to \code{TRUE})}{If \code{TRUE}, then the R/
+of a shiny app will automatically be sourced.}
 \item{shiny.usecairo (defaults to \code{TRUE})}{This is used to disable graphical rendering by the
 Cairo package, if it is installed. See \code{\link[=plotPNG]{plotPNG()}} for more
 information.}

--- a/tests/testthat/test-options.R
+++ b/tests/testthat/test-options.R
@@ -70,3 +70,47 @@ test_that("Shared secret", {
   expect_false(checkSharedSecret(NULL))
   expect_error(checkSharedSecret(1:10))
 })
+
+
+test_that("Capturing options at creation time", {
+  # These are tests of captureAppOptions. Specific options should be captured
+  # and stored at app creation time and immediately reset. If another app is
+  # created, it will also capture these options at creation time.
+  # When these apps are started, they will apply the options.
+  shinyOptions(bookmarkStore = 123)
+  value <- NULL
+  s <- shinyApp(basicPage(), function(input, output) {},
+    onStart = function() {
+      value <<- getShinyOption("bookmarkStore")
+      observe(stopApp())
+    }
+  )
+  # After creating app, bookmarkStore option should be reset
+  expect_identical(getShinyOption("bookmarkStore"), NULL)
+  expect_identical(value, NULL)
+
+  # Create another app
+  shinyOptions(bookmarkStore = 456)
+  value2 <- NULL
+  s2 <- shinyApp(basicPage(), function(input, output) {},
+    onStart = function() {
+      value2 <<- getShinyOption("bookmarkStore")
+      observe(stopApp())
+    }
+  )
+  expect_identical(getShinyOption("bookmarkStore"), NULL)
+  expect_identical(value2, NULL)
+
+  # Running second app will cause the option to be restored while it's running,
+  # and in our onStart, we save it into value2.
+  runApp(s2, launch.browser = FALSE)
+  expect_identical(value, NULL)
+  expect_identical(value2, 456)
+  expect_identical(getShinyOption("bookmarkStore"), NULL)
+
+  # Same, for first app and value1.
+  runApp(s, launch.browser = FALSE)
+  expect_identical(value, 123)
+  expect_identical(value2, 456)
+  expect_identical(getShinyOption("bookmarkStore"), NULL)
+})

--- a/tests/testthat/test-options.R
+++ b/tests/testthat/test-options.R
@@ -17,6 +17,19 @@ test_that("Shared secret", {
   expect_error(checkSharedSecret(1:10))
 })
 
+test_that("Captured options contain expected elements", {
+  shinyOptions(bookmarkStore = 123)
+  shinyOptions(appDir = normalizePath("../")) # stomped
+  caps <- captureAppOptions()
+  
+  expect_equal(sort(names(caps)), c("appDir", "bookmarkStore")
+  expect_equal(caps$appDir, getwd())
+  expect_equal(caps$bookmarkStore, 123)
+
+  # verify that options are reset
+  expect_equal(getShinyOption("bookmarkStore"), NULL)
+  expect_equal(getShinyOption("appDir"), NULL)
+})
 
 test_that("Capturing options at creation time", {
   # These are tests of captureAppOptions. Specific options should be captured

--- a/tests/testthat/test-options.R
+++ b/tests/testthat/test-options.R
@@ -21,8 +21,8 @@ test_that("Captured options contain expected elements", {
   shinyOptions(bookmarkStore = 123)
   shinyOptions(appDir = normalizePath("../")) # stomped
   caps <- captureAppOptions()
-  
-  expect_equal(sort(names(caps)), c("appDir", "bookmarkStore")
+
+  expect_equal(sort(names(caps)), c("appDir", "bookmarkStore"))
   expect_equal(caps$appDir, getwd())
   expect_equal(caps$bookmarkStore, 123)
 

--- a/tests/testthat/test-options.R
+++ b/tests/testthat/test-options.R
@@ -1,59 +1,5 @@
 context("options")
 
-test_that("Local options", {
-  # Clear out any options so we know we're starting fresh
-  .globals$options <- list()
-
-  # Basic options
-  shinyOptions(a = 1, b = 2)
-
-  expect_true(contents_identical(shinyOptions(),list(a = 1, b = 2)))
-  expect_identical(getShinyOption('a'), 1)
-  expect_identical(getShinyOption('b'), 2)
-
-  # Options that haven't been set
-  expect_identical(getShinyOption('c'), NULL)
-  expect_identical(getShinyOption('c', default = 10), 10)
-
-  withLocalOptions({
-    # No changes yet
-    expect_true(contents_identical(shinyOptions(), list(a = 1, b = 2)))
-    expect_identical(getShinyOption('a'), 1)
-    expect_identical(getShinyOption('b'), 2)
-
-    # Override an option
-    shinyOptions(a = 3)
-    expect_true(contents_identical(shinyOptions(), list(b = 2, a = 3)))
-    expect_identical(getShinyOption('a'), 3)
-    expect_identical(getShinyOption('b'), 2)
-
-    # Options that haven't been set
-    expect_identical(getShinyOption('c'), NULL)
-    expect_identical(getShinyOption('c', default = 10), 10)
-
-    # Another local option set
-    withLocalOptions({
-      # Override an option
-      shinyOptions(a = 4)
-      expect_true(contents_identical(shinyOptions(), list(b = 2, a = 4)))
-      expect_identical(getShinyOption('a'), 4)
-      expect_identical(getShinyOption('b'), 2)
-    })
-  })
-
-  # Should be back to original state
-  expect_true(contents_identical(shinyOptions(), list(a = 1, b = 2)))
-  expect_identical(getShinyOption('a'), 1)
-  expect_identical(getShinyOption('b'), 2)
-
-  # Setting options to NULL removes them entirely
-  shinyOptions(b = NULL)
-  expect_identical(shinyOptions(), list(a = 1))
-
-
-  # Finish tests; reset shinyOptions
-  shinyOptions(a = NULL)
-})
 
 test_that("Shared secret", {
   op <- options(shiny.sharedSecret = "This is a secret string")


### PR DESCRIPTION
This PR adds support for `shinyOptions()` that are set at the session level, app level, and global level. Previously, we only had support for app- and global-level options.

It also:
* Adds `getCurrentAppState()`, which returns an environment that contains data for the currently-running app. The app-level options are now set with this mechanism, and in the future it will be used to store and access other app-level data.
* Renames `consumeAppOptions` to `captureAppOptions` and clarifies what it does and why it's there. Also adds unit tests for this.
* Cleans up and adds annotations to `runApp()` so that it's clearer what's going on in there.
* Fixes the documentation for `shinyOptions`, so that the values set via `options` are separate from those from `shinyOptions`.


Here's a test application. Not sure we can use it with shinycoreci-apps, since it involves starting and stopping an application, and then checking some values.

```R
library(shiny)
shinyOptions(foo = NULL)
values <- list()
values["global_in"] <- list(getShinyOption("foo"))
shinyOptions(foo = "global")

s <- shinyApp(
  basicPage(),
  function(input, output, session) {
    values["session_in"] <<- list(getShinyOption("foo"))
    shinyOptions(foo = "session")
    # shinyOptions(foo = NULL)
    # values["session_out"] <<- list(getShinyOption("foo"))
    onStop(function() {
      browser()
      values["session_out"] <<- list(getShinyOption("foo"))
    })

    observe(stopApp())
  },
  onStart = function() {
    values["app_in"] <<- list(getShinyOption("foo"))

    shinyOptions(foo = "app")

    onStop(function() {
      values["app_out"] <<- list(getShinyOption("foo"))
    })
  }
)

# Run the app
runApp(s)
values["global_out"] <- list(getShinyOption("foo"))

expect_identical(
  values,
  list(
    global_in = NULL,
    app_in = "global",
    session_in = "app", 
    session_out = "session",
    app_out = "app",
    global_out = "global"
  )
)
```