### PR TITLE
Ensure that `reactiveValues` keys and values are sorted

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 * Closed #789: `<script>` loaded from dynamic UI are no longer loaded using synchronous `XMLHttpRequest` (via jQuery). (#3666)
 
+* For `reactiveValues()` objects, whenever the `$names()` or `$values()` methods are called, the keys are now in sorted order. (#3774)
+
 ### Bug fixes
 
 * Fixed #3771: Sometimes the error `ion.rangeSlider.min.js: i.stopPropagation is not a function` would appear in the JavaScript console. (#3772)

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 
 * Closed #789: `<script>` loaded from dynamic UI are no longer loaded using synchronous `XMLHttpRequest` (via jQuery). (#3666)
 
-* For `reactiveValues()` objects, whenever the `$names()` or `$values()` methods are called, the keys are now in sorted order. (#3774)
+* For `reactiveValues()` objects, whenever the `$names()` or `$values()` methods are called, the keys are now returned in the order that they were inserted. (#3774)
 
 ### Bug fixes
 

--- a/R/reactives.R
+++ b/R/reactives.R
@@ -420,12 +420,12 @@ ReactiveValues <- R6Class(
 
       if (hidden) {
         if (isTRUE(.hasRetrieved$asListAll)) {
-          rLog$valueChangeAsListAll(.reactId, .values$values(), domain)
+          rLog$valueChangeAsListAll(.reactId, .values$values(sort = TRUE), domain)
           .allValuesDeps$invalidate()
         }
       } else {
         if (isTRUE(.hasRetrieved$asList)) {
-          react_vals <- .values$values()
+          react_vals <- .values$values(sort = TRUE)
           react_vals <- react_vals[!grepl("^\\.", base::names(react_vals))]
           # leave as is. both object would be registered to the listening object
           rLog$valueChangeAsList(.reactId, react_vals, domain)
@@ -444,7 +444,7 @@ ReactiveValues <- R6Class(
     },
 
     names = function() {
-      nameValues <- .values$keys()
+      nameValues <- .values$keys(sort = TRUE)
       if (!isTRUE(.hasRetrieved$names)) {
         domain <- getDefaultReactiveDomain()
         rLog$defineNames(.reactId, nameValues, .label, domain)
@@ -499,7 +499,7 @@ ReactiveValues <- R6Class(
     },
 
     toList = function(all.names=FALSE) {
-      listValue <- .values$values()
+      listValue <- .values$values(sort = TRUE)
       if (!all.names) {
         listValue <- listValue[!grepl("^\\.", base::names(listValue))]
       }

--- a/R/reactives.R
+++ b/R/reactives.R
@@ -326,6 +326,9 @@ ReactiveValues <- R6Class(
     .dedupe = logical(0),
     # Key, asList(), or names() have been retrieved
     .hasRetrieved = list(),
+    # All names, in insertion order. The names are also stored in the .values
+    # object, but it does not preserve order.
+    .nameOrder = character(0),
 
 
     initialize = function(
@@ -403,6 +406,11 @@ ReactiveValues <- R6Class(
         return(invisible())
       }
 
+      # If it's new, append key to the name order
+      if (!key_exists) {
+        .nameOrder[length(.nameOrder) + 1] <<- key
+      }
+
       # set the value for better logging
       .values$set(key, value)
 
@@ -420,12 +428,12 @@ ReactiveValues <- R6Class(
 
       if (hidden) {
         if (isTRUE(.hasRetrieved$asListAll)) {
-          rLog$valueChangeAsListAll(.reactId, .values$values(sort = TRUE), domain)
+          rLog$valueChangeAsListAll(.reactId, .values$values(), domain)
           .allValuesDeps$invalidate()
         }
       } else {
         if (isTRUE(.hasRetrieved$asList)) {
-          react_vals <- .values$values(sort = TRUE)
+          react_vals <- .values$values()
           react_vals <- react_vals[!grepl("^\\.", base::names(react_vals))]
           # leave as is. both object would be registered to the listening object
           rLog$valueChangeAsList(.reactId, react_vals, domain)
@@ -444,14 +452,13 @@ ReactiveValues <- R6Class(
     },
 
     names = function() {
-      nameValues <- .values$keys(sort = TRUE)
       if (!isTRUE(.hasRetrieved$names)) {
         domain <- getDefaultReactiveDomain()
-        rLog$defineNames(.reactId, nameValues, .label, domain)
+        rLog$defineNames(.reactId, .nameOrder, .label, domain)
         .hasRetrieved$names <<- TRUE
       }
       .namesDeps$register()
-      return(nameValues)
+      return(.nameOrder)
     },
 
     # Get a metadata value. Does not trigger reactivity.
@@ -499,7 +506,7 @@ ReactiveValues <- R6Class(
     },
 
     toList = function(all.names=FALSE) {
-      listValue <- .values$values(sort = TRUE)
+      listValue <- .values$mget(.nameOrder)
       if (!all.names) {
         listValue <- listValue[!grepl("^\\.", base::names(listValue))]
       }

--- a/tests/testthat/test-reactivity.r
+++ b/tests/testthat/test-reactivity.r
@@ -127,17 +127,19 @@ test_that("ReactiveValues", {
 })
 
 test_that("reactiveValues keys are sorted", {
-  values <- reactiveValues()
-  values$a <- 1
-  values$A <- 11
+  values <- reactiveValues(b=2, a=0)
+  values$C <- 13
+  values$A <- 0
   values$c <- 3
   values$B <- 12
-  values$C <- 13
-  values$b <- 2
-  expect_identical(isolate(names(values)), c("A", "B", "C", "a", "b", "c"))
+  # Setting an existing value shouldn't change order
+  values$a <- 1
+  values$A <- 11
+
+  expect_identical(isolate(names(values)), c("b", "a", "C", "A", "c", "B"))
   expect_identical(
     isolate(reactiveValuesToList(values)),
-    list(A=11, B=12, C=13, a=1, b=2, c=3)
+    list(b=2, a=1, C=13, A=11, c=3, B=12)
   )
 })
 

--- a/tests/testthat/test-reactivity.r
+++ b/tests/testthat/test-reactivity.r
@@ -126,6 +126,21 @@ test_that("ReactiveValues", {
   expect_error(values$a <- 1)
 })
 
+test_that("reactiveValues keys are sorted", {
+  values <- reactiveValues()
+  values$a <- 1
+  values$A <- 11
+  values$c <- 3
+  values$B <- 12
+  values$C <- 13
+  values$b <- 2
+  expect_identical(isolate(names(values)), c("A", "B", "C", "a", "b", "c"))
+  expect_identical(
+    isolate(reactiveValuesToList(values)),
+    list(A=11, B=12, C=13, a=1, b=2, c=3)
+  )
+})
+
 test_that("reactiveValues() has useful print method", {
   verify_output(test_path("print-reactiveValues.txt"), {
     x <- reactiveValues(x = 1, y = 2, z = 3)


### PR DESCRIPTION
This PR also ensures that anywhere that a `reactiveValues` `$names()` or `$values()` method is called, the keys will be sorted in the same order that they were inserted. (Note: a previous version of this PR sorted lexicographically, and some of the comments were for that version.)

In our shinycoreci tests, we found that bookmarked input values were not always in consistent order. For example, for the same app in the same state, both of these URLs might be generated:

* http://127.0.0.1/?_inputs_&reset=0&x=5
* http://127.0.0.1/?_inputs_&x=5&reset=0
