### PR TITLE
Protect against NULL width/height in drawPlot

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,8 @@ shiny 1.7.3.9000
 
 * Closed #3687: Updated jQuery-UI to v1.13.2. (#3697)
 
+* Closed #3735: Protect renderPlot against NULL height/width (#3736)
+
 
 shiny 1.7.3
 ===========

--- a/R/render-plot.R
+++ b/R/render-plot.R
@@ -235,6 +235,22 @@ drawPlot <- function(name, session, func, width, height, alt, pixelratio, res, .
   #  9. Return img, value, displaylist, coordmap
   # 10. On error, take width and height dependency
 
+  checkDimsForNulls <- function(width, height) {
+    null_width <- is.null(width)
+    null_height <- is.null(height)
+    if (null_width || null_height) {
+      stop("null ",
+           paste0(c("width", "height")[c(null_width, null_height)], collapse=" and "),
+           " seen for plot output ",
+           name,
+           ". Make sure that the plot container has non-zero size.")
+    }
+  }
+
+  # if any dim is null, this is most likely because the shiny app hasn't sent
+  # any clientData height/width for that output yet.
+  checkDimsForNulls(width, height)
+
   outfile <- tempfile(fileext='.png') # If startPNG throws, this could leak. Shrug.
   device <- startPNG(outfile, width*pixelratio, height*pixelratio, res = res*pixelratio, ...)
   domain <- createGraphicsDevicePromiseDomain(device)


### PR DESCRIPTION
Somehow our bespoke RMarkdown Shiny app is sending `hidden:false` for plots, but also not sending any dimensions.

This causes the R process hosting the shiny app to crash - with very little debug output.

This PR protects `drawPlot` against these `NULL` values.

- [x] Add an entry to NEWS.md concisely describing what you changed.
- [x] Not Applicable: If appropriate, add unit tests in the tests/ directory.
- [x] Not Applicable: If you made any changes to the JavaScript files in the srcjs/ directory, make sure you build the output JavaScript files. See tools/README.md file for information on using the build system.
- [x] Run Build->Check Package in the RStudio IDE, or devtools::check(), to make sure your change did not add any messages, warnings, or errors.
- [x] If you find a bug in Shiny, you can also [file an issue](https://github.com/rstudio/shiny/issues/new). Please provide as much relevant information as you can, and include a minimal reproducible example if possible. 
- [ ] Work out how I've messed up Stuart Lodge and slodge in the commits - sorry!

See bug report: https://github.com/rstudio/shiny/issues/3735