### PR TITLE
devmode should activate autoreload

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,7 +13,9 @@ shiny development
 
 * Default for `ref` input in `runGithub()` changed from `"master"` to `"HEAD"`. (#3346)
 
-* When taking a test snapshot, the sort order of the json keys of the `input`, `output`, and `export` fields is currently sorted using the locale of the machine. This can lead to inconsistent test snapshot results. To opt-in to a consistent ordering of snapshot fields with `{shinytest}`, please set the global option `options(shiny.snapshotsortc = TRUE)`. `{shinytest2}` users do not need to set this value.  (#3515)
+* When taking a test snapshot, the sort order of the json keys of the `input`, `output`, and `export` fields is currently sorted using the locale of the machine. This can lead to inconsistent test snapshot results. To opt-in to a consistent ordering of snapshot fields with `{shinytest}`, please set the global option `options(shiny.snapshotsortc = TRUE)`. `{shinytest2}` users do not need to set this value. (#3515)
+
+* The auto-reload feature (`options(shiny.autoreload=TRUE)`) was not being activated by `devmode(TRUE)`, despite a console message asserting that it was. (#3620)
 
 ### Bug fixes
 

--- a/R/shinyapp.R
+++ b/R/shinyapp.R
@@ -286,7 +286,7 @@ shinyAppDir_serverR <- function(appDir, options=list()) {
 #
 # The return value is a function that halts monitoring when called.
 initAutoReloadMonitor <- function(dir) {
-  if (!getOption("shiny.autoreload", FALSE)) {
+  if (!get_devmode_option("shiny.autoreload", FALSE)) {
     return(function(){})
   }
 


### PR DESCRIPTION
It said it didn't, but until this commit, it appeared not to.

## Testing notes

Create an app.R with a simple app. Do NOT have `options(shiny.autoreload=TRUE)` set.

```r
library(shiny)

ui <- "hello"

server <- function(input, output, session) {
}

shinyApp(ui, server)
```

Launch the app under devmode. You can do this from the terminal:

```
R --quiet -e 'shiny::devmode(TRUE); shiny::runApp("app.R", launch.browser=TRUE)'
```

Edit app.R, changing the UI string from "hello" to something else, and save. With this fix, you should see the browser window reload automatically.

## Testing notes 2

Same as before, but this time:

```
R --quiet -e 'shiny::devmode(TRUE); options(shiny.autoreload=FALSE); shiny::runApp("app.R", launch.browser=TRUE)'
```

This time, you should NOT see the browser window reload automatically when you save changes to app.R.
