### PR TITLE
Add legacy R support to `registerThemeDependency()`

### DIFF
--- a/R/bookmark-state.R
+++ b/R/bookmark-state.R
@@ -79,7 +79,7 @@ saveShinySaveState <- function(state) {
 
   # Look for a save.interface function. This will be defined by the hosting
   # environment if it supports bookmarking.
-  saveInterface <- getShinyOption("save.interface")
+  saveInterface <- getShinyOption("save.interface", default = NULL)
 
   if (is.null(saveInterface)) {
     if (inShinyServer()) {
@@ -296,7 +296,7 @@ RestoreContext <- R6Class("RestoreContext",
 
       # Look for a load.interface function. This will be defined by the hosting
       # environment if it supports bookmarking.
-      loadInterface <- getShinyOption("load.interface")
+      loadInterface <- getShinyOption("load.interface", default = NULL)
 
       if (is.null(loadInterface)) {
         if (inShinyServer()) {

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -150,7 +150,7 @@ is_bs_theme <- function(x) {
 #' @keywords internal
 #' @export
 getCurrentTheme <- function() {
-  getShinyOption("bootstrapTheme")
+  getShinyOption("bootstrapTheme", default = NULL)
 }
 
 setCurrentTheme <- function(theme) {

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -188,7 +188,7 @@ registerThemeDependency <- function(func) {
 
   # Note that this will automatically scope to the app or session level,
   # depending on if this is called from within a session or not.
-  funcs <- getShinyOption("themeDependencyFuncs")
+  funcs <- getShinyOption("themeDependencyFuncs", default = list())
 
   # Don't add func if it's already present.
   have_func <- any(vapply(funcs, identical, logical(1), func))

--- a/R/render-cached-plot.R
+++ b/R/render-cached-plot.R
@@ -337,7 +337,7 @@ renderCachedPlot <- function(expr,
       return()
 
     } else if (identical(cache, "app")) {
-      cache <<- getShinyOption("cache")
+      cache <<- getShinyOption("cache", default = NULL)
 
     } else if (identical(cache, "session")) {
       cache <<- session$cache

--- a/R/runapp.R
+++ b/R/runapp.R
@@ -142,7 +142,7 @@ runApp <- function(appDir=getwd(),
   shinyOptions(appToken = createUniqueId(8))
 
   # Set up default cache for app.
-  if (is.null(getShinyOption("cache"))) {
+  if (is.null(getShinyOption("cache", default = NULL))) {
     shinyOptions(cache = MemoryCache$new())
   }
 

--- a/R/server-resource-paths.R
+++ b/R/server-resource-paths.R
@@ -80,7 +80,7 @@ addResourcePath <- function(prefix, directoryPath) {
 
   # If a shiny app is currently running, dynamically register this path with
   # the corresponding httpuv server object.
-  if (!is.null(getShinyOption("server")))
+  if (!is.null(getShinyOption("server", default = NULL)))
   {
     getShinyOption("server")$setStaticPath(.list = stats::setNames(normalizedPath, prefix))
   }

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -1289,7 +1289,7 @@ ShinySession <- R6Class(
       shinyOptions(bootstrapTheme = theme)
 
       # Call any theme dependency functions and make sure we get a list of deps back
-      funcs <- getShinyOption("themeDependencyFuncs")
+      funcs <- getShinyOption("themeDependencyFuncs", default = list())
       deps <- lapply(funcs, function(func) {
         deps <- func(theme)
         if (length(deps) == 0) return(NULL)
@@ -1471,7 +1471,7 @@ ShinySession <- R6Class(
       # Warn if trying to enable save-to-server bookmarking on a version of SS,
       # SSP, or Connect that doesn't support it.
       if (store == "server" && inShinyServer() &&
-          is.null(getShinyOption("save.interface")))
+          is.null(getShinyOption("save.interface", default = NULL)))
       {
         showNotification(
           "This app tried to enable saved-to-server bookmarking, but it is not supported by the hosting environment.",


### PR DESCRIPTION
* Also added explicit default values to all calls of `getShinyOption()`

This NOT work on R <= v3.6.3:

```r
x <- NULL
x[[length(x) + 1]] <- identity
#> Warning: Error in <-: invalid type/length (closure/0) in vector allocation
```

Original error caused by:

```r
  # depending on if this is called from within a session or not.
  funcs <- getShinyOption("themeDependencyFuncs") # NULL

  # Don't add func if it's already present.
  have_func <- any(vapply(funcs, identical, logical(1), func))
  if (!have_func) {
    funcs[[length(funcs) + 1]] <- func
  }
```

Fixed by changing line:

```r
  funcs <- getShinyOption("themeDependencyFuncs") # NULL
```