### PR TITLE
Warn when running in a package directory

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -54,6 +54,8 @@ shiny 1.5.0.9000
 
 * `shinyOptions()` now has session-level scoping, in addition to global and application-level scoping. (#3080)
 
+* `runApp()` now warns when running an application in an R package directory. (#3114)
+
 ### Bug fixes
 
 * Fixed #2859: `renderPlot()` wasn't correctly setting `showtext::showtext_opts()`'s `dpi` setting with the correct resolution on high resolution displays; which means, if the font was rendered by showtext, font sizes would look smaller than they should on such displays. (#2941)

--- a/R/shinyapp.R
+++ b/R/shinyapp.R
@@ -345,6 +345,17 @@ loadSupport <- function(appDir=NULL, renv=new.env(parent=globalenv()), globalren
     appDir <- findEnclosingApp(".")
   }
 
+  descFile <- file.path.ci(appDir, "DESCRIPTION")
+  if (file.exists(descFile) &&
+      identical(as.character(read.dcf(descFile, fields = "Type")), "Package"))
+  {
+    warning(
+      "Loading R/ subdirectory for Shiny application, but the DESCRIPTION file ",
+      "says this directory contains an R package. Sourcing files in R/ may cause ",
+      "unexpected behavior."
+    )
+  }
+
   if (!is.null(globalrenv)){
     # Evaluate global.R, if it exists.
     globalPath <- file.path.ci(appDir, "global.R")

--- a/R/shinyapp.R
+++ b/R/shinyapp.R
@@ -346,13 +346,13 @@ loadSupport <- function(appDir=NULL, renv=new.env(parent=globalenv()), globalren
   }
 
   descFile <- file.path.ci(appDir, "DESCRIPTION")
-  if (file.exists(descFile) &&
-      identical(as.character(read.dcf(descFile, fields = "Type")), "Package"))
+  if (file.exists(file.path.ci(appDir, "NAMESPACE")) ||
+      (file.exists(descFile) &&
+       identical(as.character(read.dcf(descFile, fields = "Type")), "Package")))
   {
     warning(
-      "Loading R/ subdirectory for Shiny application, but the DESCRIPTION file ",
-      "says this directory contains an R package. Sourcing files in R/ may cause ",
-      "unexpected behavior."
+      "Loading R/ subdirectory for Shiny application, but this directory appears ",
+      "to contain an R package. Sourcing files in R/ may cause unexpected behavior."
     )
   }
 


### PR DESCRIPTION
I've tested this with a DESCRIPTION file that has `Type: Package`, and a DESCRIPTION file without that. It warns in the first case, and not in the second.