### PR TITLE
Cache the reactlog version found. Remove `mustWork` argument to `system_file()`.

### DIFF
--- a/R/graph.R
+++ b/R/graph.R
@@ -115,22 +115,28 @@ check_reactlog <- function() {
 }
 # read reactlog version from description file
 # prevents version mismatch in code and description file
-reactlog_version <- function() {
-  desc <- read.dcf(system_file("DESCRIPTION", package = "shiny", mustWork = TRUE))
-  suggests <- desc[1,"Suggests"][[1]]
-  suggests_pkgs <- strsplit(suggests, "\n")[[1]]
+reactlog_version <- local({
+  version <- NULL
+  function() {
+    if (!is.null(version)) return(version)
 
-  reactlog_info <- suggests_pkgs[grepl("reactlog", suggests_pkgs)]
-  if (length(reactlog_info) == 0) {
-    stop("reactlog can not be found in shiny DESCRIPTION file")
+    desc <- read.dcf(system_file("DESCRIPTION", package = "shiny"))
+    suggests <- desc[1,"Suggests"][[1]]
+    suggests_pkgs <- strsplit(suggests, "\n")[[1]]
+
+    reactlog_info <- suggests_pkgs[grepl("reactlog", suggests_pkgs)]
+    if (length(reactlog_info) == 0) {
+      stop("reactlog can not be found in shiny DESCRIPTION file")
+    }
+
+    reactlog_info <- sub("^[^\\(]*\\(", "", reactlog_info)
+    reactlog_info <- sub("\\)[^\\)]*$", "", reactlog_info)
+    reactlog_info <- sub("^[>= ]*", "", reactlog_info)
+
+    version <<- package_version(reactlog_info)
+    version
   }
-
-  reactlog_info <- sub("^[^\\(]*\\(", "", reactlog_info)
-  reactlog_info <- sub("\\)[^\\)]*$", "", reactlog_info)
-  reactlog_info <- sub("^[>= ]*", "", reactlog_info)
-
-  package_version(reactlog_info)
-}
+})
 
 
 RLog <- R6Class(


### PR DESCRIPTION
From https://github.com/rstudio/shiny/pull/3541/files#diff-639545e1944c282101f0b3dbaf5a26bbd7a00198fb75331e8bffb25c318130ae , the new `system_file()` was used. This makes the `mustWork` argument unnecessary.  

Before the PR, if `mustWork` existed, it would throw and error: `All arguments other than `package` must be unnamed.`
Now, reactlog works as expected.

cc @MadhulikaTanuboddi 

Fixes https://github.com/rstudio/shinycoreci-apps/issues/196