### PR TITLE
Revert 3413

### DIFF
--- a/R/input-select.R
+++ b/R/input-select.R
@@ -208,15 +208,6 @@ selectizeIt <- function(inputId, select, options, nonempty = FALSE) {
     options$plugins <- c(options$plugins, list('selectize-plugin-a11y'))
   }
 
-  # to prevent clipping of the selectize drop-down we set the dropdownParent
-  # to "body". This might be necessary if e.g. overflow-x: scroll is set
-  # on it's container, which forces overflow-y to 'auto' (as per
-  # https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-y). Discussion
-  # of usage here: https://github.com/selectize/selectize.js/issues/192
-  if (is.null(options$dropdownParent)) {
-    options$dropdownParent <- "body"
-  }
-
   res <- checkAsIs(options)
 
   deps <- list(selectizeDependency())


### PR DESCRIPTION
Fixes #3448

Reverts #3413, which introduced https://github.com/rstudio/shiny/issues/3448. 

After discussing this with @jjallaire, we decided that, for his use case, he'll avoid setting `overflow-x: scroll` (which implies `overflow-y: scroll`) on code chunks that produce a `selectizeInput()`