### PR TITLE
Add a warning message when value < min | value > max in sliderInput

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -76,6 +76,8 @@ shiny 1.5.0.9000
 
 * Fixed a bug that `textAreaInput()` doesn't work as expected for relative `width` (thanks to @shrektan). (#2049)
 
+* Closed #2910, #2909, #1552: `sliderInput()` warns if the `value` is outside of `min` and `max`, and errors if `value` is `NULL` or `NA`. (#3194)
+
 ### Library updates
 
 * Removed html5shiv and respond.js, which were used for IE 8 and IE 9 compatibility. (#2973)

--- a/R/input-slider.R
+++ b/R/input-slider.R
@@ -89,14 +89,7 @@ sliderInput <- function(inputId, label, min, max, value, step = NULL,
                     version = "0.10.2.2")
   }
 
-  if (isTRUE(min(value) < min | max(value) > max)) {
-    warning(noBreaks. = TRUE,
-      sprintf(
-        "Trying to set a `value` outside of the [`min`, `max`] range (`value` = %s, `min` = %s, `max = %s). `value` will be set to `max`.",
-        paste(value, collapse = ","), min, max
-      )
-    )
-  }
+  assert_slider_value(value = value, min = min, max = max, fun = "sliderInput")
 
   dataType <- getSliderType(min, max, value)
 
@@ -302,6 +295,18 @@ findStepSize <- function(min, max, step) {
 
   } else {
     1
+  }
+}
+
+# Throw a warning if ever `value` is not in the [`min`, `max`] range
+assert_slider_value <- function(value, min, max, fun){
+  if (isTRUE(min(value) < min || max(value) > max)) {
+    warning(noBreaks. = TRUE, call. = FALSE,
+            sprintf(
+              "In %s(): Trying to set a `value` outside of the [`min`, `max`] range (`value` = %s, `min` = %s, `max = %s). `value` will be set to `max`.",
+              fun, paste(value, collapse = ","), min, max
+            )
+    )
   }
 }
 

--- a/R/input-slider.R
+++ b/R/input-slider.R
@@ -89,7 +89,7 @@ sliderInput <- function(inputId, label, min, max, value, step = NULL,
                     version = "0.10.2.2")
   }
 
-  assert_slider_value(value = value, min = min, max = max, fun = "sliderInput")
+  check_slider_value(min, max, value, "sliderInput")
 
   dataType <- getSliderType(min, max, value)
 
@@ -299,13 +299,32 @@ findStepSize <- function(min, max, step) {
 }
 
 # Throw a warning if ever `value` is not in the [`min`, `max`] range
