### PR TITLE
remove_source: safely handle quosures

### DIFF
--- a/R/utils-lang.R
+++ b/R/utils-lang.R
@@ -51,6 +51,10 @@ remove_source <- function(x) {
   if (is.function(x)) {
     body(x) <- remove_source(body(x))
     x
+
+  } else if (is_quosure(x)) {
+    rlang::quo_set_expr(x, remove_source(rlang::quo_get_expr(x)))
+
   } else if (is.call(x)) {
     attr(x, "srcref") <- NULL
     attr(x, "wholeSrcref") <- NULL
@@ -65,6 +69,7 @@ remove_source <- function(x) {
 
     x[] <- lapply(x, remove_source)
     x
+
   } else {
     x
   }


### PR DESCRIPTION
This handles the following warning which could be seen when running unit tests:

```
Warning (test-reactivity.r:705:3): reactive() accepts injected quosures
Subsetting quosures with `[[` is deprecated as of rlang 0.4.0
Please use `quo_get_expr()` instead.
This warning is displayed once per session.
Backtrace:
  1. shiny::inject(reactive(!!exp)) test-reactivity.r:705:2
  3. shiny::reactive(a + 10)
  5. shiny::remove_source(get_expr(x))
  6. base::lapply(x, remove_source) /Users/barret/Documents/git/rstudio/shiny/shiny.nosync/R/utils-lang.R:78:4
  7. shiny:::FUN(X[[i]], ...)
  9. rlang:::`[[.quosure`(x, 1) /Users/barret/Documents/git/rstudio/shiny/shiny.nosync/R/utils-lang.R:73:4
 10. rlang:::signal_soft_deprecated(...)
 11. rlang:::warn_deprecated(msg, id)
 12. base:::.Signal(msg = msg)
```

For reference: https://github.com/r-lib/testthat/issues/1228#issuecomment-730697573
