### PR TITLE
Adjust app port tests to use random port values

### DIFF
--- a/tests/test-helpers/app7-port/app.R
+++ b/tests/test-helpers/app7-port/app.R
@@ -7,10 +7,7 @@ server <- function(input, output, session) {
 }
 
 opts <- list(
-  port = Sys.getenv(
-    "SHINY_TEST_PORT_APP",
-    stop("`Sys.env('SHINY_TEST_PORT_APP')` not found")
-  ),
+  port = as.numeric(readLines(tempdir(), "shiny_testthat_port", "app")),
   launch.browser = FALSE
 )
 

--- a/tests/test-helpers/app7-port/app.R
+++ b/tests/test-helpers/app7-port/app.R
@@ -7,7 +7,10 @@ server <- function(input, output, session) {
 }
 
 opts <- list(
-  port = 3030,
+  port = Sys.getenv(
+    "SHINY_TEST_PORT_APP",
+    stop("`Sys.env('SHINY_TEST_PORT_APP')` not found")
+  ),
   launch.browser = FALSE
 )
 

--- a/tests/test-helpers/app7-port/app.R
+++ b/tests/test-helpers/app7-port/app.R
@@ -7,7 +7,7 @@ server <- function(input, output, session) {
 }
 
 opts <- list(
-  port = as.numeric(readLines(tempdir(), "shiny_testthat_port", "app")),
+  port = as.numeric(Sys.getenv("SHINY_TESTTHAT_PORT_APP", "8080")),
   launch.browser = FALSE
 )
 

--- a/tests/test-helpers/app7-port/option-broken.R
+++ b/tests/test-helpers/app7-port/option-broken.R
@@ -1,6 +1,6 @@
 library(shiny)
 
-op <- options(shiny.port = 7777)
+op <- options(shiny.port = httpuv::randomPort())
 onStop(function() { options(op) })
 
 stop("boom")

--- a/tests/test-helpers/app7-port/option.R
+++ b/tests/test-helpers/app7-port/option.R
@@ -1,6 +1,9 @@
 library(shiny)
 
