### PR TITLE
mismatched time units

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -478,7 +478,7 @@ serviceApp <- function() {
   # to keep the session responsive to user input
   maxTimeout <- ifelse(interactive(), 100, 1000)
 
-  timeout <- max(1, min(maxTimeout, timerCallbacks$timeToNextEvent(), later::next_op_secs()))
+  timeout <- max(1, min(maxTimeout, timerCallbacks$timeToNextEvent(), later::next_op_secs() * 1000))
   service(timeout)
 
   flushReact()


### PR DESCRIPTION
`httpuv::service(timeoutMs)` takes time in milliseconds. The first two parameters (`maxTimeout` and `timerCallback$timeToNextEvent()`) are in ms, the final `later::next_op_secs` is in seconds.

With the mismatched units the `min()` call would've resulted in a very small value (because of the `later` argument being in seconds), leading to short timeouts, possibly increasing unnecessary polling (and perhaps higher-than-needed CPU usage?).