-assert_slider_value <- function(value, min, max, fun){
-  if (isTRUE(min(value) < min || max(value) > max)) {
-    warning(noBreaks. = TRUE, call. = FALSE,
-            sprintf(
-              "In %s(): Trying to set a `value` outside of the [`min`, `max`] range (`value` = %s, `min` = %s, `max = %s). `value`(s) will be constrained to [`min`, `max`].",
-              fun, paste(value, collapse = ","), min, max
-            )
+check_slider_value <- function(min, max, value, fun) {
+  if (is.null(min)   || is_na(min) ||
+      is.null(max)   || is_na(max) ||
+      is.null(value) || is_na(value))
+  {
+    stop(call. = FALSE,
+      sprintf("In %s(): `min`, `max`, and `value` cannot be NULL or NA.", fun)
+    )
+  }
+
+  if (!isTRUE(min(value) >= min)) {
+    warning(call. = FALSE,
+      sprintf(
+        "In %s(): `value` should be greater than or equal to `min` (value = %s, min = %s).",
+        fun, paste(value, collapse = ", "), min
+      )
+    )
+  }
+
+  if (!isTRUE(max(value) <= max)) {
+    warning(
+      noBreaks. = TRUE, call. = FALSE,
+      sprintf(
+        "In %s(): `value` should be less than or equal to `max` (value = %s, max = %s).",
+        fun, paste(value, collapse = ", "), max
+      )
     )
   }
 }

--- a/R/input-slider.R
+++ b/R/input-slider.R
@@ -89,11 +89,11 @@ sliderInput <- function(inputId, label, min, max, value, step = NULL,
                     version = "0.10.2.2")
   }
 
-  if (value < min | value > max) {
+  if (min(value) < min | max(value) > max) {
     warning(noBreaks. = TRUE,
       sprintf(
-        "Trying to set a `value` outside of the [`min`, `max`] range (value = %s, min =%s, max = %s). `value` will be set to `max`.",
-        value, min, max
+        "Trying to set a `value` outside of the [`min`, `max`] range (`value` = %s, `min` = %s, `max = %s). `value` will be set to `max`.",
+        paste(value, collapse = ","), min, max
       )
     )
   }

--- a/R/input-slider.R
+++ b/R/input-slider.R
@@ -89,7 +89,7 @@ sliderInput <- function(inputId, label, min, max, value, step = NULL,
                     version = "0.10.2.2")
   }
 
-  if (min(value) < min | max(value) > max) {
+  if (isTRUE(min(value) < min | max(value) > max)) {
     warning(noBreaks. = TRUE,
       sprintf(
         "Trying to set a `value` outside of the [`min`, `max`] range (`value` = %s, `min` = %s, `max = %s). `value` will be set to `max`.",

--- a/R/input-slider.R
+++ b/R/input-slider.R
@@ -300,16 +300,16 @@ findStepSize <- function(min, max, step) {
 
 # Throw a warning if ever `value` is not in the [`min`, `max`] range
 validate_slider_value <- function(min, max, value, fun) {
-  if (is.null(min)   || is_na(min) ||
-      is.null(max)   || is_na(max) ||
-      is.null(value) || is_na(value))
+  if (length(min)   != 1 || is_na(min) ||
+      length(max)   != 1 || is_na(max) ||
+      length(value) <  1 || length(value) > 2 || any(is.na(value)))
   {
     stop(call. = FALSE,
-      sprintf("In %s(): `min`, `max`, and `value` cannot be NULL or NA.", fun)
+      sprintf("In %s(): `min`, `max`, and `value` cannot be NULL, NA, or empty.", fun)
     )
   }
 
-  if (!isTRUE(min(value) >= min)) {
+  if (min(value) < min) {
     warning(call. = FALSE,
       sprintf(
         "In %s(): `value` should be greater than or equal to `min` (value = %s, min = %s).",
@@ -318,7 +318,7 @@ validate_slider_value <- function(min, max, value, fun) {
     )
   }
 
-  if (!isTRUE(max(value) <= max)) {
+  if (max(value) > max) {
     warning(
       noBreaks. = TRUE, call. = FALSE,
       sprintf(

--- a/R/input-slider.R
+++ b/R/input-slider.R
@@ -89,6 +89,15 @@ sliderInput <- function(inputId, label, min, max, value, step = NULL,
                     version = "0.10.2.2")
   }
 
+  if (value < min | value > max) {
+    warning(noBreaks. = TRUE,
+      sprintf(
+        "Trying to set a `value` outside of the [`min`, `max`] range (value = %s, min =%s, max = %s). `value` will be set to `max`.",
+        value, min, max
+      )
+    )
+  }
+
   dataType <- getSliderType(min, max, value)
 
   if (is.null(timeFormat)) {

--- a/R/input-slider.R
+++ b/R/input-slider.R
@@ -89,7 +89,7 @@ sliderInput <- function(inputId, label, min, max, value, step = NULL,
                     version = "0.10.2.2")
   }
 
-  check_slider_value(min, max, value, "sliderInput")
+  validate_slider_value(min, max, value, "sliderInput")
 
   dataType <- getSliderType(min, max, value)
 
@@ -299,7 +299,7 @@ findStepSize <- function(min, max, step) {
 }
 
 # Throw a warning if ever `value` is not in the [`min`, `max`] range
-check_slider_value <- function(min, max, value, fun) {
+validate_slider_value <- function(min, max, value, fun) {
   if (is.null(min)   || is_na(min) ||
       is.null(max)   || is_na(max) ||
       is.null(value) || is_na(value))

--- a/R/input-slider.R
+++ b/R/input-slider.R
@@ -303,7 +303,7 @@ assert_slider_value <- function(value, min, max, fun){
   if (isTRUE(min(value) < min || max(value) > max)) {
     warning(noBreaks. = TRUE, call. = FALSE,
             sprintf(
-              "In %s(): Trying to set a `value` outside of the [`min`, `max`] range (`value` = %s, `min` = %s, `max = %s). `value` will be set to `max`.",
+              "In %s(): Trying to set a `value` outside of the [`min`, `max`] range (`value` = %s, `min` = %s, `max = %s). `value`(s) will be constrained to [`min`, `max`].",
               fun, paste(value, collapse = ","), min, max
             )
     )

--- a/R/update-input.R
+++ b/R/update-input.R
@@ -422,14 +422,7 @@ updateSliderInput <- function(session, inputId, label = NULL, value = NULL,
     if (!is.null(value)) value <- to_ms(value)
   }
 
-  if (isTRUE(min(value) < min | max(value) > max)) {
-    warning(noBreaks. = TRUE,
-            sprintf(
-              "Trying to set a `value` outside of the [`min`, `max`] range (`value` = %s, `min` = %s, `max = %s). `value` will be set to `max`.",
-              paste(value, collapse = ","), min, max
-            )
-    )
-  }
+  assert_slider_value(value = value, min = min, max = max, fun = "updateSliderInput")
 
   message <- dropNulls(list(
     label = label,

--- a/R/update-input.R
+++ b/R/update-input.R
@@ -422,6 +422,15 @@ updateSliderInput <- function(session, inputId, label = NULL, value = NULL,
     if (!is.null(value)) value <- to_ms(value)
   }
 
+  if (isTRUE(min(value) < min | max(value) > max)) {
+    warning(noBreaks. = TRUE,
+            sprintf(
+              "Trying to set a `value` outside of the [`min`, `max`] range (`value` = %s, `min` = %s, `max = %s). `value` will be set to `max`.",
+              paste(value, collapse = ","), min, max
+            )
+    )
+  }
+
   message <- dropNulls(list(
     label = label,
     value = formatNoSci(value),

--- a/R/update-input.R
+++ b/R/update-input.R
@@ -422,8 +422,6 @@ updateSliderInput <- function(session, inputId, label = NULL, value = NULL,
     if (!is.null(value)) value <- to_ms(value)
   }
 
-  assert_slider_value(value = value, min = min, max = max, fun = "updateSliderInput")
-
   message <- dropNulls(list(
     label = label,
     value = formatNoSci(value),

--- a/tests/testthat/test-input-select.R
+++ b/tests/testthat/test-input-select.R
@@ -43,3 +43,58 @@ test_that("jqueryui is attached when drag_drop plugin is present", {
     c("selectize", "jqueryui")
   )
 })
+
+
+test_that("selectInput options are properly escaped", {
+  si <- selectInput("quote", "Quote", list(
+    "\"Separators\"" = list(
+      "None" = "",
+      "Double quote" = "\"",
+      "Single quote" = "'"
+    )
+  ))
+
+  si_str <- as.character(si)
+  expect_true(any(grepl("<option value=\"&quot;\">", si_str, fixed = TRUE)))
+  expect_true(any(grepl("<option value=\"&#39;\">", si_str, fixed = TRUE)))
+  expect_true(any(grepl("<optgroup label=\"&quot;Separators&quot;\">", si_str, fixed = TRUE)))
+})
+
+
+test_that("selectInputUI has a select at an expected location", {
+  for (multiple in c(TRUE, FALSE)) {
+    for (selected in list(NULL, "", "A")) {
+      for (selectize in c(TRUE, FALSE)) {
+        selectInputVal <- selectInput(
+          inputId = "testId",
+          label = "test label",
+          choices = c("A", "B", "C"),
+          selected = selected,
+          multiple = multiple,
+          selectize = selectize
+        )
+        # if this getter is changed, varSelectInput getter needs to be changed
+        selectHtml <- selectInputVal$children[[2]]$children[[1]]
+        expect_true(inherits(selectHtml, "shiny.tag"))
+        expect_equal(selectHtml$name, "select")
+        if (!is.null(selectHtml$attribs$class)) {
+          expect_false(grepl(selectHtml$attribs$class, "symbol"))
+        }
+
+        varSelectInputVal <- varSelectInput(
+          inputId = "testId",
+          label = "test label",
+          data = data.frame(A = 1:2, B = 3:4, C = 5:6),
+          selected = selected,
+          multiple = multiple,
+          selectize = selectize
+        )
+        # if this getter is changed, varSelectInput getter needs to be changed
+        varSelectHtml <- varSelectInputVal$children[[2]]$children[[1]]
+        expect_true(inherits(varSelectHtml, "shiny.tag"))
+        expect_equal(varSelectHtml$name, "select")
+        expect_true(grepl("symbol", varSelectHtml$attribs$class, fixed = TRUE))
+      }
+    }
+  }
+})

--- a/tests/testthat/test-input-slider.R
+++ b/tests/testthat/test-input-slider.R
@@ -24,6 +24,7 @@ test_that("sliderInput validation", {
   expect_error(sliderInput('s', 's', NULL, x+1,  x))
   expect_error(sliderInput('s', 's', NULL, NULL, x))
   expect_error(sliderInput('s', 's', x-1,  x+1, NA_real_))
+  expect_error(sliderInput('s', 's', x-1,  x+1, c(x, NA_real_)))
 
   # Date
   x <- Sys.Date()
@@ -76,4 +77,20 @@ test_that("sliderInput validation", {
   expect_error(sliderInput('s', 's', x-1,  NULL, x))
   expect_error(sliderInput('s', 's', NULL, x+1,  x))
   expect_error(sliderInput('s', 's', NULL, NULL, x))
+
+
+  # Size
+  x <- 10
+  ## length 0
+  expect_error(sliderInput('s', 's', x-1, x+1, numeric(0)))
+  expect_error(sliderInput('s', 's', x-1, numeric(0), x))
+  expect_error(sliderInput('s', 's', numeric(0), x+1, x))
+  ## length 1
+  expect_silent(sliderInput('s', 's', x-1, x+1, x))
+  ## length 2
+  expect_silent(sliderInput('s', 's', x-1, x+1, c(x, x)))
+  ## length 3+
+  expect_error(sliderInput('s', 's', x-1, x+1, c(x, x, x)))
+  expect_error(sliderInput('s', 's', x-1, c(x, x, x), x))
+  expect_error(sliderInput('s', 's', c(x, x, x), x+1, x))
 })

--- a/tests/testthat/test-input-slider.R
+++ b/tests/testthat/test-input-slider.R
@@ -1,0 +1,79 @@
+# For issue #1006
+test_that("sliderInput steps don't have rounding errors", {
+  # Need to use expect_identical; expect_equal is too forgiving of rounding error
+  expect_identical(findStepSize(-5.5, 4, NULL), 0.1)
+})
+
+
+
+test_that("sliderInput validation", {
+  # Number
+  x <- 10
+  expect_silent(sliderInput('s', 's', x-1, x+1, x))
+  expect_silent(sliderInput('s', 's', x-1, x+1, x-1))
+  expect_silent(sliderInput('s', 's', x-1, x+1, c(x-1, x+1)))
+
+  expect_warning(sliderInput('s', 's', x-1,  x+1,  x+2))
+  expect_warning(sliderInput('s', 's', x-1,  x+1,  x-2))
+  expect_warning(sliderInput('s', 's', x-1,  x+1,  c(x-2, x)))
+  expect_warning(sliderInput('s', 's', x-1,  x+1,  c(x, x+2)))
+
+  expect_error(sliderInput('s', 's', x-1,  x+1))
+  expect_error(sliderInput('s', 's', x-1,  x+1,  NULL))
+  expect_error(sliderInput('s', 's', x-1,  NULL, x))
+  expect_error(sliderInput('s', 's', NULL, x+1,  x))
+  expect_error(sliderInput('s', 's', NULL, NULL, x))
+  expect_error(sliderInput('s', 's', x-1,  x+1, NA_real_))
+
+  # Date
+  x <- Sys.Date()
+  expect_silent(sliderInput('s', 's', x-1, x+1, x))
+  expect_silent(sliderInput('s', 's', x-1, x+1, x-1))
+  expect_silent(sliderInput('s', 's', x-1, x+1, c(x-1, x+1)))
+
+  expect_warning(sliderInput('s', 's', x-1,  x+1,  x+2))
+  expect_warning(sliderInput('s', 's', x-1,  x+1,  x-2))
+  expect_warning(sliderInput('s', 's', x-1,  x+1,  c(x-2, x)))
+  expect_warning(sliderInput('s', 's', x-1,  x+1,  c(x, x+2)))
+
+  expect_error(sliderInput('s', 's', x-1,  x+1))
+  expect_error(sliderInput('s', 's', x-1,  x+1,  NULL))
+  expect_error(sliderInput('s', 's', x-1,  NULL, x))
+  expect_error(sliderInput('s', 's', NULL, x+1,  x))
+  expect_error(sliderInput('s', 's', NULL, NULL, x))
+  expect_error(sliderInput('s', 's', x-1,  x+1, as.Date(NA)))
+
+  # POSIXct
+  x <- Sys.time()
+  expect_silent(sliderInput('s', 's', x-1, x+1, x))
+  expect_silent(sliderInput('s', 's', x-1, x+1, x-1))
+  expect_silent(sliderInput('s', 's', x-1, x+1, c(x-1, x+1)))
+
+  expect_warning(sliderInput('s', 's', x-1,  x+1,  x+2))
+  expect_warning(sliderInput('s', 's', x-1,  x+1,  x-2))
+  expect_warning(sliderInput('s', 's', x-1,  x+1,  c(x-2, x)))
+  expect_warning(sliderInput('s', 's', x-1,  x+1,  c(x, x+2)))
+
+  expect_error(sliderInput('s', 's', x-1,  x+1))
+  expect_error(sliderInput('s', 's', x-1,  x+1,  NULL))
+  expect_error(sliderInput('s', 's', x-1,  NULL, x))
+  expect_error(sliderInput('s', 's', NULL, x+1,  x))
+  expect_error(sliderInput('s', 's', NULL, NULL, x))
+
+  # POSIXLt
+  x <- as.POSIXlt(Sys.time())
+  expect_silent(sliderInput('s', 's', x-1, x+1, x))
+  expect_silent(sliderInput('s', 's', x-1, x+1, x-1))
+  expect_silent(sliderInput('s', 's', x-1, x+1, c(x-1, x+1)))
+
+  expect_warning(sliderInput('s', 's', x-1,  x+1,  x+2))
+  expect_warning(sliderInput('s', 's', x-1,  x+1,  x-2))
+  expect_warning(sliderInput('s', 's', x-1,  x+1,  c(x-2, x)))
+  expect_warning(sliderInput('s', 's', x-1,  x+1,  c(x, x+2)))
+
+  expect_error(sliderInput('s', 's', x-1,  x+1))
+  expect_error(sliderInput('s', 's', x-1,  x+1,  NULL))
+  expect_error(sliderInput('s', 's', x-1,  NULL, x))
+  expect_error(sliderInput('s', 's', NULL, x+1,  x))
+  expect_error(sliderInput('s', 's', NULL, NULL, x))
+})

--- a/tests/testthat/test-ui.R
+++ b/tests/testthat/test-ui.R
@@ -1,8 +1,0 @@
-context("UI")
-
-
-# For issue #1006
-test_that("sliderInput steps don't have rounding errors", {
-  # Need to use expect_identical; expect_equal is too forgiving of rounding error
-  expect_identical(findStepSize(-5.5, 4, NULL), 0.1)
-})

--- a/tests/testthat/test-ui.R
+++ b/tests/testthat/test-ui.R
@@ -1,62 +1,8 @@
 context("UI")
 
-test_that("selectInput options are properly escaped", {
-  si <- selectInput("quote", "Quote", list(
-    "\"Separators\"" = list(
-      "None" = "",
-      "Double quote" = "\"",
-      "Single quote" = "'"
-    )
-  ))
-
-  si_str <- as.character(si)
-  expect_true(any(grepl("<option value=\"&quot;\">", si_str, fixed = TRUE)))
-  expect_true(any(grepl("<option value=\"&#39;\">", si_str, fixed = TRUE)))
-  expect_true(any(grepl("<optgroup label=\"&quot;Separators&quot;\">", si_str, fixed = TRUE)))
-})
-
 
 # For issue #1006
 test_that("sliderInput steps don't have rounding errors", {
   # Need to use expect_identical; expect_equal is too forgiving of rounding error
   expect_identical(findStepSize(-5.5, 4, NULL), 0.1)
-})
-
-
-test_that("selectInputUI has a select at an expected location", {
-  for (multiple in c(TRUE, FALSE)) {
-    for (selected in list(NULL, "", "A")) {
-      for (selectize in c(TRUE, FALSE)) {
-        selectInputVal <- selectInput(
-          inputId = "testId",
-          label = "test label",
-          choices = c("A", "B", "C"),
-          selected = selected,
-          multiple = multiple,
-          selectize = selectize
-        )
-        # if this getter is changed, varSelectInput getter needs to be changed
-        selectHtml <- selectInputVal$children[[2]]$children[[1]]
-        expect_true(inherits(selectHtml, "shiny.tag"))
-        expect_equal(selectHtml$name, "select")
-        if (!is.null(selectHtml$attribs$class)) {
-          expect_false(grepl(selectHtml$attribs$class, "symbol"))
-        }
-
-        varSelectInputVal <- varSelectInput(
-          inputId = "testId",
-          label = "test label",
-          data = data.frame(A = 1:2, B = 3:4, C = 5:6),
-          selected = selected,
-          multiple = multiple,
-          selectize = selectize
-        )
-        # if this getter is changed, varSelectInput getter needs to be changed
-        varSelectHtml <- varSelectInputVal$children[[2]]$children[[1]]
-        expect_true(inherits(varSelectHtml, "shiny.tag"))
-        expect_equal(varSelectHtml$name, "select")
-        expect_true(grepl("symbol", varSelectHtml$attribs$class, fixed = TRUE))
-      }
-    }
-  }
 })


### PR DESCRIPTION
This supersedes #3105, since I'm not able to push to the branch for that PR. Closes #2910, closes #2909, closes #1552.

I removed the check for `updateSliderInput` because there's no guarantee that any of `min`, `max`, and `value` are present, and the benefit of checking there is smaller.