### PR TITLE
Feat: allow capturing unhandled errors 

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -2398,7 +2398,6 @@ flushPendingSessions <- function() {
       stop = function(e) {
         # If there are any uncaught errors that bubbled up to here, close the
         # session.
-        print("------------ERROR------------")
         shinysession$close()
       }
     )


### PR DESCRIPTION
This is to tackle problem detailed in #3724

> I have asked a few people and in a few places for a way to catch when a shiny application disconnects/crashes along with the error that caused it.

> Question on [SO](https://stackoverflow.com/questions/74291807/shiny-disconnect-crash?noredirect=1#comment131172858_74291807) and [RStudio Community](https://community.rstudio.com/t/shiny-capture-crash-disconnect/151688/9)

> I cannot find a solution with shiny's existing tools, sorry if this is already possible.

Previous solution PR #3724 is actually not ideal; it allows capturing errors and print them on stop but we would still not be sure whether the app disconnected/crashed because of captured error (could be graceful shutdown with handled error on stack).

Looking more at the source code, I seem to understand that the app closes when it encounters "unhandled errors" in observers, [here](https://github.com/rstudio/shiny/blob/634b1c7c3cf137361b93e7c66b9dd979d6735295/R/reactives.R#L1212).

The idea is then to add an option to pass a handler similar to `shiny.error` but called `shiny.unhandled.error`.

```r
library(shiny)

errs <- list()

on_error <- function(e) {
  errs <<- append(errs, e$message)
}

options(shiny.unhandled.error = on_error)

ui <- fluidPage(
  actionButton("crash", "Crash")
)

server <- function(input, output, session) {
  onStop(function(){
    # only unhandled errors are pushed to `errs`
    # if graceful shutdown `length(errs) == 0`
    print(errs)
  })
 
  observeEvent(input$crash, {
    print(error)  # no `error` object => disconnect
  })
}

shinyApp(ui, server)
```

I'm not sure whether 1) this is an elegant solution and 2) this captures all disconnects/crashes.