### PR TITLE
getCurrentOutputInfo() bugfix

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -1484,7 +1484,7 @@ ShinySession <- R6Class(
           # invocation of getCurrentOutputInfo()$width() and saves it; future
           # invocations of getCurrentOutputInfo()$width() use the existing
           # reactive and save it.
-          tmp_info[[prop]] <- function() {
+          tmp_info[[prop]] <<- function() {
             if (is.null(r)) {
               r <<- reactive(label = prop_name, {
                 wrapfun(self$clientData[[prop_name]])


### PR DESCRIPTION
Follow up to #3180. At the moment, this app throws an error since at the moment the CSS info isn't actually added

```r
shinyApp(
    fluidPage(
      tags$style(HTML("body {background-color: black; color: white; }")),
      tags$style(HTML("body a {color: purple}")),
      tags$style(HTML("#info {background-color: teal; color: orange; }")),
      plotOutput("p"),
      "Computed CSS styles for the output named info:",
      tagAppendAttributes(
        textOutput("info"),
        class = "shiny-report-theme"
      )
    ),
    function(input, output) {
      output$p <- renderPlot({
        info <- getCurrentOutputInfo()
        par(bg = info$bg(), fg = info$fg(), col.axis = info$fg(), col.main = info$fg())
        plot(1:10, col = info$accent(), pch = 19)
        title("A simple R plot that uses its CSS styling")
      })
      output$info <- renderText({
        info <- getCurrentOutputInfo()
        jsonlite::toJSON(
          list(
            bg = info$bg(),
            fg = info$fg(),
            accent = info$accent(),
            font = info$font()
          ),
          auto_unbox = TRUE
        )
      })
    }
  )
```