### PR TITLE
Make template test less brittle and failures more verbose

### DIFF
--- a/tests/testthat/test-test.R
+++ b/tests/testthat/test-test.R
@@ -168,8 +168,12 @@ test_that("app template works with runTests", {
     on.exit(unlink(tempTemplateDir, recursive = TRUE))
 
     if (any(c("all", "shinytest", "testthat") %in% combo)) {
+
+      ignore <- capture.output({
+        test_result <- runTests(tempTemplateDir)
+      })
       expect_output(
-        print(runTests(tempTemplateDir)),
+        print(test_result),
         paste0(
           "Shiny App Test Results\\n\\* Success",
           if (any(c("all", "shinytest") %in% combo))

--- a/tests/testthat/test-test.R
+++ b/tests/testthat/test-test.R
@@ -165,23 +165,46 @@ test_that("app template works with runTests", {
     random_folder <- paste0("shinyAppTemplate-", paste0(combo, collapse = "_"))
     tempTemplateDir <- file.path(tempdir(), random_folder)
     shinyAppTemplate(tempTemplateDir, combo)
-    on.exit(unlink(tempTemplateDir, recursive = TRUE))
+    on.exit(unlink(tempTemplateDir, recursive = TRUE), add = TRUE)
 
     if (any(c("all", "shinytest", "testthat") %in% combo)) {
 
+      # suppress all output messages
       ignore <- capture.output({
-        test_result <- runTests(tempTemplateDir)
+        # do not let an error here stop this test
+        # string comparisons will be made below
+        test_result <- try({
+          runTests(tempTemplateDir)
+        }, silent = TRUE)
       })
-      expect_output(
-        print(test_result),
-        paste0(
-          "Shiny App Test Results\\n\\* Success",
+
+      expected_test_output <- paste0(
+        c(
+          "Shiny App Test Results",
+          "* Success",
           if (any(c("all", "shinytest") %in% combo))
-            paste0("\\n  - ", file.path(random_folder, "tests", "shinytest\\.R")),
+            paste0("  - ", file.path(random_folder, "tests", "shinytest.R")),
           if (any(c("all", "testthat") %in% combo))
-            paste0("\\n  - ", file.path(random_folder, "tests", "testthat\\.R"))
-        )
+            paste0("  - ", file.path(random_folder, "tests", "testthat.R"))
+        ),
+        collapse = "\n"
       )
+
+      test_output <- paste0(
+        capture.output({
+          print(test_result)
+        }),
+        collapse = "\n"
+      )
+
+      if (identical(expected_test_output, test_output)) {
+        testthat::succeed()
+      } else {
+        # be very verbose in the error output to help find root cause of failure
+        cat("\nrunTests() output:\n", test_output, "\n\n")
+        cat("Expected print output:\n", expected_test_output, "\n")
+        testthat::fail(paste0("runTests() output for '", random_folder, "' failed. Received:\n", test_output, "\n"))
+      }
 
     } else {
       expect_error(

--- a/tools/documentation/checkPkgdown.R
+++ b/tools/documentation/checkPkgdown.R
@@ -32,7 +32,7 @@ local({
   known_unindexed <- c("shiny-package", "stacktrace", "knitr_methods",
                        "pageWithSidebar", "headerPanel", "shiny.appobj",
                        "deprecatedReactives", "reexports", "makeReactiveBinding",
-                       "reactiveConsole")
+                       "reactiveConsole", "registerThemeDependency2")
 
   ## This test ensures that every documented topic is included in
   ## staticdocs/index.r, unless explicitly waived by specifying it
@@ -42,12 +42,15 @@ local({
   unknown <- setdiff(c(known_unindexed, indexed_topics), c(all_topics, reexports_man_file_names))
 
   testthat::expect_equal(length(missing), 0,
-    info = paste("Functions missing from _pkgdown.yml:\n",
-      paste("  ", missing, sep = "", collapse = "\n"),
+    info = paste("Functions missing from ./tools/documentation/pkgdown.yaml:\n",
+      paste(" - ", missing, sep = "", collapse = "\n"),
+      "\nPlease update ./tools/documentation/pkgdown.yaml or ",
+      "`known_unindexed` in ./tools/documentation/checkPkgdown.R",
       sep = ""))
   testthat::expect_equal(length(unknown), 0,
-    info = paste("Unrecognized functions in _pkgdown.yml:\n",
-      paste("  ", unknown, sep = "", collapse = "\n"),
+    info = paste("Unrecognized functions in ./tools/documentation/pkgdown.yaml:\n",
+      paste(" - ", unknown, sep = "", collapse = "\n"),
+      "\nPlease update ./tools/documentation/pkgdown.yaml",
       sep = ""))
   invisible(TRUE)
 })

--- a/tools/documentation/checkPkgdown.R
+++ b/tools/documentation/checkPkgdown.R
@@ -32,7 +32,7 @@ local({
   known_unindexed <- c("shiny-package", "stacktrace", "knitr_methods",
                        "pageWithSidebar", "headerPanel", "shiny.appobj",
                        "deprecatedReactives", "reexports", "makeReactiveBinding",
-                       "reactiveConsole", "registerThemeDependency2")
+                       "reactiveConsole", "registerThemeDependency")
 
   ## This test ensures that every documented topic is included in
   ## staticdocs/index.r, unless explicitly waived by specifying it

--- a/tools/documentation/checkPkgdown.R
+++ b/tools/documentation/checkPkgdown.R
@@ -42,15 +42,15 @@ local({
   unknown <- setdiff(c(known_unindexed, indexed_topics), c(all_topics, reexports_man_file_names))
 
   testthat::expect_equal(length(missing), 0,
-    info = paste("Functions missing from ./tools/documentation/pkgdown.yaml:\n",
+    info = paste("Functions missing from ./tools/documentation/pkgdown.yml:\n",
       paste(" - ", missing, sep = "", collapse = "\n"),
-      "\nPlease update ./tools/documentation/pkgdown.yaml or ",
+      "\nPlease update ./tools/documentation/pkgdown.yml or ",
       "`known_unindexed` in ./tools/documentation/checkPkgdown.R",
       sep = ""))
   testthat::expect_equal(length(unknown), 0,
-    info = paste("Unrecognized functions in ./tools/documentation/pkgdown.yaml:\n",
+    info = paste("Unrecognized functions in ./tools/documentation/pkgdown.yml:\n",
       paste(" - ", unknown, sep = "", collapse = "\n"),
-      "\nPlease update ./tools/documentation/pkgdown.yaml",
+      "\nPlease update ./tools/documentation/pkgdown.yml",
       sep = ""))
   invisible(TRUE)
 })

--- a/tools/documentation/pkgdown.yml
+++ b/tools/documentation/pkgdown.yml
@@ -158,7 +158,6 @@ reference:
     desc: Functions that are intended to be called by third-party packages that extend Shiny.
     contents:
       - createWebDependency
-      - registerThemeDependency
       - resourcePaths
       - registerInputHandler
       - removeInputHandler

--- a/tools/documentation/pkgdown.yml
+++ b/tools/documentation/pkgdown.yml
@@ -158,6 +158,7 @@ reference:
     desc: Functions that are intended to be called by third-party packages that extend Shiny.
     contents:
       - createWebDependency
+      - registerThemeDependency
       - resourcePaths
       - registerInputHandler
       - removeInputHandler


### PR DESCRIPTION
* Add `registerThemeDependency()` to `"Extending Shiny"` section of docs
* Do not mix output from calling `runTests()` with the printed result of `runTests()`
	* While calling `runTests()`, output is created. The test is to only test the result of `runTests()`.