### PR TITLE
Reduce promises version to 1.1.0 and safeguard visibility test

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -85,7 +85,7 @@ Imports:
     R6 (>= 2.0),
     sourcetools,
     later (>= 1.0.0),
-    promises (>= 1.1.1.9001),
+    promises (>= 1.1.0),
     tools,
     crayon,
     rlang (>= 0.4.9),
@@ -116,7 +116,6 @@ Suggests:
     sass
 Remotes:
     rstudio/htmltools,
-    rstudio/promises,
     rstudio/sass,
     rstudio/bslib,
     rstudio/shinytest,

--- a/tests/testthat/test-bind-cache.R
+++ b/tests/testthat/test-bind-cache.R
@@ -923,6 +923,9 @@ test_that("bindCache visibility", {
 
 
 test_that("bindCache reactive visibility - async", {
+  # only test if promises handles visibility
+  skip_if_not_installed("promises", "1.1.1.9001")
+
   cache <- cachem::cache_mem()
   k <- reactiveVal(0)
   res <- NULL

--- a/tests/testthat/test-hybrid-chain.R
+++ b/tests/testthat/test-hybrid-chain.R
@@ -27,6 +27,9 @@ test_that("hybrid_chain preserves visibility", {
 
 
 test_that("hybrid_chain preserves visibility - async", {
+  # only test if promises handles visibility
+  skip_if_not_installed("promises", "1.1.1.9001")
+
   res <- NULL
   hybrid_chain(
     promise_resolve(1),


### PR DESCRIPTION
Related: https://github.com/rstudio/shiny/pull/3151