### PR TITLE
fix typo in docs

### DIFF
--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -995,9 +995,9 @@ buildTabItem <- function(index, tabsetId, foundSelected, tabs = NULL,
 #' Render a reactive output variable as text within an application page.
 #' `textOutput()` is usually paired with [renderText()] and puts regular text
 #' in `<div>` or `<span>`; `verbatimTextOutput()` is usually paired with
-#' [renderPrint()] and provudes fixed-width text in a `<pre>`.
+#' [renderPrint()] and provides fixed-width text in a `<pre>`.
 #'
-#' In both funtions, text is HTML-escaped prior to rendering.
+#' In both functions, text is HTML-escaped prior to rendering.
 #'
 #' @param outputId output variable to read the value from
 #' @param container a function to generate an HTML element to contain the text

--- a/man/textOutput.Rd
+++ b/man/textOutput.Rd
@@ -28,10 +28,10 @@ A output element for use in UI.
 Render a reactive output variable as text within an application page.
 \code{textOutput()} is usually paired with \code{\link[=renderText]{renderText()}} and puts regular text
 in \verb{<div>} or \verb{<span>}; \code{verbatimTextOutput()} is usually paired with
-\code{\link[=renderPrint]{renderPrint()}} and provudes fixed-width text in a \verb{<pre>}.
+\code{\link[=renderPrint]{renderPrint()}} and provides fixed-width text in a \verb{<pre>}.
 }
 \details{
-In both funtions, text is HTML-escaped prior to rendering.
+In both functions, text is HTML-escaped prior to rendering.
 }
 \examples{
 ## Only run this example in interactive R sessions


### PR DESCRIPTION
I actually can't seem to install several of the shiny-related packages right now (sass and bslib) and can't run roxygen on the pkg as a result, but it looks like you have the /document action for this repo, so I'll let you all handle it 😇 