### PR TITLE
Various cleanup

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@ shiny 1.6.0.9000
 
 * The `format` and `locale` arguments to `sliderInput()` have been removed. They have been deprecated since 0.10.2.2 (released on 2014-12-08).
 
+* Closed #3403: `insertTab()` with `target = NULL` now inserts the `tab` before (instead of after) the tabset when `position = "before"` (which is the default). (#3404)
+
 ### New features and improvements
 
 * Bootstrap 5 support. (#3410 and rstudio/bslib#304)

--- a/R/input-slider.R
+++ b/R/input-slider.R
@@ -229,8 +229,11 @@ ionRangeSliderDependencyCSS <- function(theme) {
   }
 
   bslib::bs_dependency(
-    input = sass::sass_file(
-      system.file(package = "shiny", "www/shared/ionrangeslider/scss/shiny.scss")
+    input = list(
+      list(accent = "$component-active-bg"),
+      sass::sass_file(
+        system.file(package = "shiny", "www/shared/ionrangeslider/scss/shiny.scss")
+      )
     ),
     theme = theme,
     name = "ionRangeSlider",

--- a/R/insert-tab.R
+++ b/R/insert-tab.R
@@ -137,14 +137,14 @@ insertTab <- function(inputId, tab, target = NULL,
 #' @export
 prependTab <- function(inputId, tab, select = FALSE, menuName = NULL,
                        session = getDefaultReactiveDomain()) {
-  bslib::tab_prepend(inputId, tab, menu_title = menuName, select = select, session = session)
+  bslib::nav_prepend(inputId, tab, menu_title = menuName, select = select, session = session)
 }
 
 #' @rdname insertTab
 #' @export
 appendTab <- function(inputId, tab, select = FALSE, menuName = NULL,
                       session = getDefaultReactiveDomain()) {
-  bslib::tab_append(inputId, tab, menu_title = menuName, select = select, session = session)
+  bslib::nav_append(inputId, tab, menu_title = menuName, select = select, session = session)
 }
 
 #' @rdname insertTab

--- a/inst/www/shared/ionrangeslider/css/ion.rangeSlider.css
+++ b/inst/www/shared/ionrangeslider/css/ion.rangeSlider.css
@@ -172,9 +172,9 @@
 .irs--shiny .irs-bar {
   top: 25px;
   height: 8px;
-  border-top: 1px solid #337ab7;
-  border-bottom: 1px solid #337ab7;
-  background: #337ab7;
+  border-top: 1px solid #428bca;
+  border-bottom: 1px solid #428bca;
+  background: #428bca;
 }
 
 .irs--shiny .irs-bar--single {
@@ -228,7 +228,7 @@
   color: #fff;
   text-shadow: none;
   padding: 1px 3px;
-  background-color: #337ab7;
+  background-color: #428bca;
   border-radius: 3px;
   font-size: 11px;
   line-height: 1.333;

--- a/inst/www/shared/ionrangeslider/scss/shiny.scss
+++ b/inst/www/shared/ionrangeslider/scss/shiny.scss
@@ -37,7 +37,7 @@ $font-family: $font-family-base !default;
   // "High-level" coloring
   $bg:     $body-bg !default;
   $fg:     color-contrast($body-bg) !default;
-  $accent: $component-active-bg !default;
+  $accent: #428bca !default;
 
   // "Low-level" coloring, borders, and fonts
   $line_bg:            linear-gradient(to bottom, mix($bg, $fg, 87%) -50%, $bg 150%) !default;

--- a/tests/testthat/_snaps/tabPanel.md
+++ b/tests/testthat/_snaps/tabPanel.md
@@ -313,10 +313,10 @@
     Output
       <div class="tabbable">
         <ul class="nav nav-tabs" data-tabsetid="4785">
-          <li class="active">
+          <li>
             <a href="#tab-4785-1" data-toggle="tab" data-bs-toggle="tab"></a>
           </li>
-          <li>
+          <li class="active">
             <a href="#tab-4785-2" data-toggle="tab" data-bs-toggle="tab" data-value="A">A</a>
           </li>
           <li>
@@ -338,8 +338,8 @@
           </li>
         </ul>
         <div class="tab-content" data-tabsetid="4785">
-          <div class="active" id="tab-4785-1">A div</div>
-          <div class="tab-pane" data-value="A" id="tab-4785-2">a</div>
+          <div id="tab-4785-1">A div</div>
+          <div class="tab-pane active" data-value="A" id="tab-4785-2">a</div>
           <div class="tab-pane" data-value="B" data-icon-class="fab fa-github fa-fw" id="tab-4785-3">b</div>
           <div class="tab-pane" data-value="C" id="tab-1502-1">c</div>
         </div>

--- a/tools/ion.rangeSlider-patches/0001-Add-skin-customized-for-Shiny.patch
+++ b/tools/ion.rangeSlider-patches/0001-Add-skin-customized-for-Shiny.patch
@@ -43,7 +43,7 @@ index 00000000..ba052f8b
 +  // "High-level" coloring
 +  $bg:     $body-bg !default;
 +  $fg:     color-contrast($body-bg) !default;
-+  $accent: $component-active-bg !default;
++  $accent: #428bca !default;
 +
 +  // "Low-level" coloring, borders, and fonts
 +  $line_bg:            linear-gradient(to bottom, mix($bg, $fg, 87%) -50%, $bg 150%) !default;


### PR DESCRIPTION
e089e73 is a follow up to #3366 (the primary intention of that PR was to fix `sliderInput()`'s color contrast with dark themes, not to change the default accent color)

04e0151 and 64799f5 are a follow up to #3404

04cb537 is a follow up to https://github.com/rstudio/bslib/pull/332 (non-`tabPanel()` are no longer considered when determining which tab should be shown by default)