### PR TITLE
Fixed automatic guessing of Content-Type in downloadHandler

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,9 @@ shiny 1.6.0.9000
 
 * Exported `register_devmode_option()`. This method was described in the documentation for `devmode()` but was never exported. See `?devmode()` for more details on how to register Shiny Developer options using `register_devmode_option()`. (#3364)
 
+* Restored the previous behavior of automatically guessing the `Content-Type` header for
+  `downloadHandler` functions when no explicit `contentType` argument is supplied.
+
 ### Library updates
 
 * Closed #3286: Updated to Font-Awesome 5.15.2. (#3288)

--- a/R/shinywrappers.R
+++ b/R/shinywrappers.R
@@ -711,9 +711,9 @@ renderUI <- function(expr, env = parent.frame(), quoted = FALSE,
 #'   function.)
 #' @param contentType A string of the download's
 #'   [content type](https://en.wikipedia.org/wiki/Internet_media_type), for
-#'   example `"text/csv"` or `"image/png"`. If `NULL` or
-#'   `NA`, the content type will be guessed based on the filename
-#'   extension, or `application/octet-stream` if the extension is unknown.
+#'   example `"text/csv"` or `"image/png"`. If `NULL`, the content type 
+#'   will be guessed based on the filename extension, or 
+#'   `application/octet-stream` if the extension is unknown.
 #' @param outputArgs A list of arguments to be passed through to the implicit
 #'   call to [downloadButton()] when `downloadHandler` is used
 #'   in an interactive R Markdown document.
@@ -743,7 +743,7 @@ renderUI <- function(expr, env = parent.frame(), quoted = FALSE,
 #' shinyApp(ui, server)
 #' }
 #' @export
-downloadHandler <- function(filename, content, contentType=NA, outputArgs=list()) {
+downloadHandler <- function(filename, content, contentType=NULL, outputArgs=list()) {
   renderFunc <- function(shinysession, name, ...) {
     shinysession$registerDownload(name, filename, contentType, content)
   }


### PR DESCRIPTION
Commit [`e44a9b1`](https://github.com/rstudio/shiny/commit/e44a9b1dedf9b16f7c8d776e9edfc45e60512519) changed uses of `%OR%` to rlang's `%||%` operator. The latter is less restrictive in what is considered truthy, and the default `NA` value of the `contentType` argument is considered truthy. As a result, a `downloadHandler` that does not supply an explicit `contentType` argument will use `NA`, which will result in the server returning `Content-Type: NA` in the response headers.

This pull request changes the default value of the `contentType` argument to `NULL` which results in the `getContentType(...)` function being evaluated [in the request handler](https://github.com/rstudio/shiny/blob/d65ad5ea90a3ab7bbc75bb597272a2da80beb7c5/R/shiny.R#L1952), thus restoring the intended behavior for download handlers that don't supply an explicit `contentType`.