### PR TITLE
Corrected for stricter length checking in R 4.2.0

### DIFF
--- a/R/bootstrap-layout.R
+++ b/R/bootstrap-layout.R
@@ -516,7 +516,7 @@ splitLayout <- function(..., cellWidths = NULL, cellArgs = list()) {
   children <- children[childIdx]
   count <- length(children)
 
-  if (length(cellWidths) == 0 || is.na(cellWidths)) {
+  if (length(cellWidths) == 0 || any(is.na(cellWidths))) {
     cellWidths <- sprintf("%.3f%%", 100 / count)
   }
   cellWidths <- rep(cellWidths, length.out = count)

--- a/R/bootstrap-layout.R
+++ b/R/bootstrap-layout.R
@@ -516,7 +516,7 @@ splitLayout <- function(..., cellWidths = NULL, cellArgs = list()) {
   children <- children[childIdx]
   count <- length(children)
 
-  if (length(cellWidths) == 0 || any(is.na(cellWidths))) {
+  if (length(cellWidths) == 0 || isTRUE(is.na(cellWidths))) {
     cellWidths <- sprintf("%.3f%%", 100 / count)
   }
   cellWidths <- rep(cellWidths, length.out = count)


### PR DESCRIPTION
https://github.com/rstudio/shiny/issues/3619


library(shiny)
splitLayout(cellWidths = c("25%", "75%"),
            plotOutput("plot1"),
            plotOutput("plot2"))
#> Warning in length(cellWidths) == 0 || is.na(cellWidths): 'length(x) = 2 > 1' in
#> coercion to 'logical(1)'