-op <- options(shiny.port = 7777)
+op <- options(shiny.port = Sys.getenv(
+  "SHINY_TEST_PORT_OPTION",
+  stop("`Sys.env('SHINY_TEST_PORT_OPTION')` not found")
+))
 onStop(function() { options(op) })
 
 ui <- fluidPage(

--- a/tests/test-helpers/app7-port/option.R
+++ b/tests/test-helpers/app7-port/option.R
@@ -1,6 +1,6 @@
 library(shiny)
 
-op <- options(shiny.port = as.numeric(readLines(tempdir(), "shiny_testthat_port", "option")))
+op <- options(shiny.port = as.numeric(Sys.getenv("SHINY_TESTTHAT_PORT_OPTION", "8080")))
 onStop(function() { options(op) })
 
 ui <- fluidPage(

--- a/tests/test-helpers/app7-port/option.R
+++ b/tests/test-helpers/app7-port/option.R
@@ -1,9 +1,6 @@
 library(shiny)
 
-op <- options(shiny.port = Sys.getenv(
-  "SHINY_TEST_PORT_OPTION",
-  stop("`Sys.env('SHINY_TEST_PORT_OPTION')` not found")
-))
+op <- options(shiny.port = as.numeric(readLines(tempdir(), "shiny_testthat_port", "option")))
 onStop(function() { options(op) })
 
 ui <- fluidPage(

--- a/tests/test-helpers/app7-port/wrapped2.R
+++ b/tests/test-helpers/app7-port/wrapped2.R
@@ -1,6 +1,6 @@
 shinyAppFile(
   "wrapped.R",
   options = list(
-    port = as.numeric(readLines(tempdir(), "shiny_testthat_port", "wrapped2"))
+    port = as.numeric(Sys.getenv("SHINY_TESTTHAT_PORT_WRAPPED2", "8080"))
   )
 )

--- a/tests/test-helpers/app7-port/wrapped2.R
+++ b/tests/test-helpers/app7-port/wrapped2.R
@@ -1,9 +1,6 @@
 shinyAppFile(
   "wrapped.R",
   options = list(
-    port = Sys.getenv(
-      "SHINY_TEST_PORT_WRAPPED_2",
-      stop("`Sys.env('SHINY_TEST_PORT_WRAPPED_2')` not found")
-    )
+    port = as.numeric(readLines(tempdir(), "shiny_testthat_port", "wrapped2"))
   )
 )

--- a/tests/test-helpers/app7-port/wrapped2.R
+++ b/tests/test-helpers/app7-port/wrapped2.R
@@ -1,1 +1,9 @@
-shinyAppFile("wrapped.R", options = list(port = 3032))
+shinyAppFile(
+  "wrapped.R",
+  options = list(
+    port = Sys.getenv(
+      "SHINY_TEST_PORT_WRAPPED_2",
+      stop("`Sys.env('SHINY_TEST_PORT_WRAPPED_2')` not found")
+    )
+  )
+)

--- a/tests/testthat/test-app.R
+++ b/tests/testthat/test-app.R
@@ -207,9 +207,9 @@ test_that("Setting options in various places works", {
   # https://github.com/rstudio/shiny/pull/3488
   # Try up to 100 times to find a unique port
   for (i in 1:100) {
-    test_app_port      <- make_and_save_port("app")
-    test_wrapped2_port <- make_and_save_port("wrapped2")
-    test_option_port   <- make_and_save_port("option")
+    test_app_port      <- httpuv::randomPort()
+    test_wrapped2_port <- httpuv::randomPort()
+    test_option_port   <- httpuv::randomPort()
     # If all ports are unique, move on
     if (length(unique(
       c(test_app_port, test_wrapped2_port, test_option_port)

--- a/tests/testthat/test-app.R
+++ b/tests/testthat/test-app.R
@@ -236,8 +236,16 @@ test_that("Setting options in various places works", {
 
   expect_port <- function(expr, port) {
     later::later(~stopApp(), 0)
-    expect_message(expr, paste0("Listening on http://127.0.0.1:", port), fixed = TRUE)
+    testthat::expect_message(expr, paste0("Listening on http://127.0.0.1:", port), fixed = TRUE)
   }
+
+  withr::local_envvar(
+    list(
+      SHINY_TESTTHAT_PORT_APP      = as.character(test_app_port),
+      SHINY_TESTTHAT_PORT_WRAPPED2 = as.character(test_wrapped2_port),
+      SHINY_TESTTHAT_PORT_OPTION   = as.character(test_option_port)
+    )
+  )
 
   expect_port(runApp(appDir), test_app_port)
 
@@ -276,4 +284,6 @@ test_that("Setting options in various places works", {
   # onStop still works even if app.R has an error (ensure option was unset)
   expect_error(runApp(file.path(appDir, "option-broken.R")), "^boom$")
   expect_null(getOption("shiny.port"))
+
+
 })

--- a/tests/testthat/test-app.R
+++ b/tests/testthat/test-app.R
@@ -222,9 +222,18 @@ test_that("Setting options in various places works", {
   dir.create(test_fldr, showWarnings = FALSE)
   on.exit({unlink(test_fldr, recursive = TRUE)}, add = TRUE)
 
-  test_app_port      <- make_and_save_port("app")
-  test_wrapped2_port <- make_and_save_port("wrapped2")
-  test_option_port   <- make_and_save_port("option")
+  # Try up to 100 times to find a unique port
+  for (i in 1:100) {
+    test_app_port      <- make_and_save_port("app")
+    test_wrapped2_port <- make_and_save_port("wrapped2")
+    test_option_port   <- make_and_save_port("option")
+    # If all ports are unique, move on
+    if (length(unique(
+      c(test_app_port, test_wrapped2_port, test_option_port)
+    )) == 3) {
+      break
+    }
+  }
 
   appDir <- test_path("../test-helpers/app7-port")
   withPort <- function(port, expr) {

--- a/tests/testthat/test-app.R
+++ b/tests/testthat/test-app.R
@@ -218,7 +218,7 @@ test_that("Setting options in various places works", {
 
   withr::local_envvar(list(
     SHINY_TEST_PORT_APP = test_app_port,
-    SHINY_TEST_PORT_WRAPPED_2 = test_wrapped_2_port
+    SHINY_TEST_PORT_WRAPPED_2 = test_wrapped_2_port,
     SHINY_TEST_PORT_OPTION = test_option_port
   ))
 


### PR DESCRIPTION
This change allows `revdepcheck` to run in parallel without errors