### PR TITLE
Add reactive `session$getCurrentTheme()`

### DIFF
--- a/R/mock-session.R
+++ b/R/mock-session.R
@@ -156,6 +156,7 @@ makeExtraMethods <- function() {
     "sendInsertUI",
     "sendModal",
     "setCurrentTheme",
+    "getCurrentTheme",
     "sendNotification",
     "sendProgress",
     "sendRemoveTab",

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -277,6 +277,18 @@ workerId <- local({
 #'   character vector, as in `input=c("x", "y")`. The format can be
 #'   "rds" or "json".
 #' }
+#' \item{setCurrentTheme(theme)}{
+#'   Sets the current [bootstrapLib()] theme, which updates the value of
+#'   [getCurrentTheme()], invalidates `session$getCurrentTheme()`, and calls
+#'   function(s) registered with [registerThemeDependency()] with provided
+#'   `theme`. If those function calls return [htmltools::htmlDependency()]s with
+#'   `stylesheet`s, then those stylesheets are "refreshed" (i.e., the new
+#'   stylesheets are inserted on the page and the old ones are disabled and
+#'   removed).
+#' }
+#' \item{getCurrentTheme()}{
+#'   A reactive read of the current [bootstrapLib()] theme.
+#' }
 #'
 #' @name session
 NULL

--- a/man/session.Rd
+++ b/man/session.Rd
@@ -171,6 +171,18 @@ possible to specify by name which values to return by providing a
 character vector, as in \code{input=c("x", "y")}. The format can be
 "rds" or "json".
 }
+\item{setCurrentTheme(theme)}{
+Sets the current \code{\link[=bootstrapLib]{bootstrapLib()}} theme, which updates the value of
+\code{\link[=getCurrentTheme]{getCurrentTheme()}}, invalidates \code{session$getCurrentTheme()}, and calls
+function(s) registered with \code{\link[=registerThemeDependency]{registerThemeDependency()}} with provided
+\code{theme}. If those function calls return \code{\link[htmltools:htmlDependency]{htmltools::htmlDependency()}}s with
+\code{stylesheet}s, then those stylesheets are "refreshed" (i.e., the new
+stylesheets are inserted on the page and the old ones are disabled and
+removed).
+}
+\item{getCurrentTheme()}{
+A reactive read of the current \code{\link[=bootstrapLib]{bootstrapLib()}} theme.
+}
 }
 \description{
 Shiny server functions can optionally include \code{session} as a parameter


### PR DESCRIPTION
This adds a method `session$getCurrentTheme()`, which is reactive and returns the current theme for the session.

We may want to tweak the interface, but this works.


```R
remotes::install_github('rstudio/shiny@wch-reactive-theme')
```


Demo app:

```R
library(shiny)
library(bootstraplib)

shinyApp(
  ui = fluidPage(
    theme = bs_theme(bootswatch = "darkly"),
    selectInput("theme", "Select theme", choices = c("darkly", "sketchy", "solar", "lux")),
    numericInput("n", "n", 1),
    sliderInput("slider", "Slider Input", 1, 10, 5),
    p("This is some text"),
    br(),
    verbatimTextOutput("theme_info")
  ),
  server = function(input, output, session) {
    observe({
      theme <- bs_theme(bootswatch = input$theme)
      session$setCurrentTheme(theme)
    })
    
    output$theme_info <- renderPrint({
      print(Sys.time())
      session$getCurrentTheme()
    })
  }
)
```