### PR TITLE
modify downloadButton to make the output visible and remove extra space

### DIFF
--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -1212,13 +1212,13 @@ downloadButton <- function(outputId,
                            class=NULL,
                            ...,
                            icon = shiny::icon("download")) {
-  aTag <- tags$a(id=outputId,
-                 class=paste('btn btn-default shiny-download-link', class),
-                 href='',
-                 target='_blank',
-                 download=NA,
-                 validateIcon(icon),
-                 label, ...)
+  tags$a(id=outputId,
+         class=paste(c('btn btn-default shiny-download-link', class), collapse=" "),
+         href='',
+         target='_blank',
+         download=NA,
+         validateIcon(icon),
+         label, ...)
 }
 
 #' @rdname downloadButton


### PR DESCRIPTION
Cosmetic change.

Currently the `downloadButton` function hides its output, because the result is assigned to a local variable `aTag`, which is useless since the value is returned right away.

Moreover, the JavaScript `class` field ends with a space when the class parameter is `NULL`, which is not very pretty.

The code is changed to match the similar `downloadLink` function (except the classes, of course): no assignment to a local, and no extra space by rewriting `paste(a, b)` as `paste(c(a, b), collapse = " ")`.