### PR TITLE
Do correct assignment of resizeObserverCreated

### DIFF
--- a/R/bind-cache.R
+++ b/R/bind-cache.R
@@ -574,7 +574,7 @@ bindCache.shiny.renderPlot <- function(x, ...,
     # session ends. This is generally bad programming practice and should be
     # rare, but still, we should try to clean up properly.
 
-    resizeObserverCreated <- TRUE
+    resizeObserverCreated <<- TRUE
   }
 
   renderFunc <- function(...) {


### PR DESCRIPTION
This fixes one part of https://github.com/rstudio/shinycoreci-apps/issues/83#issuecomment-737320167 : the spurious `observe({ doResizeCheck() })` instances.
