### PR TITLE
Replace dev versions with `-alpha` versions for JS code

### DIFF
--- a/.github/workflows/rituals.yaml
+++ b/.github/workflows/rituals.yaml
@@ -128,7 +128,8 @@ jobs:
         run: |
           Rscript -e 'pak::pkg_install("jsonlite")'
           Rscript -e 'pkg <- jsonlite::read_json("package.json", simplifyVector = TRUE)' \
-          -e 'pkg$version <- as.list(read.dcf("DESCRIPTION")[1,])$Version' \
+          -e 'version <- as.list(read.dcf("DESCRIPTION")[1,])$Version' \
+          -e 'pkg$version <- gsub("^(\\d+).(\\d+).(\\d+).(.+)$", "\\1.\\2.\\3-alpha.\\4", version)' \
           -e 'pkg$files <- as.list(pkg$files)' \
           -e 'jsonlite::write_json(pkg, path = "package.json", pretty = TRUE, auto_unbox = TRUE)'
           git add package.json && git commit -m 'sync package version (GitHub Actions)' || echo "No version changes to commit"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "homepage": "https://shiny.rstudio.com",
   "repository": "github:rstudio/shiny",
   "name": "@types/shiny",
-  "version": "1.6.0.9021",
+  "version": "1.6.0-alpha.9021",
   "license": "GPL-3.0-only",
   "main": "",
   "browser": "",


### PR DESCRIPTION
Fixes types installation error:
```
error Can't add "@types/shiny": invalid package version "1.6.0.9021". 
```