### PR TITLE
Fix use of shinyOptions in modules

### DIFF
--- a/R/modules.R
+++ b/R/modules.R
@@ -31,6 +31,14 @@ createSessionProxy <- function(parentSession, ...) {
   # but not `session$userData <- TRUE`) from within a module
   # without any hacks (see PR #1732)
   if (identical(x[[name]], value)) return(x)
+
+  # Special case for $options (issue #3112)
+  if (name == "options") {
+    parent <- .subset2(x, "parent")
+    parent[[name]] <- value
+    return(x)
+  }
+
   stop("Attempted to assign value on session proxy.")
 }
 

--- a/R/modules.R
+++ b/R/modules.R
@@ -34,8 +34,8 @@ createSessionProxy <- function(parentSession, ...) {
 
   # Special case for $options (issue #3112)
   if (name == "options") {
-    parent <- .subset2(x, "parent")
-    parent[[name]] <- value
+    session <- find_ancestor_session(x)
+    session[[name]] <- value
     return(x)
   }
 
@@ -43,6 +43,23 @@ createSessionProxy <- function(parentSession, ...) {
 }
 
 `[[<-.session_proxy` <- `$<-.session_proxy`
+
+# Given a session_proxy, search `parent` recursively to find the real
+# ShinySession object. If given a ShinySession, simply return it.
+find_ancestor_session <- function(x, depth = 5) {
+  if (depth < 0) {
+    stop("ShinySession not found")
+  }
+  if (inherits(x, "ShinySession")) {
+    return(x)
+  }
+  if (inherits(x, "session_proxy")) {
+    return(find_ancestor_session(.subset2(x, "parent"), depth-1))
+  }
+
+  stop("ShinySession not found")
+}
+
 
 #' Shiny modules
 #'

--- a/R/modules.R
+++ b/R/modules.R
@@ -46,7 +46,7 @@ createSessionProxy <- function(parentSession, ...) {
 
 # Given a session_proxy, search `parent` recursively to find the real
 # ShinySession object. If given a ShinySession, simply return it.
-find_ancestor_session <- function(x, depth = 5) {
+find_ancestor_session <- function(x, depth = 20) {
   if (depth < 0) {
     stop("ShinySession not found")
   }


### PR DESCRIPTION
Closes #3112.

The test app below should show "This is my_option" and "This is my_option_nested" in the text boxes.



```R
library(shiny)

my_ui <- function(id) {
  ns <- NS(id)
  verbatimTextOutput(ns("txt"), placeholder = TRUE)
}

my_server <- function(id, nested = FALSE) {
  moduleServer(id, function(input, output, session) {
    if (nested) {
      str(getCurrentOutputInfo())
      shinyOptions("my_option_nested" = "This is my_option_nested")
      output$txt <- renderText(getShinyOption("my_option_nested"))
    } else {
      shinyOptions("my_option" = "This is my_option")
      output$txt <- renderText(getShinyOption("my_option"))
    }
  })
}


my_ui_nested <- function(id) {
  ns <- NS(id)
  my_ui(ns(id))
}
my_server_nested <- function(id) {
  moduleServer(id, function(input, output, session) {
    my_server(id, TRUE)
  })
}

shinyApp(
  fluidPage(
    my_ui("one"),
    my_ui_nested("two")
  ),
  function(input, output, session) {
    my_server("one")
    my_server_nested("two")
  }
)
```


Note: test app has been added in https://github.com/rstudio/shinycoreci-apps/pull/81