### PR TITLE
Add cacheWriteHook and cacheReadHook

### DIFF
--- a/R/bind-cache.R
+++ b/R/bind-cache.R
@@ -473,9 +473,6 @@ bindCache.reactiveExpr <- function(x, ..., cache = "app") {
   cacheHint <- digest(extractCacheHint(x), algo = "spookyhash")
   valueFunc <- wrapFunctionLabel(valueFunc, "cachedReactiveValueFunc", ..stacktraceon = TRUE)
 
-  cacheWriteHook <- attr(x, "cacheWriteHook", exact = TRUE) %||% identity
-  cacheReadHook  <- attr(x, "cacheReadHook",  exact = TRUE) %||% identity
-
   # Don't hold on to the reference for x, so that it can be GC'd
   rm(x)
   # Hacky workaround for issue with `%>%` preventing GC:
@@ -489,7 +486,7 @@ bindCache.reactiveExpr <- function(x, ..., cache = "app") {
     cache <- resolve_cache_object(cache, domain)
     hybrid_chain(
       keyFunc(),
-      generateCacheFun(valueFunc, cache, cacheHint, cacheReadHook, cacheWriteHook)
+      generateCacheFun(valueFunc, cache, cacheHint, cacheReadHook = identity, cacheWriteHook = identity)
     )
   })
 

