### PR TITLE
glyphicons hyperlink should be pinned to Bootstrap 3 docs

### DIFF
--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -1600,7 +1600,7 @@ downloadLink <- function(outputId, label="Download", class=NULL, ...) {
 #' @param name Name of icon. Icons are drawn from the
 #'   [Font Awesome Free](https://fontawesome.com/) (currently icons from
 #'   the v5.13.0 set are supported with the v4 naming convention) and
-#'   [Glyphicons](https://getbootstrap.com/components/#glyphicons)
+#'   [Glyphicons](https://getbootstrap.com/docs/3.4/components/)
 #'   libraries. Note that the "fa-" and "glyphicon-" prefixes should not be used
 #'   in icon names (i.e. the "fa-calendar" icon should be referred to as
 #'   "calendar")

--- a/man/icon.Rd
+++ b/man/icon.Rd
@@ -10,7 +10,7 @@ icon(name, class = NULL, lib = "font-awesome", ...)
 \item{name}{Name of icon. Icons are drawn from the
 \href{https://fontawesome.com/}{Font Awesome Free} (currently icons from
 the v5.13.0 set are supported with the v4 naming convention) and
-\href{https://getbootstrap.com/components/#glyphicons}{Glyphicons}
+\href{https://getbootstrap.com/docs/3.4/components/}{Glyphicons}
 libraries. Note that the "fa-" and "glyphicon-" prefixes should not be used
 in icon names (i.e. the "fa-calendar" icon should be referred to as
 "calendar")}


### PR DESCRIPTION
The current link (confusingly) links to the current version of Bootstrap, which has dropped glyphicons