### PR TITLE
Standardise coercion to functions/reactives

### DIFF
--- a/R/reactives.R
+++ b/R/reactives.R
@@ -1689,11 +1689,20 @@ invalidateLater <- function(millis, session = getDefaultReactiveDomain()) {
 }
 
 coerceToFunc <- function(x) {
-  force(x);
-  if (is.function(x))
-    return(x)
-  else
-    return(function() x)
+  if (is.function(x)) {
+    x
+  } else {
+    function() x
+  }
+}
+coerceToReactive <- function(x) {
+  if (is.reactive(x)) {
+    x
+  } else if (is.function(x)) {
+    reactive(x())
+  } else {
+    function() x
+  }
 }
 
 #' Reactive polling

--- a/R/render-cached-plot.R
+++ b/R/render-cached-plot.R
@@ -351,13 +351,8 @@ renderCachedPlot <- function(expr,
   # values get filled by an observer below.
   fitDims <- reactiveValues(width = NULL, height = NULL)
 
-  # Make sure alt param to be reactive function
-  if (is.reactive(alt))
-    altWrapper <- alt
-  else if (is.function(alt))
-    altWrapper <- reactive({ alt() })
-  else
-    altWrapper <- function() { alt }
+  # Allow alt param to be reactive function
+  altWrapper <- coerceToReactive(alt)
 
   resizeObserver <- NULL
   ensureResizeObserver <- function() {

--- a/R/render-plot.R
+++ b/R/render-plot.R
@@ -68,26 +68,9 @@ renderPlot <- function(expr, width = 'auto', height = 'auto', res = 72, ...,
 
   args <- list(...)
 
-  if (is.reactive(width))
-    widthWrapper <- width
-  else if (is.function(width))
-    widthWrapper <- reactive({ width() })
-  else
-    widthWrapper <- function() { width }
-
-  if (is.reactive(height))
-    heightWrapper <- height
-  else if (is.function(height))
-    heightWrapper <- reactive({ height() })
-  else
-    heightWrapper <- function() { height }
-
-  if (is.reactive(alt))
-    altWrapper <- alt
-  else if (is.function(alt))
-    altWrapper <- reactive({ alt() })
-  else
-    altWrapper <- function() { alt }
+  widthWrapper <- coerceToReactive(width)
+  heightWrapper <- coerceToReactive(height)
+  altWrapper <- coerceToReactive(alt)
 
   getDims <- function() {
     width <- widthWrapper()

--- a/R/render-table.R
+++ b/R/render-table.R
@@ -58,26 +58,18 @@ renderTable <- function(expr, striped = FALSE, hover = FALSE,
 
   if (!is.function(spacing)) spacing <- match.arg(spacing)
 
-  # A small helper function to create a wrapper for an argument that was
-  # passed to renderTable()
-  createWrapper <- function(arg) {
-    if (is.function(arg)) wrapper <- arg
-    else wrapper <- function() arg
-    return(wrapper)
-  }
-
   # Create wrappers for most arguments so that functions can also be passed
   # in, rather than only literals (useful for shiny apps)
-  stripedWrapper <- createWrapper(striped)
-  hoverWrapper <- createWrapper(hover)
-  borderedWrapper <- createWrapper(bordered)
-  spacingWrapper <- createWrapper(spacing)
-  widthWrapper <- createWrapper(width)
-  alignWrapper <- createWrapper(align)
-  rownamesWrapper <- createWrapper(rownames)
-  colnamesWrapper <- createWrapper(colnames)
-  digitsWrapper <- createWrapper(digits)
-  naWrapper <- createWrapper(na)
+  stripedWrapper <- coerceToFunc(striped)
+  hoverWrapper <- coerceToFunc(hover)
+  borderedWrapper <- coerceToFunc(bordered)
+  spacingWrapper <- coerceToFunc(spacing)
+  widthWrapper <- coerceToFunc(width)
+  alignWrapper <- coerceToFunc(align)
+  rownamesWrapper <- coerceToFunc(rownames)
+  colnamesWrapper <- coerceToFunc(colnames)
+  digitsWrapper <- coerceToFunc(digits)
+  naWrapper <- coerceToFunc(na)
 
   dots <- list(...)  ## used later (but defined here because of scoping)
 


### PR DESCRIPTION
Currently renderPlot() also handles reactives specially, so it is inconsistent with `renderTable()`. This isn't documented, so I suspect it might be ok to use coerceToFunc() instead, but it would be a breaking change.