### PR TITLE
Changed filename to use unique id

### DIFF
--- a/R/fileupload.R
+++ b/R/fileupload.R
@@ -65,7 +65,7 @@ FileUploadOperation <- R6Class(
       .pendingFileInfos <<- tail(.pendingFileInfos, -1)
 
       fileBasename <- basename(.currentFileInfo$name)
-      filename <- file.path(.dir, paste0(as.character(length(.files$name)), maybeGetExtension(fileBasename)))
+      filename <- file.path(.dir, paste0(as.character(createUniqueId(8)), maybeGetExtension(fileBasename)))
       row <- data.frame(name=fileBasename, size=file$size, type=file$type,
                         datapath=filename, stringsAsFactors=FALSE)
 


### PR DESCRIPTION
When enabling bookmarks, if there is more than one file input, the extra files are not correctly saved. This is due to a name conflict of the uploaded filenames.  This PR should solve this issue