### PR TITLE
Use `ragg::agg_png` over `Cairo::CairoPNG` if available

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@ shiny development
 
 ### Breaking changes
 
+* Closed #3626: `startPNG()` (and thus `renderPlot()`) now uses `ragg::agg_png()` by default when the [`{ragg}` package](https://github.com/r-lib/ragg) is installed. To opt into the previous behavior, set `options(shiny.useragg = FALSE)`. (#3654)
+
 ### Minor new features and improvements
 
 * Shiny's internal HTML dependencies are now mounted dynamically instead of statically. (#3537)

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@ shiny development
 
 ### Breaking changes
 
-* Closed #3626: `startPNG()` (and thus `renderPlot()`) now uses `ragg::agg_png()` by default when the [`{ragg}` package](https://github.com/r-lib/ragg) is installed. To opt into the previous behavior, set `options(shiny.useragg = FALSE)`. (#3654)
+* Closed #3626: `renderPlot()` (and `plotPNG()`) now uses `ragg::agg_png()` by default when the [`{ragg}` package](https://github.com/r-lib/ragg) is installed. To restore the previous behavior, set `options(shiny.useragg = FALSE)`. (#3654)
 
 ### Minor new features and improvements
 

--- a/R/imageutils.R
+++ b/R/imageutils.R
@@ -52,33 +52,31 @@ startPNG <- function(filename, width, height, res, ...) {
   grDevices::dev.cur()
 }
 
-#' Run a plotting function and save the output as a PNG
+#' Capture a plot as a PNG file.
 #'
-#' This function returns the name of the PNG file that it generates. In
-#' essence, it calls `png()`, then `func()`, then `dev.off()`.
-#' So `func` must be a function that will generate a plot when used this
-#' way.
-#'
-#' For output, it will try to use the following devices, in this order:
-#' quartz (via [grDevices::png()]), then [Cairo::CairoPNG()],
-#' and finally [grDevices::png()]. This is in order of quality of
-#' output. Notably, plain `png` output on Linux and Windows may not
-#' antialias some point shapes, resulting in poor quality output.
-#'
-#' In some cases, `Cairo()` provides output that looks worse than
-#' `png()`. To disable Cairo output for an app, use
-#' `options(shiny.usecairo=FALSE)`.
+#' The PNG graphics device used is determined in the following order:
+#'   * If the ragg package is installed (and the `shiny.useragg` is not
+#'    set to `FALSE`), then use [ragg::agg_png()].
+#'   * If a quartz device is available (i.e., `capabilities("aqua")` is
+#'    `TRUE`), then use `png(type = "quartz")`.
+#'   * If the Cairo package is installed (and the `shiny.usecairo` option
+#'    is not set to `FALSE`), then use [Cairo::CairoPNG()].
+#'   * Otherwise, use [grDevices::png()]. In this case, Linux and Windows
+#'    may not antialias some point shapes, resulting in poor quality output.
 #'
 #' @param func A function that generates a plot.
 #' @param filename The name of the output file. Defaults to a temp file with
 #'   extension `.png`.
 #' @param width Width in pixels.
 #' @param height Height in pixels.
-#' @param res Resolution in pixels per inch. This value is passed to
-#'   [grDevices::png()]. Note that this affects the resolution of PNG rendering in
+#' @param res Resolution in pixels per inch. This value is passed to the
+#'   graphics device. Note that this affects the resolution of PNG rendering in
 #'   R; it won't change the actual ppi of the browser.
