### PR TITLE
Make `validate_session_object()` work with modules

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -64,11 +64,11 @@ shiny 1.5.0.9000
 
 * Closed #3140: Added support for `...` argument in `icon()`. (#3143)
 
-* Closed #629: All `update*` functions now have a default value for `session`, and issue an informative warning if it is missing. (#3195)
-
-### Bug fixes
+* Closed #629: All `update*` functions now have a default value for `session`, and issue an informative warning if it is missing. (#3195, #3199)
 
 * Improved error messages when reading reactive values outside of a reactive domain (e.g., `reactiveVal()()`). (#3007)
+
+### Bug fixes
 
 * Fixed #1942: Calling `runApp("app.R")` no longer ignores options passed into `shinyApp()`. This makes it possible for Shiny apps to specify what port/host should be used by default. (#2969)
 

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -2537,7 +2537,9 @@ markdown <- function(mds, extensions = TRUE, .noWS = NULL, ...) {
 # Check that an object is a ShinySession object, and give an informative error.
 # The default label is the caller function's name.
 validate_session_object <- function(session, label = as.character(sys.call(sys.parent())[[1]])) {
-  if (missing(session) || !inherits(session, c("ShinySession", "MockShinySession"))) {
+  if (missing(session) ||
+      !inherits(session, c("ShinySession", "MockShinySession", "session_proxy")))
+  {
     stop(call. = FALSE,
       sprintf(
         "`session` must be a 'ShinySession' object. Did you forget to pass `session` to `%s()`?",

--- a/tests/testthat/test-input-slider.R
+++ b/tests/testthat/test-input-slider.R
@@ -65,12 +65,18 @@ test_that("sliderInput validation", {
   x <- as.POSIXlt(Sys.time())
   expect_silent(sliderInput('s', 's', x-1, x+1, x))
   expect_silent(sliderInput('s', 's', x-1, x+1, x-1))
-  expect_silent(sliderInput('s', 's', x-1, x+1, c(x-1, x+1)))
 
   expect_warning(sliderInput('s', 's', x-1,  x+1,  x+2))
   expect_warning(sliderInput('s', 's', x-1,  x+1,  x-2))
-  expect_warning(sliderInput('s', 's', x-1,  x+1,  c(x-2, x)))
-  expect_warning(sliderInput('s', 's', x-1,  x+1,  c(x, x+2)))
+
+  if (getRversion() >= "4.0") {
+    expect_silent(sliderInput('s', 's', x-1, x+1, c(x-1, x+1)))
+    expect_warning(sliderInput('s', 's', x-1,  x+1,  c(x-2, x)))
+    expect_warning(sliderInput('s', 's', x-1,  x+1,  c(x, x+2)))
+  } else {
+    skip("c() doesn't work sensibly on POSIXlt objects with this version of R")
+  }
+
 
   expect_error(sliderInput('s', 's', x-1,  x+1))
   expect_error(sliderInput('s', 's', x-1,  x+1,  NULL))

--- a/tests/testthat/test-update-input.R
+++ b/tests/testthat/test-update-input.R
@@ -8,6 +8,7 @@ test_that("Radio buttons and checkboxes work with modules", {
         session$lastInputMessage = list(id = inputId, message = message)
       }
     ))
+    class(session) <- "ShinySession"
     session
   }
 


### PR DESCRIPTION
PR #3195 introduced a problem: The `update*Input` functions would no longer work with modules. This fixes it.