### PR TITLE
Perform type check before value check

### DIFF
--- a/R/input-slider.R
+++ b/R/input-slider.R
@@ -95,9 +95,8 @@ sliderInput <- function(inputId, label, min, max, value, step = NULL,
     )
   }
 
-  validate_slider_value(min, max, value, "sliderInput")
-
   dataType <- getSliderType(min, max, value)
+  validate_slider_value(min, max, value, "sliderInput")
 
   if (is.null(timeFormat)) {
     timeFormat <- switch(dataType, date = "%F", datetime = "%F %T", number = NULL)
@@ -302,6 +301,23 @@ findStepSize <- function(min, max, step) {
   } else {
     1
   }
+}
+
+getSliderType <- function(min, max, value) {
+  vals <- dropNulls(list(value, min, max))
+  if (length(vals) == 0) return("")
+  type <- unique(lapply(vals, function(x) {
+    if      (inherits(x, "Date"))   "date"
+    else if (inherits(x, "POSIXt")) "datetime"
+    else                            "number"
+  }))
+  if (length(type) > 1) {
+    rlang::abort(c(
+      "Type mismatch for `min`, `max`, and `value`.",
+      i = "All values must have same type: either numeric, Date, or POSIXt."
+    ))
+  }
+  type[[1]]
 }
 
 # Throw a warning if ever `value` is not in the [`min`, `max`] range

--- a/R/utils.R
+++ b/R/utils.R
@@ -1770,23 +1770,6 @@ createVarPromiseDomain <- function(env, name, value) {
   )
 }
 
-getSliderType <- function(min, max, value) {
-  vals <- dropNulls(list(value, min, max))
-  if (length(vals) == 0) return("")
-  type <- unique(lapply(vals, function(x) {
-    if      (inherits(x, "Date"))   "date"
-    else if (inherits(x, "POSIXt")) "datetime"
-    else                            "number"
-  }))
-  if (length(type) > 1) {
-    rlang::abort(c(
-      "Type mismatch for `min`, `max`, and `value`.",
-      "All values must either be numeric, Date, or POSIXt."
-    ))
-  }
-  type[[1]]
-}
-
 # Reads the `shiny.sharedSecret` global option, and returns a function that can
 # be used to test header values for a match.
 loadSharedSecret <- function() {


### PR DESCRIPTION
If you don't validate the input types before validating the values, you get uninformative errors from min/max. (Which comes up in Mastering Shiny).

I also moved `getSliderType()` into input-slider.R since it's the only place that it's used, and mildly improved the error message.

I'm happy to add some tests, but I think the existing tests will need some refactoring, as there are acres of tests that are neither particularly sensitive nor specific.