### PR TITLE
make mathjax configurable

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,8 @@ shiny development
 
 * The auto-reload feature (`options(shiny.autoreload=TRUE)`) was not being activated by `devmode(TRUE)`, despite a console message asserting that it was. (#3620)
 
+* Add `shiny.mathjax.url` and `shiny.mathjax.config` options for configuring the MathJax URL used by `withMathJax`. Thanks, @Neutron3529! (#3639)
+
 ### Bug fixes
 
 * Closed tidyverse/dplyr#5552: Compatibility of dplyr 1.0 (and rlang chained errors in general) with `req()`, `validate()`, and friends.

--- a/R/shiny-options.R
+++ b/R/shiny-options.R
@@ -94,10 +94,10 @@ getShinyOption <- function(name, default = NULL) {
 #'   numbers to JSON format to send to the client web browser.}
 #' \item{shiny.launch.browser (defaults to `interactive()`)}{A boolean which controls the default behavior
 #'   when an app is run. See [runApp()] for more information.}
-#' \item{shiny.mathjax.url (defaults to `NULL`)}{Option to switch the default mathjax provider.
-#'   When set, shiny will access this url to acquire the `MathJax.js` file.
-#' \item{shiny.mathjax.config (defaults to `NULL`)}{Option for configure MathJax. It affects the way
-#`   `withMathJax` access `MathJax.js` file. Keep it empty suits for most cases.
+#' \item{shiny.mathjax.url (defaults to `"https://mathjax.rstudio.com/latest/MathJax.js"`)}{
+#'   The URL that should be used to load MathJax, via [withMathJax()].}
+#' \item{shiny.mathjax.config (defaults to `"config=TeX-AMS-MML_HTMLorMML"`)}{The querystring
+#'   used to load MathJax, via [withMathJax()].}
 #' \item{shiny.maxRequestSize (defaults to 5MB)}{This is a number which specifies the maximum
 #'   web request size, which serves as a size limit for file uploads.}
 #' \item{shiny.minified (defaults to `TRUE`)}{By default

--- a/R/shiny-options.R
+++ b/R/shiny-options.R
@@ -94,6 +94,10 @@ getShinyOption <- function(name, default = NULL) {
 #'   numbers to JSON format to send to the client web browser.}
 #' \item{shiny.launch.browser (defaults to `interactive()`)}{A boolean which controls the default behavior
 #'   when an app is run. See [runApp()] for more information.}
+#' \item{shiny.mathjax.url (defaults to `NULL`)}{Option to switch the default mathjax provider.
+#'   When set, shiny will access this url to acquire the `MathJax.js` file.
+#' \item{shiny.mathjax.config (defaults to `NULL`)}{Option for configure MathJax. It affects the way
+#`   `withMathJax` access `MathJax.js` file. Keep it empty suits for most cases.
 #' \item{shiny.maxRequestSize (defaults to 5MB)}{This is a number which specifies the maximum
 #'   web request size, which serves as a size limit for file uploads.}
 #' \item{shiny.minified (defaults to `TRUE`)}{By default

--- a/R/shinyui.R
+++ b/R/shinyui.R
@@ -14,7 +14,7 @@ NULL
 #' # now we can just write "static" content without withMathJax()
 #' div("more math here $$\\sqrt{2}$$")
 withMathJax <- function(...) {
-  path <- 'https://mathjax.rstudio.com/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'
+  path <- paste(getOption('shiny.mathjax.url','https://mathjax.rstudio.com/latest/MathJax.js'),getOption('shiny.mathjax.config','config=TeX-AMS-MML_HTMLorMML'),sep='?')
   tagList(
     tags$head(
       singleton(tags$script(src = path, type = 'text/javascript'))

--- a/man/shinyOptions.Rd
+++ b/man/shinyOptions.Rd
@@ -73,6 +73,10 @@ then jQuery 3.6.0 is used.}
 numbers to JSON format to send to the client web browser.}
 \item{shiny.launch.browser (defaults to \code{interactive()})}{A boolean which controls the default behavior
 when an app is run. See \code{\link[=runApp]{runApp()}} for more information.}
+\item{shiny.mathjax.url (defaults to \code{"https://mathjax.rstudio.com/latest/MathJax.js"})}{
+The URL that should be used to load MathJax, via \code{\link[=withMathJax]{withMathJax()}}.}
+\item{shiny.mathjax.config (defaults to \code{"config=TeX-AMS-MML_HTMLorMML"})}{The querystring
+used to load MathJax, via \code{\link[=withMathJax]{withMathJax()}}.}
 \item{shiny.maxRequestSize (defaults to 5MB)}{This is a number which specifies the maximum
 web request size, which serves as a size limit for file uploads.}
 \item{shiny.minified (defaults to \code{TRUE})}{By default


### PR DESCRIPTION
Provide two option, `shiny.mathjax.url` and `shiny.mathjax.config`, to enable the modification of the default mathjax.js.
Since the response of `mathjax.rstudio.com` could be slower in some regions, it is better to provide a default value and a configure technique to enable the modification of the default mathjax url.