### PR TITLE
Remove old @param theme roxygen documentation and rely in @inheritParams bootstrapPage

### DIFF
--- a/R/bootstrap-layout.R
+++ b/R/bootstrap-layout.R
@@ -13,9 +13,6 @@
 #'   Can also be set as a side effect of the [titlePanel()] function.
 #' @param responsive This option is deprecated; it is no longer optional with
 #'   Bootstrap 3.
-#' @param theme Alternative Bootstrap stylesheet (normally a css file within the
-#'   www directory). For example, to use the theme located at
-#'   `www/bootstrap.css` you would use `theme = "bootstrap.css"`.
 #' @inheritParams bootstrapPage
 #'
 #' @return A UI defintion that can be passed to the [shinyUI] function.
@@ -117,9 +114,6 @@ fluidRow <- function(...) {
 #' @param title The browser window title (defaults to the host URL of the page)
 #' @param responsive This option is deprecated; it is no longer optional with
 #'   Bootstrap 3.
-#' @param theme Alternative Bootstrap stylesheet (normally a css file within the
-#'   www directory). For example, to use the theme located at
-#'   `www/bootstrap.css` you would use `theme = "bootstrap.css"`.
 #' @inheritParams bootstrapPage
 #'
 #' @return A UI defintion that can be passed to the [shinyUI] function.

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -283,7 +283,6 @@ basicPage <- function(...) {
 #' @param title The title to use for the browser window/tab (it will not be
 #'   shown in the document).
 #' @param bootstrap If `TRUE`, load the Bootstrap CSS library.
-#' @param theme URL to alternative Bootstrap stylesheet.
 #' @inheritParams bootstrapPage
 #'
 #' @family layout functions
@@ -378,9 +377,6 @@ collapseSizes <- function(padding) {
 #'   layout.
 #' @param responsive This option is deprecated; it is no longer optional with
 #'   Bootstrap 3.
-#' @param theme Alternative Bootstrap stylesheet (normally a css file within the
-#'   www directory). For example, to use the theme located at
-#'   `www/bootstrap.css` you would use `theme = "bootstrap.css"`.
 #' @param windowTitle The title that should be displayed by the browser window.
 #'   Useful if `title` is not a string.
 #' @inheritParams bootstrapPage

--- a/man/fillPage.Rd
+++ b/man/fillPage.Rd
@@ -30,7 +30,14 @@ shown in the document).}
 
 \item{bootstrap}{If \code{TRUE}, load the Bootstrap CSS library.}
 
-\item{theme}{URL to alternative Bootstrap stylesheet.}
+\item{theme}{One of the following:
+\itemize{
+\item \code{NULL} (the default), which implies a "stock" build of Bootstrap 3.
+\item A \code{\link[bslib:bs_theme]{bslib::bs_theme()}} object. This can be used to replace a stock
+build of Bootstrap 3 with a customized version of Bootstrap 3 or higher.
+\item A character string pointing to an alternative Bootstrap stylesheet
+(normally a css file within the www directory, e.g. \code{www/bootstrap.css}).
+}}
 
 \item{lang}{ISO 639-1 language code for the HTML page, such as "en" or "ko".
 This will be used as the lang in the \code{<html>} tag, as in \code{<html lang="en">}.

--- a/man/fixedPage.Rd
+++ b/man/fixedPage.Rd
@@ -23,9 +23,14 @@ fixedRow(...)
 \item{responsive}{This option is deprecated; it is no longer optional with
 Bootstrap 3.}
 
-\item{theme}{Alternative Bootstrap stylesheet (normally a css file within the
-www directory). For example, to use the theme located at
-\code{www/bootstrap.css} you would use \code{theme = "bootstrap.css"}.}
+\item{theme}{One of the following:
+\itemize{
+\item \code{NULL} (the default), which implies a "stock" build of Bootstrap 3.
+\item A \code{\link[bslib:bs_theme]{bslib::bs_theme()}} object. This can be used to replace a stock
+build of Bootstrap 3 with a customized version of Bootstrap 3 or higher.
+\item A character string pointing to an alternative Bootstrap stylesheet
+(normally a css file within the www directory, e.g. \code{www/bootstrap.css}).
+}}
 
 \item{lang}{ISO 639-1 language code for the HTML page, such as "en" or "ko".
 This will be used as the lang in the \code{<html>} tag, as in \code{<html lang="en">}.

--- a/man/fluidPage.Rd
+++ b/man/fluidPage.Rd
@@ -24,9 +24,14 @@ Can also be set as a side effect of the \code{\link[=titlePanel]{titlePanel()}} 
 \item{responsive}{This option is deprecated; it is no longer optional with
 Bootstrap 3.}
 
-\item{theme}{Alternative Bootstrap stylesheet (normally a css file within the
-www directory). For example, to use the theme located at
-\code{www/bootstrap.css} you would use \code{theme = "bootstrap.css"}.}
+\item{theme}{One of the following:
+\itemize{
+\item \code{NULL} (the default), which implies a "stock" build of Bootstrap 3.
+\item A \code{\link[bslib:bs_theme]{bslib::bs_theme()}} object. This can be used to replace a stock
+build of Bootstrap 3 with a customized version of Bootstrap 3 or higher.
+\item A character string pointing to an alternative Bootstrap stylesheet
+(normally a css file within the www directory, e.g. \code{www/bootstrap.css}).
+}}
 
 \item{lang}{ISO 639-1 language code for the HTML page, such as "en" or "ko".
 This will be used as the lang in the \code{<html>} tag, as in \code{<html lang="en">}.

--- a/man/navbarPage.Rd
+++ b/man/navbarPage.Rd
@@ -71,9 +71,14 @@ layout.}
 \item{responsive}{This option is deprecated; it is no longer optional with
 Bootstrap 3.}
 
-\item{theme}{Alternative Bootstrap stylesheet (normally a css file within the
-www directory). For example, to use the theme located at
-\code{www/bootstrap.css} you would use \code{theme = "bootstrap.css"}.}
+\item{theme}{One of the following:
+\itemize{
+\item \code{NULL} (the default), which implies a "stock" build of Bootstrap 3.
+\item A \code{\link[bslib:bs_theme]{bslib::bs_theme()}} object. This can be used to replace a stock
+build of Bootstrap 3 with a customized version of Bootstrap 3 or higher.
+\item A character string pointing to an alternative Bootstrap stylesheet
+(normally a css file within the www directory, e.g. \code{www/bootstrap.css}).
+}}
 
 \item{windowTitle}{The title that should be displayed by the browser window.
 Useful if \code{title} is not a string.}


### PR DESCRIPTION
Fixes the fact that `?fluidPage`, `?navbarPage`, etc all have outdated documentation (they don't mention `{bslib}`)