### PR TITLE
Allow to create customMessageHandler without argument

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -1337,7 +1337,7 @@ ShinySession <- R6Class(
       }
       private$write(c(as.raw(length(typeBytes)), typeBytes, message))
     },
-    sendCustomMessage = function(type, message) {
+    sendCustomMessage = function(type, message = TRUE) {
       data <- list()
       data[[type]] <- message
       private$sendMessage(custom = data)

--- a/srcjs/shinyapp.js
+++ b/srcjs/shinyapp.js
@@ -476,9 +476,9 @@ var ShinyApp = function() {
     if (typeof(handler) !== 'function') {
       throw('handler must be a function.');
     }
-    if (handler.length !== 1) {
-      throw('handler must be a function that takes one argument.');
-    }
+    //if (handler.length !== 1) {
+    //  throw('handler must be a function that takes one argument.');
+    //}
 
     customMessageHandlerOrder.push(type);
     customMessageHandlers[type] = handler;


### PR DESCRIPTION
This PR addresses the issue #2604, and allows to create customMessageHandler() functions that do not take any argument.

```r
system("cd tools && yarn build")
pkgload::load_all()
ui <- function(request){
  tagList(
    tags$script(
      "$( document ).ready(function() {",
      "  Shiny.addCustomMessageHandler('alerthis', function() {",
      "    alert('this and that')",
      "  })",
      "});"
    ),
    actionButton("go", "Go")
  )
}
server <- function(
  input,
  output,
  session
){
  observeEvent( input$go , {
    session$sendCustomMessage("alerthis")
  })
}
shinyApp(ui, server)
```