### PR TITLE
Ensure logged-in user matches when handling session-specific routes

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -1876,6 +1876,22 @@ ShinySession <- R6Class(
     # Provides a mechanism for handling direct HTTP requests that are posted
     # to the session (rather than going through the websocket)
     handleRequest = function(req) {
+      if (!is.null(self$user)) {
+        if (is.null(req$HTTP_SHINY_SERVER_CREDENTIALS)) {
+          # Session owner is logged in, but this requester is not
+          return(NULL)
+        }
+
+        creds <- NULL
+        try({creds <- safeFromJSON(req$HTTP_SHINY_SERVER_CREDENTIALS)},
+          silent = TRUE
+        )
+        if (!identical(self$user, creds$user)) {
+          # This requester is not the same user as session owner
+          return(NULL)
+        }
+      }
+
       # TODO: Turn off caching for the response
       subpath <- req$PATH_INFO
 


### PR DESCRIPTION
Mitigation for #3748, see that issue for more information.

## Testing notes

1. Install Shiny from this branch.
2. Deploy the [download example app](https://github.com/rstudio/shiny/tree/20f8a181d44f1fdb507e868c5cd425601ddaadf9/inst/examples/10_download) to ShinyApps.io.
3. From the ShinyApps.io dashboard, mark the deployed app as requiring login, and authorize two different users.
4. Access the deployed app via a browser (logging in if necessary).
5. Right-click the Download button and copy the link.
6. From a second browser, access the app again, this time logging in as the other user.
7. Paste the link from step 5 into the second browser's URL bar and press Enter.

Before this PR, the download would succeed. After this PR, the download returns 404.