### PR TITLE
Fix failing tabPanel() test broken by testthat 3.1.0

### DIFF
--- a/tests/testthat/test-tabPanel.R
+++ b/tests/testthat/test-tabPanel.R
@@ -75,7 +75,7 @@ test_that("String input is handled properly", {
 
 test_that("Shiny.tag input produces a warning", {
   panels3 <- c(list(div("A div")), panels)
-  tab_tags <- expect_warning(tabset_panel(!!!panels3))
+  expect_warning(tab_tags <- tabset_panel(!!!panels3))
   # Carson March 12th, 2021: Yes, he 'empty nav' output here isn't
   # sensible (which is why we now throw a warning), but it's probably
   # too late to change the behavior (it could break user code to do


### PR DESCRIPTION
Fixes https://github.com/rstudio/shiny/runs/4121823538?check_suite_focus=true#step:11:204

For context, see testthat 3.1.0's breaking changes https://github.com/r-lib/testthat/blame/main/NEWS.md#L39