--- a/R/bind-cache.R
+++ b/R/bind-cache.R
@@ -492,18 +492,20 @@ bindCache.reactiveExpr <- function(x, ..., cache = "app") {
 
         # Case 1: cache hit
         if (!is.key_missing(res)) {
-          if (res$is_promise) {
-            if (res$error) {
-              return(promise_reject(valueWithVisible(res)))
+          return(hybrid_chain(
+            {
+              # The first step is just to convert `res` to a promise or not, so
+              # that hybrid_chain() knows to propagate the promise-ness.
+              if (res$is_promise) promise_resolve(res)
+              else                res
+            },
+            function(res) {
+              if (res$error) {
+                stop(res$value)
+              }
+              valueWithVisible(res)
             }
-            return(promise_resolve(valueWithVisible(res)))
-
-          } else {
-            if (res$error) {
-              stop(res$value)
-            }
-            return(valueWithVisible(res))
-          }
+          ))
         }
 
         # Case 2: cache miss
@@ -591,18 +593,20 @@ bindCache.shiny.render.function <- function(x, ..., cache = "app") {
 
         # Case 1: cache hit
         if (!is.key_missing(res)) {
-          if (res$is_promise) {
-            if (res$error) {
-              return(promise_reject(valueWithVisible(res)))
+          return(hybrid_chain(
+            {
+              # The first step is just to convert `res` to a promise or not, so
+              # that hybrid_chain() knows to propagate the promise-ness.
+              if (res$is_promise) promise_resolve(res)
+              else                res
+            },
+            function(res) {
+              if (res$error) {
+                stop(res$value)
+              }
+              valueWithVisible(res)
             }
-            return(promise_resolve(valueWithVisible(res)))
-
-          } else {
-            if (res$error) {
-              stop(res$value)
-            }
-            return(valueWithVisible(res))
-          }
+          ))
         }
 
         # Case 2: cache miss

--- a/R/image-interact.R
+++ b/R/image-interact.R
@@ -97,10 +97,10 @@ brushedPoints <- function(df, brush, xvar = NULL, yvar = NULL,
   # the NULL replacement are here just to ease the transition in case anyone is
   # using NA. We can remove these checks in a future version of Shiny.
   # https://github.com/rstudio/shiny/pull/3172
-  if (is.na(xvar))      { xvar      <- NULL; warning("xvar should be NULL, not NA.") }
-  if (is.na(yvar))      { yvar      <- NULL; warning("yvar should be NULL, not NA.") }
-  if (is.na(panelvar1)) { panelvar1 <- NULL; warning("panelvar1 should be NULL, not NA.") }
-  if (is.na(panelvar2)) { panelvar2 <- NULL; warning("panelvar2 should be NULL, not NA.") }
+  if (is_na(xvar))      { xvar      <- NULL; warning("xvar should be NULL, not NA.") }
+  if (is_na(yvar))      { yvar      <- NULL; warning("yvar should be NULL, not NA.") }
+  if (is_na(panelvar1)) { panelvar1 <- NULL; warning("panelvar1 should be NULL, not NA.") }
+  if (is_na(panelvar2)) { panelvar2 <- NULL; warning("panelvar2 should be NULL, not NA.") }
 
   # Try to extract vars from brush object
   xvar      <- xvar      %||% brush$mapping$x
@@ -245,10 +245,10 @@ nearPoints <- function(df, coordinfo, xvar = NULL, yvar = NULL,
   # the NULL replacement are here just to ease the transition in case anyone is
   # using NA. We can remove these checks in a future version of Shiny.
   # https://github.com/rstudio/shiny/pull/3172
-  if (is.na(xvar))      { xvar      <- NULL; warning("xvar should be NULL, not NA.") }
-  if (is.na(yvar))      { yvar      <- NULL; warning("yvar should be NULL, not NA.") }
-  if (is.na(panelvar1)) { panelvar1 <- NULL; warning("panelvar1 should be NULL, not NA.") }
-  if (is.na(panelvar2)) { panelvar2 <- NULL; warning("panelvar2 should be NULL, not NA.") }
+  if (is_na(xvar))      { xvar      <- NULL; warning("xvar should be NULL, not NA.") }
+  if (is_na(yvar))      { yvar      <- NULL; warning("yvar should be NULL, not NA.") }
+  if (is_na(panelvar1)) { panelvar1 <- NULL; warning("panelvar1 should be NULL, not NA.") }
+  if (is_na(panelvar2)) { panelvar2 <- NULL; warning("panelvar2 should be NULL, not NA.") }
 
   # Try to extract vars from coordinfo object
   xvar      <- xvar      %||% coordinfo$mapping$x

--- a/man/createRenderFunction.Rd
+++ b/man/createRenderFunction.Rd
@@ -9,7 +9,9 @@ createRenderFunction(
   transform = function(value, session, name, ...) value,
   outputFunc = NULL,
   outputArgs = NULL,
-  cacheHint = "auto"
+  cacheHint = "auto",
+  cacheWriteHook = NULL,
+  cacheReadHook = NULL
 )
 }
 \arguments{
@@ -39,6 +41,20 @@ identify this instance for caching using \code{\link[=bindCache]{bindCache()}}. 
 will try to automatically infer caching information. If \code{FALSE}, do not
 allow caching for the object. Some render functions (such as \link{renderPlot})
 contain internal state that makes them unsuitable for caching.}
+
+\item{cacheWriteHook}{Used if the render function is passed to \code{bindCache()}.
+This is an optional callback function to invoke before saving the value
+from the render function to the cache. This function must accept one
+argument, the value returned from \code{renderFunc}, and should return the value
+to store in the cache.}
+
+\item{cacheReadHook}{Used if the render function is passed to \code{bindCache()}.
+This is an optional callback function to invoke after reading a value from
+the cache (if there is a cache hit). The function will be passed one
+argument, the value retrieved from the cache. This can be useful when some
+side effect needs to occur for a render function to behave correctly. For
+example, some render functions call \code{\link[=createWebDependency]{createWebDependency()}} so that Shiny
+is able to serve JS and CSS resources.}
 }
 \value{
 An annotated render function, ready to be assigned to an

--- a/man/markRenderFunction.Rd
+++ b/man/markRenderFunction.Rd
@@ -4,7 +4,14 @@
 \alias{markRenderFunction}
 \title{Mark a function as a render function}
 \usage{
-markRenderFunction(uiFunc, renderFunc, outputArgs = list(), cacheHint = "auto")
+markRenderFunction(
+  uiFunc,
+  renderFunc,
+  outputArgs = list(),
+  cacheHint = "auto",
+  cacheWriteHook = NULL,
+  cacheReadHook = NULL
+)
 }
 \arguments{
 \item{uiFunc}{A function that renders Shiny UI. Must take a single argument:
@@ -25,6 +32,20 @@ identify this instance for caching using \code{\link[=bindCache]{bindCache()}}. 
 will try to automatically infer caching information. If \code{FALSE}, do not
 allow caching for the object. Some render functions (such as \link{renderPlot})
 contain internal state that makes them unsuitable for caching.}
+
+\item{cacheWriteHook}{Used if the render function is passed to \code{bindCache()}.
+This is an optional callback function to invoke before saving the value
+from the render function to the cache. This function must accept one
+argument, the value returned from \code{renderFunc}, and should return the value
+to store in the cache.}
+
+\item{cacheReadHook}{Used if the render function is passed to \code{bindCache()}.
+This is an optional callback function to invoke after reading a value from
+the cache (if there is a cache hit). The function will be passed one
+argument, the value retrieved from the cache. This can be useful when some
+side effect needs to occur for a render function to behave correctly. For
+example, some render functions call \code{\link[=createWebDependency]{createWebDependency()}} so that Shiny
+is able to serve JS and CSS resources.}
 }
 \value{
 The \code{renderFunc} function, with annotations.

--- a/tests/testthat/test-bind-cache.R
+++ b/tests/testthat/test-bind-cache.R
@@ -313,7 +313,7 @@ test_that("bindCache reactives with async value", {
   k(0)
   flushReact()
   expect_identical(vals, c("0k"))
-  later::run_now()
+  for (i in 1:2) later::run_now()
   expect_identical(vals, c("0k", "0o"))
 })
 

--- a/tests/testthat/test-bind-cache.R
+++ b/tests/testthat/test-bind-cache.R
@@ -193,56 +193,6 @@ test_that("bindCache reactive - value is isolated", {
 })
 
 
-
-test_that("cacheWriteHook and cacheReadHook for reactives", {
-  write_hook_n <- 0
-  read_hook_n  <- 0
-  n <- 0
-  v <- reactiveVal(1)
-
-  r <- reactive({ n <<- n+1; v() })
-  attr(r, "cacheWriteHook") <- function(value) {
-    write_hook_n <<- write_hook_n + 1
-    paste0(value, ",w")
-  }
-  attr(r, "cacheReadHook") <- function(value) {
-    read_hook_n <<- read_hook_n + 1
-    paste0(value, ",r")
-  }
-  r <- r %>% bindCache(v(), cache = cachem::cache_mem())
-
-  vals <<- character()
-  o <- observe({
-    vals <<- r()
-  })
-
-  # Writing to cache
-  flushReact()
-  expect_identical(vals, 1)
-  expect_identical(write_hook_n, 1)
-  expect_identical(read_hook_n, 0)
-
-  v(2)
-  flushReact()
-  expect_identical(vals, 2)
-  expect_identical(write_hook_n, 2)
-  expect_identical(read_hook_n, 0)
-
-  # Reading from cache
-  v(1)
-  flushReact()
-  expect_identical(vals, "1,w,r")
-  expect_identical(write_hook_n, 2)
-  expect_identical(read_hook_n, 1)
-
-  v(2)
-  flushReact()
-  expect_identical(vals, "2,w,r")
-  expect_identical(write_hook_n, 2)
-  expect_identical(read_hook_n, 2)
-})
-
-
 # ============================================================================
 # Async key
 # ============================================================================


### PR DESCRIPTION
This adds support for `cacheWriteHook` and `cacheReadHook` for the objects passed to `bindCache()`. The purpose is to solve issues like https://github.com/ramnathv/htmlwidgets/issues/396.

The `cacheWriteHook` can modify values before the stored in the cache, and the `cacheReadHook` can modify values after they're retrieved from the cache, but before they're sent to the browser. These functions can also be used for side effects, as is done in https://github.com/ramnathv/htmlwidgets/pull/397, where it calls `createWebDependency()`.

Note that `bindCache.reactive` also adds support for these hooks, although there currently isn't a simple way to add the hooks to a `reactive()`. One would need to specifically add them as attributes to a reactive. I wonder if the `bindCache()` function itself should also allow users to pass in hooks like this -- currently, the author of a render function (not the end user) is the one who would provide these hooks.

This PR is made against the `wch-cache-read-hook` branch, because it uses changes from there, and because including that branch's changes would result in a lot of spurious changes shown in this PR. If/when we merge that PR (or if we don't), this branch can be retargeted against master.