### PR TITLE
Handle chained errors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,8 @@ shiny 1.7.1.9001
 
 ### Bug fixes
 
+* Closed tidyverse/dplyr#5552: Compatibility of dplyr 1.0 (and rlang chained errors in general) with `req()`, `validate()`, and friends.
+
 * Closed #2955: Input and output bindings previously attempted to use `el['data-input-id']`, but that never worked. They now use `el.getAttribute('data-input-id')` instead. (#3538)
 
 

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -228,7 +228,9 @@ withLogErrors <- function(expr,
       if (promises::is.promise(result)) {
         result <- promises::catch(result, function(cond) {
           # Don't print shiny.silent.error (i.e. validation errors)
-          if (inherits(cond, "shiny.silent.error")) return()
+          if (cnd_inherits(cond, "shiny.silent.error")) {
+            return()
+          }
           if (isTRUE(getOption("show.error.messages"))) {
             printError(cond, full = full, offset = offset)
           }
@@ -239,7 +241,7 @@ withLogErrors <- function(expr,
     },
     error = function(cond) {
       # Don't print shiny.silent.error (i.e. validation errors)
-      if (inherits(cond, "shiny.silent.error")) return()
+      if (cnd_inherits(cond, "shiny.silent.error")) return()
       if (isTRUE(getOption("show.error.messages"))) {
         printError(cond, full = full, offset = offset)
       }

--- a/R/reactives.R
+++ b/R/reactives.R
@@ -1203,7 +1203,7 @@ Observer <- R6Class(
             # validation = function(e) NULL,
             # shiny.output.cancel = function(e) NULL
 
-            if (inherits(e, "shiny.silent.error")) {
+            if (cnd_inherits(e, "shiny.silent.error")) {
               return()
             }
 

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -1114,7 +1114,12 @@ ShinySession <- R6Class(
                   structure(list(), class = "try-error", condition = cond)
                 } else if (inherits(cond, "shiny.output.cancel")) {
                   structure(list(), class = "cancel-output")
-                } else if (inherits(cond, "shiny.silent.error")) {
+                } else if (cnd_inherits(cond, "shiny.silent.error")) {
+                  # The error condition might have been chained by
+                  # foreign code, e.g. dplyr. Find the original error.
+                  while (!inherits(cond, "shiny.silent.error")) {
+                    cond <- cond$parent
+                  }
                   # Don't let shiny.silent.error go through the normal stop
                   # path of try, because we don't want it to print. But we
                   # do want to try to return the same looking result so that

--- a/R/utils.R
+++ b/R/utils.R
@@ -472,7 +472,7 @@ shinyCallingHandlers <- function(expr) {
   withCallingHandlers(captureStackTraces(expr),
     error = function(e) {
       # Don't intercept shiny.silent.error (i.e. validation errors)
-      if (inherits(e, "shiny.silent.error"))
+      if (cnd_inherits(e, "shiny.silent.error"))
         return()
 
       handle <- getOption('shiny.error')
@@ -1691,4 +1691,22 @@ findEnclosingApp <- function(path = ".") {
       stop("Shiny app not found at ", orig_path, " or in any parent directory.")
     path <- dirname(path)
   }
+}
+
+# Until `rlang::cnd_inherits()` is on CRAN
+cnd_inherits <- function(cnd, class) {
+  cnd_some(cnd, ~ inherits(.x, class))
+}
+cnd_some <- function(.cnd, .p, ...) {
+  .p <- rlang::as_function(.p)
+
+  while (rlang::is_condition(.cnd)) {
+    if (.p(.cnd, ...)) {
+      return(TRUE)
+    }
+
+    .cnd <- .cnd$parent
+  }
+
+  FALSE
 }

--- a/tests/testthat/test-stacks.R
+++ b/tests/testthat/test-stacks.R
@@ -196,6 +196,28 @@ test_that("shiny.error", {
   expect_null(caught)
 })
 
+test_that("chained silent errors aren't intercepted (tidyverse/dplyr#5552)", {
+  withr::local_options(
+    shiny.error = function() caught <<- TRUE
+  )
+
+  f <- function() {
+    withCallingHandlers(
+      validate(need(NULL, FALSE)),
+      error = function(cnd) {
+        rlang::abort("Child error.", parent = cnd)
+      }
+    )
+  }
+  caught <- NULL
+  try(shiny:::shinyCallingHandlers(f()), silent = TRUE)
+  expect_null(caught)
+
+  caught <- NULL
+  try(hybrid_chain(f()), silent = TRUE)
+  expect_null(caught)
+})
+
 test_that("validation error logging", {
   caught <- NULL
 


### PR DESCRIPTION
Closes tidyverse/dplyr#5552
Part of #3566. See this issue for context.

This PR makes Shiny compatible with dplyr error wrapping by detecting silent errors using `cnd_inherits()` instead of `inherits()`. This makes it compatible with rlang chained errors created with the `parent` argument of `rlang::abort()`.

Non-chained wrapped errors will still cause unexpected behaviours with `req()` and friends. Also error handlers that systematically demote errors to warnings will still interfere with `"shiny.silent.error"` errors.