### PR TITLE
Selectize's active item fg color now uses bslib's color-contrast()

### DIFF
--- a/inst/www/shared/selectize/scss/selectize.bootstrap3.scss
+++ b/inst/www/shared/selectize/scss/selectize.bootstrap3.scss
@@ -28,7 +28,7 @@ $selectize-color-disabled: $input-bg !default;
 $selectize-color-item: mix($selectize-color-input, $selectize-color-text, 90%) !default;
 $selectize-color-item-border: rgba(black, 0) !default;
 $selectize-color-item-active: $component-active-bg !default;
-$selectize-color-item-active-text: $component-active-color !default;
+$selectize-color-item-active-text: color-contrast($selectize-color-item-active) !default;
 $selectize-color-item-active-border: rgba(black, 0) !default;
 $selectize-color-optgroup: $dropdown-bg !default;
 $selectize-color-optgroup-text: $dropdown-header-color !default;

--- a/inst/www/shared/selectize/scss/selectize.bootstrap4.scss
+++ b/inst/www/shared/selectize/scss/selectize.bootstrap4.scss
@@ -19,7 +19,7 @@ $selectize-color-disabled: $input-bg !default;
 $selectize-color-item: mix($selectize-color-input, $selectize-color-text, 90%) !default;
 $selectize-color-item-border: $input-border-color !default;
 $selectize-color-item-active: $component-active-bg !default;
-$selectize-color-item-active-text: $component-active-color !default;
+$selectize-color-item-active-text: color-contrast($selectize-color-item-active) !default;
 $selectize-color-item-active-border: rgba(0,0,0,0) !default;
 $selectize-color-optgroup: $dropdown-bg !default;
 $selectize-color-optgroup-text: $dropdown-header-color !default;


### PR DESCRIPTION
Close #3215, here's a minimal example:

```r
library(shiny)

ui <- fluidPage(
  theme = bslib::bs_theme(bg = "black", fg = "white", primary = "darkblue"),
  selectizeInput("a", "", letters, multiple = TRUE)
)

server <- function(input, output) {}

shinyApp(ui, server)
```

Before these changes the active items' fg color was black, but now it's white (which provides a better contrast to `darkblue`)