### PR TITLE
enhances error for missing label and message arguments in `need()`

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -1052,8 +1052,10 @@ validate <- function(..., errorClass = character(0)) {
 #' @rdname validate
 need <- function(expr, message = paste(label, "must be provided"), label) {
 
-  force(message) # Fail fast on message/label both being missing
-
+  if (missing(label) && missing(message)) {
+    return("label is missing in `need()`")
+  }
+  
   if (!isTruthy(expr))
     return(message)
   else


### PR DESCRIPTION
Close #2509.

Fast fail on missing arguments is also now more readable and has a more informative error message.

```r
> need(1+1)
[1] "label is missing in `need()`"
```