### PR TITLE
Fix labels with bindEvent() 

### DIFF
--- a/R/bind-event.R
+++ b/R/bind-event.R
@@ -183,14 +183,14 @@ bindEvent.reactiveExpr <- function(x, ..., ignoreNULL = TRUE, ignoreInit = FALSE
 {
   domain <- reactive_get_domain(x)
 
-  eventFunc <- quos_to_func(enquos0(...))
+  qs <- enquos0(...)
+  eventFunc <- quos_to_func(qs)
 
   valueFunc <- reactive_get_value_func(x)
   valueFunc <- wrapFunctionLabel(valueFunc, "eventReactiveValueFunc", ..stacktraceon = TRUE)
 
-  if (is.null(label)) {
-    label <- sprintf("eventReactive(%s)", paste(deparse(body(eventFunc)), collapse = "\n"))
-  }
+  label <- label %OR%
+    sprintf('bindEvent(%s, %s)', attr(x, "observable", exact = TRUE)$.label, quos_to_label(qs))
 
   # Don't hold on to the reference for x, so that it can be GC'd
   rm(x)
@@ -256,10 +256,13 @@ bindEvent.Observer <- function(x, ..., ignoreNULL = TRUE, ignoreInit = FALSE,
     stop("Cannot call bindEvent() on an Observer that has already been executed.")
   }
 
-  eventFunc <- quos_to_func(enquos0(...))
+  qs <- enquos0(...)
+  eventFunc <- quos_to_func(qs)
   valueFunc <- x$.func
 
-  x$.label <- label %OR% sprintf('bindEvent(%s)', x$.label)
+  # Note that because the observer will already have been logged by this point,
+  # this updated label won't show up in the reactlog.
+  x$.label <- label %OR% sprintf('bindEvent(%s, %s)', x$.label, quos_to_label(qs))
 
   initialized <- FALSE
 

--- a/R/reactives.R
+++ b/R/reactives.R
@@ -2284,11 +2284,16 @@ eventReactive <- function(eventExpr, valueExpr,
   eventExpr <- get_quosure(eventExpr, event.env, event.quoted)
   valueExpr <- get_quosure(valueExpr, value.env, value.quoted)
 
+  if (is.null(label)) {
+    label <- sprintf('eventReactive(%s)', paste(deparse(get_expr(eventExpr)), collapse='\n'))
+  }
+
   invisible(inject(bindEvent(
     ignoreNULL = ignoreNULL,
     ignoreInit = ignoreInit,
+    label = label,
     !!eventExpr,
-    x = reactive(!!valueExpr, domain = domain, label = "eventReactiveHandler")
+    x = reactive(!!valueExpr, domain = domain, label = label)
   )))
 }
 

--- a/R/reactives.R
+++ b/R/reactives.R
@@ -2244,9 +2244,13 @@ observeEvent <- function(eventExpr, handlerExpr,
   eventExpr   <- get_quosure(eventExpr,   event.env,   event.quoted)
   handlerExpr <- get_quosure(handlerExpr, handler.env, handler.quoted)
 
+  if (is.null(label)) {
+    label <- sprintf('observeEvent(%s)', paste(deparse(get_expr(eventExpr)), collapse='\n'))
+  }
+
   handler <- inject(observe(
     !!handlerExpr,
-    label = "observeEventHandler",
+    label = label,
     suspended = suspended,
     priority = priority,
     domain = domain,

--- a/R/utils-lang.R
+++ b/R/utils-lang.R
@@ -24,6 +24,19 @@ quos_to_func <- function(qs) {
   }
 }
 
+# Given a list of quosures, return a string representation of the expressions.
+#
+# qs <- list(quo(a+1), quo({ b+2; b + 3 }))
+# quos_to_label(qs)
+# #> [1] "a + 1, {\n    b + 2\n    b + 3\n}"
+quos_to_label <- function(qs) {
+  res <- lapply(qs, function(q) {
+    paste(deparse(get_expr(q)), collapse = "\n")
+  })
+
+  paste(res, collapse = ", ")
+}
+
 # Get the formals and body for a function, without source refs. This is used for
 # consistent hashing of the function.
 formalsAndBody <- function(x) {

--- a/man/bindEvent.Rd
+++ b/man/bindEvent.Rd
@@ -147,9 +147,8 @@ render functions.
 When \code{bindEvent()} is used with \code{reactive()}, it creates a new reactive
 expression object.
 
-When \code{bindEvent()} is used with \code{observe()}, it creates a new observer and
-calls the \verb{$destroy()} method on the original observer, so that the
-original observer will not execute.
+When \code{bindEvent()} is used with \code{observe()}, it alters the observer in
+place. It can only be used with observers which have not yet executed.
 }
 
 \section{Combining events and caching}{

--- a/tests/testthat/test-bind-event.R
+++ b/tests/testthat/test-bind-event.R
@@ -33,20 +33,16 @@ test_that("bindEvent and observers", {
 })
 
 
-test_that("bindEvent does not prevent observers from being GC'd", {
+test_that("bindEvent alters observers in place", {
   v <- reactiveVal(1)
-  o <- observe({ message(v()) })
-
-  finalized <- FALSE
-  reg.finalizer(o, function(e) { finalized <<- TRUE })
-
-  # o1 shouldn't keep a reference to o (and prevent it from getting GC'd).
+  o <- observe({ v() })
   o1 <- bindEvent(o, v())
-  rm(o)
 
-  flushReact()
-  gc()
-  expect_true(finalized)
+  # o and o1 are the same object
+  expect_identical(o, o1)
+
+  # Can't call bindEvent twice on an observer
+  expect_error(bindEvent(o, v()))
 })
 
 


### PR DESCRIPTION
This is for https://github.com/rstudio/shinycoreci-apps/issues/83.

The reactive graph now looks like this:
![image](https://user-images.githubusercontent.com/86978/99853250-3e6e7c80-2b48-11eb-9b37-cfac146baff7.png)

Note that the new `private$currentThemeDependency` node was introduced by #3116, and is expected. 

This also changes the behavior of `observe() %>% bindEvent()` so that the original observer is modified in place.
