### PR TITLE
Remove eslint `newline-after-var rule`

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -44,9 +44,6 @@ rules:
   semi:
     - error
     - always
-  newline-after-var:
-    - error
-    - always
   dot-location:
     - error
     - property


### PR DESCRIPTION
I think the `newline-after-var` rule often leads to code that has strangely-grouped lines and whitespace.

Here are some misc examples just from a quick look at some of the TS files in Shiny:

https://github.com/rstudio/shiny/blob/ecff638920dd7310322d2b8a3082bdf2720caa4c/srcts/src/shiny/init.ts#L62-L70

https://github.com/rstudio/shiny/blob/ecff638920dd7310322d2b8a3082bdf2720caa4c/srcts/src/shiny/init.ts#L175-L180

https://github.com/rstudio/shiny/blob/ecff638920dd7310322d2b8a3082bdf2720caa4c/srcts/src/shiny/notifications.ts#L34-L37
