### PR TITLE
shinyAppDir() now throws an exception with a special class if no app.R/server.R file is found.

### DIFF
--- a/R/shinyapp.R
+++ b/R/shinyapp.R
@@ -125,7 +125,10 @@ shinyAppDir <- function(appDir, options=list()) {
   } else if (file.exists.ci(appDir, "app.R")) {
     shinyAppDir_appR("app.R", appDir, options = options)
   } else {
-    stop("App dir must contain either app.R or server.R.")
+    rlang::abort(
+      "App dir must contain either app.R or server.R.",
+      class = "shiny_app_dir_missing_file"
+    )
   }
 }
 


### PR DESCRIPTION
Needed for https://github.com/rstudio/shinytest/pull/375