### PR TITLE
Fix url bookmarking with possibility to modify excludes

### DIFF
--- a/R/bookmark-state.R
+++ b/R/bookmark-state.R
@@ -99,12 +99,12 @@ saveShinySaveState <- function(state) {
 
 # Encode the state to a URL. This does not save to disk.
 encodeShinySaveState <- function(state) {
-  exclude <- c(state$exclude, "._bookmark_")
-  inputVals <- serializeReactiveValues(state$input, exclude, stateDir = NULL)
-
   # Allow user-supplied onSave function to do things like add state$values.
   if (!is.null(state$onSave))
     isolate(state$onSave(state))
+
+  exclude <- c(state$exclude, "._bookmark_")
+  inputVals <- serializeReactiveValues(state$input, exclude, stateDir = NULL)
 
   inputVals <- vapply(inputVals,
     function(x) toJSON(x, strict_atomic = FALSE),


### PR DESCRIPTION
This small bug fix the problem that `exclude` was created before `onSave` call. It's impacting the `url` bookmarking and this change made it consistent with the `server` bookmarking. 

Minimal example:
```
library(shiny)

ui <- function(req) {
  fluidPage(
    sliderInput("obs", "Number of observations:",
                min = 0, max = 1000, value = 500
    ),
    textInput("text", "Label", "Data Summary"),
    plotOutput("distPlot"),
    bookmarkButton()
  )
}

# Server logic
server <- function(input, output) {
  output$distPlot <- renderPlot({
    hist(rnorm(input$obs))
  })

  onBookmark(function(state) {
    # Exclude from bookmarking
    state$exclude <- c("text")
  })
}

shinyApp(ui, server, enableBookmarking = "url")
# shinyApp(ui, server, enableBookmarking = "server")
```