### PR TITLE
Create session$currentThemeDependency only when needed

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -628,6 +628,15 @@ ShinySession <- R6Class(
       fun %||% identity
     },
 
+    # Ensure that `private$currentThemeDependency` is initialized. We don't do
+    # this in the `initialize()` method because then the reactiveVal doesn't
+    # have a reactive domain, and can persist after the app has exited.
+    ensureCurrentThemeDependency = function() {
+      if (is.null(private$currentThemeDependency)) {
+        private$currentThemeDependency <- reactiveVal(0)
+      }
+    },
+
     # See cycleStartAction
     startCycle = function() {
       # TODO: This should check for busyCount == 0L, and remove the checks from
@@ -727,8 +736,6 @@ ShinySession <- R6Class(
 
       private$testMode <- getShinyOption("testmode", default = FALSE)
       private$enableTestSnapshot()
-
-      private$currentThemeDependency <- reactiveVal(0)
 
       private$registerSessionEndCallbacks()
 
@@ -1305,6 +1312,8 @@ ShinySession <- R6Class(
     },
 
     getCurrentTheme = function() {
+      private$ensureCurrentThemeDependency()
+
       private$currentThemeDependency()
       getShinyOption("bootstrapTheme")
     },
@@ -1313,6 +1322,8 @@ ShinySession <- R6Class(
       # This function does three things: (1) sets theme as the current
       # bootstrapTheme, (2) re-executes any registered theme dependencies, and
       # (3) sends the resulting dependencies to the client.
+
+      private$ensureCurrentThemeDependency()
 
       # Note that this will automatically scope to the session.
       shinyOptions(bootstrapTheme = theme)

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -628,9 +628,10 @@ ShinySession <- R6Class(
       fun %||% identity
     },
 
-    # Ensure that `private$currentThemeDependency` is initialized. We don't do
-    # this in the `initialize()` method because then the reactiveVal doesn't
-    # have a reactive domain, and can persist after the app has exited.
+    # Used in getCurrentTheme()/setCurrentTheme() to ensure their reactive 
+    # dependency is initialized. Note that we don't initialize this reactiveVal()
+    # inside the initialize() method because at that point there isn't a
+    # reactive domain yet, and so it can persist after the app has exited.
     ensureCurrentThemeDependency = function() {
       if (is.null(private$currentThemeDependency)) {
         private$currentThemeDependency <- reactiveVal(0)
@@ -1315,7 +1316,7 @@ ShinySession <- R6Class(
       private$ensureCurrentThemeDependency()
 
       private$currentThemeDependency()
-      getShinyOption("bootstrapTheme")
+      getCurrentTheme()
     },
 
     setCurrentTheme = function(theme) {
@@ -1323,10 +1324,10 @@ ShinySession <- R6Class(
       # bootstrapTheme, (2) re-executes any registered theme dependencies, and
       # (3) sends the resulting dependencies to the client.
 
-      private$ensureCurrentThemeDependency()
-
       # Note that this will automatically scope to the session.
-      shinyOptions(bootstrapTheme = theme)
+      setCurrentTheme()
+      
+      private$ensureCurrentThemeDependency()
 
       # Invalidate
       private$currentThemeDependency(isolate(private$currentThemeDependency()) + 1)


### PR DESCRIPTION
This fixes https://github.com/rstudio/shinycoreci-apps/issues/89, where a new `session$currentThemeDependency` `reactiveVal` gets created every time a session starts, but they never get cleaned up.

Test app:

```R
library(shiny)
library(bslib)
library(reactlog)
reactlog_enable()

light <- bs_theme()
dark <- bs_theme(bg = "black", fg = "white", primary = "purple")
ui <- fluidPage(
  theme = light,
  checkboxInput("dark_mode", "Dark mode", FALSE),
  verbatimTextOutput("txt"),
  reactlog_module_ui()
)
server <- function(input, output, session) {
  observe({
    session$setCurrentTheme(
      if (isTRUE(input$dark_mode)) dark else light
    )
  })
  output$txt <- renderPrint({
    vars <- bs_get_variables(session$getCurrentTheme(), c("bg", "fg"))
    str(as.list(vars))
  })
  reactlog_module_server()
}
shinyApp(ui, server)
```

Previously the reactive graph for this app looked like this after reloading three times:

![image](https://user-images.githubusercontent.com/86978/101098669-ecd2e280-3588-11eb-961d-99b16e6278ba.png)

After the change, it looks like this:

![image](https://user-images.githubusercontent.com/86978/101098705-fceac200-3588-11eb-86c3-8f1e35e4d485.png)
