### PR TITLE
Fixed typo in un-export function name

### DIFF
--- a/R/reactives.R
+++ b/R/reactives.R
@@ -627,7 +627,7 @@ is.reactivevalues <- function(x) inherits(x, 'reactivevalues')
   if (!hasCurrentContext()) {
     rlang::abort(c(
       paste0("Can't access reactive value '", name, "' outside of reactive consumer."),
-      i = "Do you need to wrap inside reactive() or observer()?"
+      i = "Do you need to wrap inside reactive() or observe()?"
     ))
   }
 


### PR DESCRIPTION
I think the `observes()` in the message is a typo because it is not an exported function, and `shiny::observe()` is the correct one.