### PR TITLE
Pass error to handler

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -488,7 +488,7 @@ shinyCallingHandlers <- function(expr) {
         return()
 
       handle <- getOption('shiny.error')
-      if (is.function(handle)) handle()
+      if (is.function(handle)) handle(e)
     }
   )
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -489,16 +489,11 @@ shinyCallingHandlers <- function(expr) {
 
       handle <- getOption('shiny.error')
       if (is.function(handle)) {
-        # if the handler takes at least one argument
-        # pass error along
-        args <- formalArgs(handle)
-
-        if(length(args) > 0) {
+        if (length(formals(handle)) > 0) {
           handle(e)
-          return()
+        } else {
+          handle()
         }
-        
-        handle()
       } 
     }
   )

--- a/R/utils.R
+++ b/R/utils.R
@@ -488,7 +488,18 @@ shinyCallingHandlers <- function(expr) {
         return()
 
       handle <- getOption('shiny.error')
-      if (is.function(handle)) handle(e)
+      if (is.function(handle)) {
+        # if the handler takes at least one argument
+        # pass error along
+        args <- formalArgs(handle)
+
+        if(length(args) > 0) {
+          handle(e)
+          return()
+        }
+        
+        handle()
+      } 
     }
   )
 }

--- a/man/plotPNG.Rd
+++ b/man/plotPNG.Rd
@@ -41,7 +41,7 @@ set to \code{FALSE}), then use \code{\link[ragg:agg_png]{ragg::agg_png()}}.
 \item If a quartz device is available (i.e., \code{capabilities("aqua")} is
 \code{TRUE}), then use \code{png(type = "quartz")}.
 \item If the Cairo package is installed (and the \code{shiny.usecairo} option
-is not set to \code{FALSE}), then use \code{\link[Cairo:Cairo]{Cairo::CairoPNG()}}.
+is not set to \code{FALSE}), then use \code{\link[Cairo:CairoPNG]{Cairo::CairoPNG()}}.
 \item Otherwise, use \code{\link[grDevices:png]{grDevices::png()}}. In this case, Linux and Windows
 may not antialias some point shapes, resulting in poor quality output.
 }


### PR DESCRIPTION
I have asked a few people and in a few places for a way to catch when a shiny application disconnects/crashes along with the error that caused it.

Question on [SO](https://stackoverflow.com/questions/74291807/shiny-disconnect-crash?noredirect=1#comment131172858_74291807) and [RStudio Community](https://community.rstudio.com/t/shiny-capture-crash-disconnect/151688/9)

I cannot find a solution with shiny's existing tools, sorry if this is already possible.

I thought of using the handler set as `shiny.error` option to capture the error/its message.
This allows something like the example below.

```r
library(shiny)

errs <- list()

on_error <- function(e) {
  errs <<- append(errs, e$message)
}

options(shiny.error = on_error)

ui <- fluidPage(
  actionButton("crash", "Crash")
)

server <- function(input, output, session) {
  onStop(function(){
    print(errs)
  })
 
  observeEvent(input$crash, {
    print(error)  # no `error` object => disconnect
  })
}

shinyApp(ui, server)
```