### PR TITLE
Add missing space for html lang

### DIFF
--- a/inst/template/default.html
+++ b/inst/template/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html{{ if (isTRUE(nzchar(lang))) paste0("lang=\"", lang, "\"") }}>
+<html{{ if (isTRUE(nzchar(lang))) paste0(" lang=\"", lang, "\"") }}>
 <head>
 {{ headContent() }}
 </head>


### PR DESCRIPTION
Followup from https://github.com/rstudio/shiny/pull/3087

Prevents `<htmllang="en">` from being produced.

Expecting `<html lang="en">`

cc @MadhulikaTanuboddi 