### PR TITLE
Remove Font Awesome 5 message about the `level-up` icon

### DIFF
--- a/R/showcase.R
+++ b/R/showcase.R
@@ -134,7 +134,7 @@ showcaseCodeTabs <- function(codeLicense) {
     a(id="showcase-code-position-toggle",
       class="btn btn-default btn-sm",
       onclick="toggleCodePosition()",
-      icon("level-up"),
+      icon("level-up-alt"),
       "show with app"),
     ul(class="nav nav-tabs",
        navTabsHelper(rFiles),


### PR DESCRIPTION
Message:

> The `name` provided ('level-up') is deprecated in Font Awesome 5:
> * please consider using 'level-up-alt' or 'fas fa-level-up-alt' instead
> * use the `verify_fa = FALSE` to deactivate these messages