### PR TITLE
Added lang attribute for accessibility and search-engine parsers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,8 @@ shiny 1.5.0.9000
 
 * Added semantic landmarks for `mainPanel()` and `sidebarPanel()` so that assistive technologies can recognize them as "main" and "complementary" region respectively. (#3009)
 
+* Closed #2844: Added `lang` argument to ui `*Page()` functions (e.g., `fluidPage`, `bootstrapPage`) that specifies document-level language within the app for the accessibility of screen readers and search-engine parsers. By default, it is set to empty string which is commonly recognized as a browser's default locale. (#2920)
+
 ### Minor new features and improvements
 
 * When UI is specified as a function (e.g. `ui <- function(req) { ... }`), the response can now be an HTTP response as returned from the (newly exported) `httpResponse()` function. (#2970)

--- a/R/bootstrap-layout.R
+++ b/R/bootstrap-layout.R
@@ -16,6 +16,9 @@
 #' @param theme Alternative Bootstrap stylesheet (normally a css file within the
 #'   www directory). For example, to use the theme located at
 #'   `www/bootstrap.css` you would use `theme = "bootstrap.css"`.
+#' @param lang ISO 639-1 language code for the HTML page, such as "en" or "ko".
+#'   This will be used as the lang in the \code{<html>} tag, as in \code{<html lang="en">}.
+#'   The default (NULL) results in an empty string.
 #'
 #' @return A UI defintion that can be passed to the [shinyUI] function.
 #'
@@ -87,11 +90,12 @@
 #' }
 #' @rdname fluidPage
 #' @export
-fluidPage <- function(..., title = NULL, responsive = NULL, theme = NULL) {
+fluidPage <- function(..., title = NULL, responsive = NULL, theme = NULL, lang = NULL) {
   bootstrapPage(div(class = "container-fluid", ...),
                 title = title,
                 responsive = responsive,
-                theme = theme)
+                theme = theme,
+                lang = lang)
 }
 
 
@@ -118,6 +122,9 @@ fluidRow <- function(...) {
 #' @param theme Alternative Bootstrap stylesheet (normally a css file within the
 #'   www directory). For example, to use the theme located at
 #'   `www/bootstrap.css` you would use `theme = "bootstrap.css"`.
+#' @param lang ISO 639-1 language code for the HTML page, such as "en" or "ko".
+#'   This will be used as the lang in the \code{<html>} tag, as in \code{<html lang="en">}.
+#'   The default (NULL) results in an empty string.
 #'
 #' @return A UI defintion that can be passed to the [shinyUI] function.
 #'
@@ -156,11 +163,12 @@ fluidRow <- function(...) {
 #'
 #' @rdname fixedPage
 #' @export
-fixedPage <- function(..., title = NULL, responsive = NULL, theme = NULL) {
+fixedPage <- function(..., title = NULL, responsive = NULL, theme = NULL, lang = NULL) {
   bootstrapPage(div(class = "container", ...),
                 title = title,
                 responsive = responsive,
-                theme = theme)
+                theme = theme,
+                lang = lang)
 }
 
 #' @rdname fixedPage

--- a/R/bootstrap-layout.R
+++ b/R/bootstrap-layout.R
@@ -16,9 +16,7 @@
 #' @param theme Alternative Bootstrap stylesheet (normally a css file within the
 #'   www directory). For example, to use the theme located at
 #'   `www/bootstrap.css` you would use `theme = "bootstrap.css"`.
-#' @param lang ISO 639-1 language code for the HTML page, such as "en" or "ko".
-#'   This will be used as the lang in the \code{<html>} tag, as in \code{<html lang="en">}.
-#'   The default (NULL) results in an empty string.
+#' @inheritParams bootstrapPage
 #'
 #' @return A UI defintion that can be passed to the [shinyUI] function.
 #'
@@ -122,9 +120,7 @@ fluidRow <- function(...) {
 #' @param theme Alternative Bootstrap stylesheet (normally a css file within the
 #'   www directory). For example, to use the theme located at
 #'   `www/bootstrap.css` you would use `theme = "bootstrap.css"`.
-#' @param lang ISO 639-1 language code for the HTML page, such as "en" or "ko".
-#'   This will be used as the lang in the \code{<html>} tag, as in \code{<html lang="en">}.
-#'   The default (NULL) results in an empty string.
+#' @inheritParams bootstrapPage
 #'
 #' @return A UI defintion that can be passed to the [shinyUI] function.
 #'

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -252,9 +252,7 @@ basicPage <- function(...) {
 #'   shown in the document).
 #' @param bootstrap If `TRUE`, load the Bootstrap CSS library.
 #' @param theme URL to alternative Bootstrap stylesheet.
-#' @param lang ISO 639-1 language code for the HTML page, such as "en" or "ko".
-#'   This will be used as the lang in the \code{<html>} tag, as in \code{<html lang="en">}.
-#'   The default (NULL) results in an empty string.
+#' @inheritParams bootstrapPage
 #'
 #' @family layout functions
 #'
@@ -353,9 +351,7 @@ collapseSizes <- function(padding) {
 #'   `www/bootstrap.css` you would use `theme = "bootstrap.css"`.
 #' @param windowTitle The title that should be displayed by the browser window.
 #'   Useful if `title` is not a string.
-#' @param lang ISO 639-1 language code for the HTML page, such as "en" or "ko".
-#'   This will be used as the lang in the \code{<html>} tag, as in \code{<html lang="en">}.
-#'   The default (NULL) results in an empty string.
+#' @inheritParams bootstrapPage
 #' @param icon Optional icon to appear on a `navbarMenu` tab.
 #'
 #' @return A UI defintion that can be passed to the [shinyUI] function.

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -66,7 +66,7 @@ getLang <- function(ui) {
 }
 htmlStartTag <- function(lang) {
   if (isTRUE(nzchar(lang))) {
-    return(HTML("<html lang = \"{{ lang }}\">"))
+    return(HTML(paste0("<html lang = \"", lang, "\">")))
   }
 
   HTML("<html>")

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -22,6 +22,9 @@ NULL
 #'   build of Bootstrap 3 with a customized version of Bootstrap 3 or higher.
 #'   * A character string pointing to an alternative Bootstrap stylesheet
 #'   (normally a css file within the www directory, e.g. `www/bootstrap.css`).
+#' @param lang ISO 639-1 language code for the HTML page, such as "en" or "ko".
+#'   This will be used as the lang in the \code{<html>} tag, as in \code{<html lang="en">}.
+#'   The default (NULL) results in an empty string.
 #'
 #' @return A UI defintion that can be passed to the [shinyUI] function.
 #'
@@ -30,7 +33,7 @@ NULL
 #'
 #' @seealso [fluidPage()], [fixedPage()]
 #' @export
-bootstrapPage <- function(..., title = NULL, responsive = NULL, theme = NULL) {
+bootstrapPage <- function(..., title = NULL, responsive = NULL, theme = NULL, lang = NULL) {
 
   if (!is.null(responsive)) {
     shinyDeprecated("The 'responsive' argument is no longer used with Bootstrap 3.")
@@ -46,6 +49,16 @@ bootstrapPage <- function(..., title = NULL, responsive = NULL, theme = NULL) {
     # remainder of tags passed to the function
     list(...)
   )
+
+  # Also store `lang` to be passed for rendering processor.
+  if (!is.null(lang)) {
+    if (is.character(lang) && length(lang) == 1) {
+      # Append lang attribute to be passed to renderPage function
+      attr(ui, "lang") <- lang
+    }
+  }
+
+  return(ui)
 }
 
 #' Bootstrap libraries
@@ -184,8 +197,8 @@ bootstrapSass <- function(sassInput, theme, basename, dirname = "shiny-sass-") {
 
 #' @rdname bootstrapPage
 #' @export
-basicPage <- function(...) {
-  bootstrapPage(div(class="container-fluid", list(...)))
+basicPage <- function(..., lang = NULL) {
+  bootstrapPage(div(class="container-fluid", list(...)), lang = lang)
 }
 
 
@@ -235,6 +248,9 @@ basicPage <- function(...) {
 #'   shown in the document).
 #' @param bootstrap If `TRUE`, load the Bootstrap CSS library.
 #' @param theme URL to alternative Bootstrap stylesheet.
+#' @param lang ISO 639-1 language code for the HTML page, such as "en" or "ko".
+#'   This will be used as the lang in the \code{<html>} tag, as in \code{<html lang="en">}.
+#'   The default (NULL) results in an empty string.
 #'
 #' @family layout functions
 #'
@@ -262,7 +278,7 @@ basicPage <- function(...) {
 #' )
 #' @export
 fillPage <- function(..., padding = 0, title = NULL, bootstrap = TRUE,
-  theme = NULL) {
+  theme = NULL, lang = NULL) {
 
   fillCSS <- tags$head(tags$style(type = "text/css",
     "html, body { width: 100%; height: 100%; overflow: hidden; }",
@@ -270,14 +286,24 @@ fillPage <- function(..., padding = 0, title = NULL, bootstrap = TRUE,
   ))
 
   if (isTRUE(bootstrap)) {
-    bootstrapPage(title = title, theme = theme, fillCSS, ...)
+    ui <- bootstrapPage(title = title, theme = theme, fillCSS, lang = lang, ...)
   } else {
-    tagList(
+    ui <- tagList(
       fillCSS,
       if (!is.null(title)) tags$head(tags$title(title)),
       ...
     )
+
+    # Also store `lang` to be passed for rendering processor.
+    if (!is.null(lang)) {
+      if (is.character(lang) && length(lang) == 1) {
+        # Append lang attribute to be passed to renderPage function
+        attr(ui, "lang") <- lang
+      }
+    }
   }
+
+  return(ui)
 }
 
 collapseSizes <- function(padding) {
@@ -329,6 +355,9 @@ collapseSizes <- function(padding) {
 #'   `www/bootstrap.css` you would use `theme = "bootstrap.css"`.
 #' @param windowTitle The title that should be displayed by the browser window.
 #'   Useful if `title` is not a string.
+#' @param lang ISO 639-1 language code for the HTML page, such as "en" or "ko".
+#'   This will be used as the lang in the \code{<html>} tag, as in \code{<html lang="en">}.
+#'   The default (NULL) results in an empty string.
 #' @param icon Optional icon to appear on a `navbarMenu` tab.
 #'
 #' @return A UI defintion that can be passed to the [shinyUI] function.
@@ -373,7 +402,8 @@ navbarPage <- function(title,
                        fluid = TRUE,
                        responsive = NULL,
                        theme = NULL,
-                       windowTitle = title) {
+                       windowTitle = title,
+                       lang = NULL) {
 
   if (!missing(collapsable)) {
     shinyDeprecated("`collapsable` is deprecated; use `collapsible` instead.")
@@ -444,6 +474,7 @@ navbarPage <- function(title,
     title = windowTitle,
     responsive = responsive,
     theme = theme,
+    lang = lang,
     tags$nav(class=navbarClass, role="navigation", containerDiv),
     contentDiv
   )

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -64,6 +64,12 @@ getLang <- function(ui) {
   # Check if ui has lang attribute; otherwise, NULL
   attr(ui, "lang", exact = TRUE)
 }
+htmlStartTag <- function(lang) {
+  if (isTRUE(nzchar(lang))) {
+    return(HTML("<html lang = \"{{ lang }}\">"))
+
+  HTML("<html>")
+}
 
 #' Bootstrap libraries
 #'

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -67,6 +67,7 @@ getLang <- function(ui) {
 htmlStartTag <- function(lang) {
   if (isTRUE(nzchar(lang))) {
     return(HTML("<html lang = \"{{ lang }}\">"))
+  }
 
   HTML("<html>")
 }

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -50,15 +50,19 @@ bootstrapPage <- function(..., title = NULL, responsive = NULL, theme = NULL, la
     list(...)
   )
 
-  # Also store `lang` to be passed for rendering processor.
-  if (!is.null(lang)) {
-    if (is.character(lang) && length(lang) == 1) {
-      # Append lang attribute to be passed to renderPage function
-      attr(ui, "lang") <- lang
-    }
-  }
+  ui <- setLang(ui, lang)
 
   return(ui)
+}
+
+setLang <- function(ui, lang) {
+  # Add lang attribute to be passed to renderPage function
+  attr(ui, "lang") <- lang
+  ui
+}
+getLang <- function(ui) {
+  # Check if ui has lang attribute; otherwise, NULL
+  attr(ui, "lang", exact = TRUE)
 }
 
 #' Bootstrap libraries
@@ -197,8 +201,8 @@ bootstrapSass <- function(sassInput, theme, basename, dirname = "shiny-sass-") {
 
 #' @rdname bootstrapPage
 #' @export
-basicPage <- function(..., lang = NULL) {
-  bootstrapPage(div(class="container-fluid", list(...)), lang = lang)
+basicPage <- function(...) {
+  bootstrapPage(div(class="container-fluid", list(...)))
 }
 
 
@@ -294,13 +298,7 @@ fillPage <- function(..., padding = 0, title = NULL, bootstrap = TRUE,
       ...
     )
 
-    # Also store `lang` to be passed for rendering processor.
-    if (!is.null(lang)) {
-      if (is.character(lang) && length(lang) == 1) {
-        # Append lang attribute to be passed to renderPage function
-        attr(ui, "lang") <- lang
-      }
-    }
+    ui <- setLang(ui, lang)
   }
 
   return(ui)

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -64,13 +64,6 @@ getLang <- function(ui) {
   # Check if ui has lang attribute; otherwise, NULL
   attr(ui, "lang", exact = TRUE)
 }
-htmlStartTag <- function(lang) {
-  if (isTRUE(nzchar(lang))) {
-    return(HTML(paste0("<html lang = \"", lang, "\">")))
-  }
-
-  HTML("<html>")
-}
 
 #' Bootstrap libraries
 #'

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -39,7 +39,7 @@ bootstrapPage <- function(..., title = NULL, responsive = NULL, theme = NULL, la
     shinyDeprecated("The 'responsive' argument is no longer used with Bootstrap 3.")
   }
 
-  tagList(
+  ui <- tagList(
     bootstrapLib(theme),
     if (!is.null(title)) tags$head(tags$title(title)),
     # TODO: throw better error when length > 1?

--- a/R/graph.R
+++ b/R/graph.R
@@ -87,7 +87,8 @@ reactlog <- function() {
 }
 
 #' @describeIn reactlog Display a full reactlog graph for all sessions.
-#' @inheritParams reactlog::reactlog_show
+#' @param time A boolean that specifies whether or not to display the
+#' time that each reactive takes to calculate a result.
 #' @export
 reactlogShow <- function(time = TRUE) {
   check_reactlog()

--- a/R/shinyui.R
+++ b/R/shinyui.R
@@ -41,7 +41,9 @@ renderPage <- function(ui, showcase=0, testMode=FALSE) {
     ui <- htmlTemplate(
       system.file("template", "default.html", package = "shiny"),
       lang = lang,
-      body = ui
+      body = ui,
+      # this template is a complete HTML document
+      document_ = TRUE
     )
   }
 

--- a/R/shinyui.R
+++ b/R/shinyui.R
@@ -25,6 +25,9 @@ withMathJax <- function(...) {
 }
 
 renderPage <- function(ui, showcase=0, testMode=FALSE) {
+  # Check if ui has lang attribute; otherwise, NULL
+  lang <- attr(ui, "lang", exact = TRUE)
+
   # If the ui is a NOT complete document (created by htmlTemplate()), then do some
   # preprocessing and make sure it's a complete document.
   if (!inherits(ui, "html_document")) {
@@ -38,6 +41,7 @@ renderPage <- function(ui, showcase=0, testMode=FALSE) {
     # Put the body into the default template
     ui <- htmlTemplate(
       system.file("template", "default.html", package = "shiny"),
+      lang = lang,
       body = ui
     )
   }

--- a/R/shinyui.R
+++ b/R/shinyui.R
@@ -25,8 +25,7 @@ withMathJax <- function(...) {
 }
 
 renderPage <- function(ui, showcase=0, testMode=FALSE) {
-  # Check if ui has lang attribute; otherwise, NULL
-  lang <- attr(ui, "lang", exact = TRUE)
+  lang <- getLang(ui)
 
   # If the ui is a NOT complete document (created by htmlTemplate()), then do some
   # preprocessing and make sure it's a complete document.

--- a/R/showcase.R
+++ b/R/showcase.R
@@ -220,4 +220,3 @@ showcaseUI <- function(ui) {
     showcaseBody(ui)
   )
 }
-

--- a/inst/template/default.html
+++ b/inst/template/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-{{ htmlStartTag(lang) }}
+<html{{ if (isTRUE(nzchar(lang))) paste0("lang=\"", lang, "\"") }}>
 <head>
 {{ headContent() }}
 </head>

--- a/inst/template/default.html
+++ b/inst/template/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang = "{{ lang }}">
+{{ htmlStartTag(lang) }}
 <head>
 {{ headContent() }}
 </head>

--- a/inst/template/default.html
+++ b/inst/template/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang = "{{ lang }}">
 <head>
 {{ headContent() }}
 </head>

--- a/inst/template/error.html
+++ b/inst/template/error.html
@@ -1,6 +1,6 @@
 <html>
 
-<head>
+<head lang = "en">
   <title>An error has occurred</title>
 </head>
 

--- a/man/bootstrapPage.Rd
+++ b/man/bootstrapPage.Rd
@@ -5,9 +5,9 @@
 \alias{basicPage}
 \title{Create a Bootstrap page}
 \usage{
-bootstrapPage(..., title = NULL, responsive = NULL, theme = NULL)
+bootstrapPage(..., title = NULL, responsive = NULL, theme = NULL, lang = NULL)
 
-basicPage(...)
+basicPage(..., lang = NULL)
 }
 \arguments{
 \item{...}{The contents of the document body.}
@@ -25,6 +25,10 @@ build of Bootstrap 3 with a customized version of Bootstrap 3 or higher.
 \item A character string pointing to an alternative Bootstrap stylesheet
 (normally a css file within the www directory, e.g. \code{www/bootstrap.css}).
 }}
+
+\item{lang}{ISO 639-1 language code for the HTML page, such as "en" or "ko".
+This will be used as the lang in the \code{<html>} tag, as in \code{<html lang="en">}.
+The default (NULL) results in an empty string.}
 }
 \value{
 A UI defintion that can be passed to the \link{shinyUI} function.

--- a/man/bootstrapPage.Rd
+++ b/man/bootstrapPage.Rd
@@ -7,7 +7,7 @@
 \usage{
 bootstrapPage(..., title = NULL, responsive = NULL, theme = NULL, lang = NULL)
 
-basicPage(..., lang = NULL)
+basicPage(...)
 }
 \arguments{
 \item{...}{The contents of the document body.}

--- a/man/fillPage.Rd
+++ b/man/fillPage.Rd
@@ -4,7 +4,14 @@
 \alias{fillPage}
 \title{Create a page that fills the window}
 \usage{
-fillPage(..., padding = 0, title = NULL, bootstrap = TRUE, theme = NULL)
+fillPage(
+  ...,
+  padding = 0,
+  title = NULL,
+  bootstrap = TRUE,
+  theme = NULL,
+  lang = NULL
+)
 }
 \arguments{
 \item{...}{Elements to include within the page.}
@@ -24,6 +31,10 @@ shown in the document).}
 \item{bootstrap}{If \code{TRUE}, load the Bootstrap CSS library.}
 
 \item{theme}{URL to alternative Bootstrap stylesheet.}
+
+\item{lang}{ISO 639-1 language code for the HTML page, such as "en" or "ko".
+This will be used as the lang in the \code{<html>} tag, as in \code{<html lang="en">}.
+The default (NULL) results in an empty string.}
 }
 \description{
 \code{fillPage} creates a page whose height and width always fill the

--- a/man/fixedPage.Rd
+++ b/man/fixedPage.Rd
@@ -5,7 +5,7 @@
 \alias{fixedRow}
 \title{Create a page with a fixed layout}
 \usage{
-fixedPage(..., title = NULL, responsive = NULL, theme = NULL)
+fixedPage(..., title = NULL, responsive = NULL, theme = NULL, lang = NULL)
 
 fixedRow(...)
 }
@@ -20,6 +20,10 @@ Bootstrap 3.}
 \item{theme}{Alternative Bootstrap stylesheet (normally a css file within the
 www directory). For example, to use the theme located at
 \code{www/bootstrap.css} you would use \code{theme = "bootstrap.css"}.}
+
+\item{lang}{ISO 639-1 language code for the HTML page, such as "en" or "ko".
+This will be used as the lang in the \code{<html>} tag, as in \code{<html lang="en">}.
+The default (NULL) results in an empty string.}
 }
 \value{
 A UI defintion that can be passed to the \link{shinyUI} function.

--- a/man/fluidPage.Rd
+++ b/man/fluidPage.Rd
@@ -5,7 +5,7 @@
 \alias{fluidRow}
 \title{Create a page with fluid layout}
 \usage{
-fluidPage(..., title = NULL, responsive = NULL, theme = NULL)
+fluidPage(..., title = NULL, responsive = NULL, theme = NULL, lang = NULL)
 
 fluidRow(...)
 }
@@ -21,6 +21,10 @@ Bootstrap 3.}
 \item{theme}{Alternative Bootstrap stylesheet (normally a css file within the
 www directory). For example, to use the theme located at
 \code{www/bootstrap.css} you would use \code{theme = "bootstrap.css"}.}
+
+\item{lang}{ISO 639-1 language code for the HTML page, such as "en" or "ko".
+This will be used as the lang in the \code{<html>} tag, as in \code{<html lang="en">}.
+The default (NULL) results in an empty string.}
 }
 \value{
 A UI defintion that can be passed to the \link{shinyUI} function.

--- a/man/navbarPage.Rd
+++ b/man/navbarPage.Rd
@@ -19,7 +19,8 @@ navbarPage(
   fluid = TRUE,
   responsive = NULL,
   theme = NULL,
-  windowTitle = title
+  windowTitle = title,
+  lang = NULL
 )
 
 navbarMenu(title, ..., menuName = title, icon = NULL)
@@ -76,6 +77,10 @@ www directory). For example, to use the theme located at
 
 \item{windowTitle}{The title that should be displayed by the browser window.
 Useful if \code{title} is not a string.}
+
+\item{lang}{ISO 639-1 language code for the HTML page, such as "en" or "ko".
+This will be used as the lang in the \code{<html>} tag, as in \code{<html lang="en">}.
+The default (NULL) results in an empty string.}
 
 \item{menuName}{A name that identifies this \code{navbarMenu}. This
 is needed if you want to insert/remove or show/hide an entire

--- a/tests/testthat/test-test.R
+++ b/tests/testthat/test-test.R
@@ -161,7 +161,7 @@ test_that("app template works with runTests", {
     )
   ))
 
-  lapply(combos, function(combo) {
+  for (combo in combos) {local({
     random_folder <- paste0("shinyAppTemplate-", paste0(combo, collapse = "_"))
     tempTemplateDir <- file.path(tempdir(), random_folder)
     shinyAppTemplate(tempTemplateDir, combo)
@@ -184,7 +184,6 @@ test_that("app template works with runTests", {
         runTests(tempTemplateDir)
       )
     }
-
-  })
+  })}
 
 })


### PR DESCRIPTION
Fixes #2844 
Fixes #2920

#2920 main comment:
> * Added the `lang` argument to `shinyApp()` that specifies document-level language within the app for the accessibility of screen readers and search-engine parsers.
> * Users can pass [ISO 639-1 language code](https://www.w3schools.com/tags/ref_language_codes.asp) for this argument.
> * Defaulting to `lang = ""` when no input is given by users. I was pondering the default  lang value set to either "en" or auto-locale-detect method; however, that can lead to unexpected issues. For example, many people use English R and locale while creating shiny apps in their own languages. We cannot assume only based upon users' locale which can lead to other accessibility side effects for screen readers. Thus, defaulting to empty string is a safer way.
>
> \- `@jooyoungseo`

Followup changes to #2920: 

* Removed if statements
* Assign lang unconditionally
* Removed `lang` from `basicPage()` args
* Use `@inheritParams` for `@param lang`
* Added helper method to create the `html` start tag. 
  * Avoids `<html lang="">` when lang is `NULL` or empty string.

