### PR TITLE
Make sure setCurrentTheme() doesn't try and change bootstrap versions

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -1322,7 +1322,12 @@ ShinySession <- R6Class(
       # bootstrapTheme, (2) re-executes any registered theme dependencies, and
       # (3) sends the resulting dependencies to the client.
 
-      # Make sure that the theme switching is just styles (e.g. bootswatch) rather than a different version
+      if (!is_bs_theme(theme)) {
+        stop("`session$setCurrentTheme()` expects a `bslib::bs_theme()` object.", call. = FALSE)
+      }
+
+      # Switching Bootstrap versions has weird & complex consequences
+      # for the JS logic, so we forbid it
       current_version <- bslib::theme_version(getCurrentTheme())
       next_version <- bslib::theme_version(theme)
       if (!identical(current_version, next_version)) {

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -1323,14 +1323,15 @@ ShinySession <- R6Class(
       # (3) sends the resulting dependencies to the client.
 
       # Make sure that the theme switching is just styles (e.g. bootswatch) rather than a different version
-      mismatched_bootstrap_versions <- bslib::theme_version(theme) != bslib::theme_version(getCurrentTheme())
-      if(mismatched_bootstrap_versions){
-        stop(paste0("Requested theme uses a different bootstrap version (",
-                    bslib::theme_version(theme),
-                    ") than the currently loaded theme (",
-                    bslib::theme_version(getCurrentTheme()),
-                    "). Dynamic switching of bootstrap versions is not supported."),
-             call. = FALSE)
+      current_version <- bslib::theme_version(getCurrentTheme()) 
+      next_version <- bslib::theme_version(theme)
+      if (!identical(current_version, next_version)) {
+        stop(
+          "Requested theme uses a different bootstrap version (",
+          next_version, ") than the currently loaded theme (", current_theme,
+           "). Dynamic switching of bootstrap versions is not supported.",
+           call. = FALSE
+         )
       }
 
       # Note that this will automatically scope to the session.

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -1322,6 +1322,17 @@ ShinySession <- R6Class(
       # bootstrapTheme, (2) re-executes any registered theme dependencies, and
       # (3) sends the resulting dependencies to the client.
 
+      # Make sure that the theme switching is just styles (e.g. bootswatch) rather than a different version
+      mismatched_bootstrap_versions <- bslib::theme_version(theme) != bslib::theme_version(getCurrentTheme())
+      if(mismatched_bootstrap_versions){
+        stop(paste0("Requested theme uses a different bootstrap version (",
+                    bslib::theme_version(theme),
+                    ") than the currently loaded theme (",
+                    bslib::theme_version(getCurrentTheme()),
+                    "). Dynamic switching of bootstrap versions is not supported."),
+             call. = FALSE)
+      }
+
       # Note that this will automatically scope to the session.
       setCurrentTheme(theme)
 

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -1327,11 +1327,11 @@ ShinySession <- R6Class(
       next_version <- bslib::theme_version(theme)
       if (!identical(current_version, next_version)) {
         stop(
-          "Requested theme uses a different bootstrap version (",
-          next_version, ") than the currently loaded theme (", current_theme,
-           "). Dynamic switching of bootstrap versions is not supported.",
-           call. = FALSE
-         )
+          "session$setCurrentTheme() cannot be used to change the Bootstrap version ",
+          "from ", current_version, " to ", next_version, ". ",
+          "Try setting `bs_theme(version = ", next_version, ")`."
+          call. = FALSE
+        )
       }
 
       # Note that this will automatically scope to the session.

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -1323,13 +1323,13 @@ ShinySession <- R6Class(
       # (3) sends the resulting dependencies to the client.
 
       # Make sure that the theme switching is just styles (e.g. bootswatch) rather than a different version
-      current_version <- bslib::theme_version(getCurrentTheme()) 
+      current_version <- bslib::theme_version(getCurrentTheme())
       next_version <- bslib::theme_version(theme)
       if (!identical(current_version, next_version)) {
         stop(
           "session$setCurrentTheme() cannot be used to change the Bootstrap version ",
           "from ", current_version, " to ", next_version, ". ",
-          "Try setting `bs_theme(version = ", next_version, ")`."
+          "Try using `bs_theme(version = ", next_version, ")` for initial theme.",
           call. = FALSE
         )
       }


### PR DESCRIPTION
Based on https://github.com/rstudio/shiny/issues/3202

This PR adds a check to make sure that the new theme requested by `setCurrentTheme()` has the same version as the already loaded theme.

### Demo app

Before this PR the following app would not throw any errors when the user selects version 3. This would cause problems if the user then tried to change the bootswatch. With this PR shiny will throw an error on version switching. 

`app.R`
```R
library(shiny)
library(bslib)

# Setting version to 3 here
my_theme <- bs_theme(bootswatch = "darkly", version = "4")
ui <- fluidPage(
  theme = my_theme,
  radioButtons("current_theme", "Choose a theme for bslib",
               choices = c("darkly", "flatly")),
  radioButtons("bs_version", "Bootstrap version", choices = c("4", "3")),
)

server <- function(input, output, session) {
  observe({
    session$setCurrentTheme(
      bs_theme(bootswatch = input$current_theme, version = input$bs_version)
    )
  })
}

shinyApp(ui, server)
```
