### PR TITLE
Make disconnected overlay sizing styles stronger

### DIFF
--- a/inst/www/shared/shiny_scss/shiny.scss
+++ b/inst/www/shared/shiny_scss/shiny.scss
@@ -92,6 +92,8 @@ pre.shiny-text-output {
   bottom: 0;
   left: 0;
   right: 0;
+  max-width: 100%;  /* Make sure width isn't restricted by styles on selectors like "body > div" */
+  max-height: 100%;
   background-color: $shiny-disconnected-bg;
   opacity: 0.5;
   overflow: hidden;


### PR DESCRIPTION
If you have an app with a rather innocent line of css that restricts sizes of children of the body such as: `body > div { max-width: 400px; max-height: 400px; }` this will cause the disconnected overlay div to be too small as well. 

This would be fine if it still covered the children, but because of the styles of `left, right, top, bottom` being set explicitly it will always be stuck to the upper-left of the viewport. Here's a minimum app example where the aforementioned styles were used to make the content horizontally centered on the screen and not allowed to get too big.

```
library(shiny)
shinyApp(
  ui = fluidPage(
    tags$head(
      tags$style(
        HTML("body > div { max-width: 400px; max-height: 400px; }
                    #content { margin: 0 auto; background: salmon; }")
      )
    ),
    div(id = "content", "Here's my content")
  ),
  server = function(input, output) {}
)
```

## Current behavior
If we run this app and then the disconnected overlay gets triggered (by simply killing the app process) we get this rather confusing result: 
![image](https://user-images.githubusercontent.com/6764693/124320715-64cab080-db4a-11eb-9f92-571097845def.png)

## New behavior
And here's the result after the changes in this PR:
![image](https://user-images.githubusercontent.com/6764693/124320769-82981580-db4a-11eb-8461-c40eb80ed91c.png)