-#' @param ... Arguments to be passed through to [grDevices::png()].
-#'   These can be used to set the width, height, background color, etc.
+#' @param ... Arguments to be passed through to the graphics device. These can
+#'   be used to set the width, height, background color, etc.
+#'
+#' @return A path to the newly generated PNG file.
+#'
 #' @export
 plotPNG <- function(func, filename=tempfile(fileext='.png'),
                     width=400, height=400, res=72, ...) {

--- a/R/imageutils.R
+++ b/R/imageutils.R
@@ -1,19 +1,14 @@
 startPNG <- function(filename, width, height, res, ...) {
-  # shiny.useragg is an experimental option that isn't officially supported or
-  # documented. It's here in the off chance that someone really wants
-  # to use ragg (say, instead of showtext, for custom font rendering).
-  # In the next shiny release, this option will likely be superseded in
-  # favor of a fully customizable graphics device option
-  if ((getOption('shiny.useragg') %||% FALSE) && is_installed("ragg")) {
-    pngfun <- ragg::agg_png
+  pngfun <- if ((getOption('shiny.useragg') %||% TRUE) && is_installed("ragg")) {
+    ragg::agg_png
   } else if (capabilities("aqua")) {
     # i.e., png(type = 'quartz')
-    pngfun <- grDevices::png
+    grDevices::png
   } else if ((getOption('shiny.usecairo') %||% TRUE) && is_installed("Cairo")) {
-    pngfun <- Cairo::CairoPNG
+    Cairo::CairoPNG
   } else {
     # i.e., png(type = 'cairo')
-    pngfun <- grDevices::png
+    grDevices::png
   }
 
   args <- rlang::list2(filename=filename, width=width, height=height, res=res, ...)

--- a/R/render-plot.R
+++ b/R/render-plot.R
@@ -34,7 +34,7 @@
 #'   When rendering an inline plot, you must provide numeric values (in pixels)
 #'   to both \code{width} and \code{height}.
 #' @param res Resolution of resulting plot, in pixels per inch. This value is
-#'   passed to [grDevices::png()]. Note that this affects the resolution of PNG
+#'   passed to [plotPNG()]. Note that this affects the resolution of PNG
 #'   rendering in R; it won't change the actual ppi of the browser.
 #' @param alt Alternate text for the HTML `<img>` tag if it cannot be displayed
 #'   or viewed (i.e., the user uses a screen reader). In addition to a character
@@ -44,7 +44,7 @@
 #'   ggplot objects; for other plots, `NA` results in alt text of "Plot object".
 #'   `NULL` or `""` is not recommended because those should be limited to
 #'   decorative images.
-#' @param ... Arguments to be passed through to [grDevices::png()].
+#' @param ... Arguments to be passed through to [plotPNG()].
 #'   These can be used to set the width, height, background color, etc.
 #' @inheritParams renderUI
 #' @param execOnResize If `FALSE` (the default), then when a plot is

--- a/R/shiny-options.R
+++ b/R/shiny-options.R
@@ -140,9 +140,10 @@ getShinyOption <- function(name, default = NULL) {
 #'   messages).}
 #' \item{shiny.autoload.r (defaults to `TRUE`)}{If `TRUE`, then the R/
 #'   of a shiny app will automatically be sourced.}
-#' \item{shiny.usecairo (defaults to `TRUE`)}{This is used to disable graphical rendering by the
-#'   Cairo package, if it is installed. See [plotPNG()] for more
-#'   information.}
+#' \item{shiny.useragg (defaults to `TRUE`)}{Set to `FALSE` to prevent PNG rendering via the
+#'   ragg package. See [plotPNG()] for more information.}
+#' \item{shiny.usecairo (defaults to `TRUE`)}{Set to `FALSE` to prevent PNG rendering via the
+#'   Cairo package. See [plotPNG()] for more information.}
 #' \item{shiny.devmode (defaults to `NULL`)}{Option to enable Shiny Developer Mode. When set,
 #'   different default `getOption(key)` values will be returned. See [devmode()] for more details.}
 ### Not documenting as 'shiny.devmode.verbose' is for niche use only

--- a/man/plotPNG.Rd
+++ b/man/plotPNG.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/imageutils.R
 \name{plotPNG}
 \alias{plotPNG}
-\title{Run a plotting function and save the output as a PNG}
+\title{Capture a plot as a PNG file.}
 \usage{
 plotPNG(
   func,
@@ -23,27 +23,26 @@ extension \code{.png}.}
 
 \item{height}{Height in pixels.}
 
-\item{res}{Resolution in pixels per inch. This value is passed to
-\code{\link[grDevices:png]{grDevices::png()}}. Note that this affects the resolution of PNG rendering in
+\item{res}{Resolution in pixels per inch. This value is passed to the
+graphics device. Note that this affects the resolution of PNG rendering in
 R; it won't change the actual ppi of the browser.}
 
-\item{...}{Arguments to be passed through to \code{\link[grDevices:png]{grDevices::png()}}.
-These can be used to set the width, height, background color, etc.}
+\item{...}{Arguments to be passed through to the graphics device. These can
+be used to set the width, height, background color, etc.}
+}
+\value{
+A path to the newly generated PNG file.
 }
 \description{
-This function returns the name of the PNG file that it generates. In
-essence, it calls \code{png()}, then \code{func()}, then \code{dev.off()}.
-So \code{func} must be a function that will generate a plot when used this
-way.
+The PNG graphics device used is determined in the following order:
+\itemize{
+\item If the ragg package is installed (and the \code{shiny.useragg} is not
+set to \code{FALSE}), then use \code{\link[ragg:agg_png]{ragg::agg_png()}}.
+\item If a quartz device is available (i.e., \code{capabilities("aqua")} is
+\code{TRUE}), then use \code{png(type = "quartz")}.
+\item If the Cairo package is installed (and the \code{shiny.usecairo} option
+is not set to \code{FALSE}), then use \code{\link[Cairo:Cairo]{Cairo::CairoPNG()}}.
+\item Otherwise, use \code{\link[grDevices:png]{grDevices::png()}}. In this case, Linux and Windows
+may not antialias some point shapes, resulting in poor quality output.
 }
-\details{
-For output, it will try to use the following devices, in this order:
-quartz (via \code{\link[grDevices:png]{grDevices::png()}}), then \code{\link[Cairo:Cairo]{Cairo::CairoPNG()}},
-and finally \code{\link[grDevices:png]{grDevices::png()}}. This is in order of quality of
-output. Notably, plain \code{png} output on Linux and Windows may not
-antialias some point shapes, resulting in poor quality output.
-
-In some cases, \code{Cairo()} provides output that looks worse than
-\code{png()}. To disable Cairo output for an app, use
-\code{options(shiny.usecairo=FALSE)}.
 }

--- a/man/renderCachedPlot.Rd
+++ b/man/renderCachedPlot.Rd
@@ -37,7 +37,7 @@ information on the default sizing policy.}
 (the default), \code{"session"}, or a cache object like a
 \code{\link[cachem:cache_disk]{cachem::cache_disk()}}. See the Cache Scoping section for more information.}
 
-\item{...}{Arguments to be passed through to \code{\link[grDevices:png]{grDevices::png()}}.
+\item{...}{Arguments to be passed through to \code{\link[=plotPNG]{plotPNG()}}.
 These can be used to set the width, height, background color, etc.}
 
 \item{alt}{Alternate text for the HTML \verb{<img>} tag if it cannot be displayed

--- a/man/renderPlot.Rd
+++ b/man/renderPlot.Rd
@@ -35,10 +35,10 @@ When rendering an inline plot, you must provide numeric values (in pixels)
 to both \code{width} and \code{height}.}
 
 \item{res}{Resolution of resulting plot, in pixels per inch. This value is
-passed to \code{\link[grDevices:png]{grDevices::png()}}. Note that this affects the resolution of PNG
+passed to \code{\link[=plotPNG]{plotPNG()}}. Note that this affects the resolution of PNG
 rendering in R; it won't change the actual ppi of the browser.}
 
-\item{...}{Arguments to be passed through to \code{\link[grDevices:png]{grDevices::png()}}.
+\item{...}{Arguments to be passed through to \code{\link[=plotPNG]{plotPNG()}}.
 These can be used to set the width, height, background color, etc.}
 
 \item{alt}{Alternate text for the HTML \verb{<img>} tag if it cannot be displayed

--- a/man/shinyOptions.Rd
+++ b/man/shinyOptions.Rd
@@ -119,9 +119,10 @@ values are \code{"send"} (only print messages sent to the client),
 messages).}
 \item{shiny.autoload.r (defaults to \code{TRUE})}{If \code{TRUE}, then the R/
 of a shiny app will automatically be sourced.}
-\item{shiny.usecairo (defaults to \code{TRUE})}{This is used to disable graphical rendering by the
-Cairo package, if it is installed. See \code{\link[=plotPNG]{plotPNG()}} for more
-information.}
+\item{shiny.useragg (defaults to \code{TRUE})}{Set to \code{FALSE} to prevent PNG rendering via the
+ragg package. See \code{\link[=plotPNG]{plotPNG()}} for more information.}
+\item{shiny.usecairo (defaults to \code{TRUE})}{Set to \code{FALSE} to prevent PNG rendering via the
+Cairo package. See \code{\link[=plotPNG]{plotPNG()}} for more information.}
 \item{shiny.devmode (defaults to \code{NULL})}{Option to enable Shiny Developer Mode. When set,
 different default \code{getOption(key)} values will be returned. See \code{\link[=devmode]{devmode()}} for more details.}
 }


### PR DESCRIPTION
Closes #3626

See also https://github.com/rstudio/rsconnect/pull/598

## Testing notes

None needed. We should already have some pretty good coverage of this in our automated tests.