### PR TITLE
Initialize `Map` objects at load time instead of build time

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 * Closed #789: `<script>` loaded from dynamic UI are no longer loaded using synchronous `XMLHttpRequest` (via jQuery). (#3666)
 
+* `Map` objects are now initialized at load time instead of build time. This avoids potential problems that could arise from storing `fastmap` objects into the built Shiny package. (#3775)
+
 ### Bug fixes
 
 * Fixed #3771: Sometimes the error `ion.rangeSlider.min.js: i.stopPropagation is not a function` would appear in the JavaScript console. (#3772)

--- a/R/bookmark-state.R
+++ b/R/bookmark-state.R
@@ -452,8 +452,10 @@ RestoreInputSet <- R6Class("RestoreInputSet",
   )
 )
 
-# This is a fastmap::faststack(); value is assigned in .onLoad().
 restoreCtxStack <- NULL
+on_load({
+    restoreCtxStack <- fastmap::faststack()
+})
 
 withRestoreContext <- function(ctx, expr) {
   restoreCtxStack$push(ctx)

--- a/R/devmode.R
+++ b/R/devmode.R
@@ -190,8 +190,9 @@ devmode_inform <- function(
 
 
 
+# This is a Map object and is assigned in .onLoad().
 #' @include map.R
-registered_devmode_options <- Map$new()
+registered_devmode_options <- NULL
 
 #' @describeIn devmode Registers a Shiny Developer Mode option with an updated
 #'   value and Developer message. This registration method allows package

--- a/R/devmode.R
+++ b/R/devmode.R
@@ -190,9 +190,10 @@ devmode_inform <- function(
 
 
 
-# This is a Map object and is assigned in .onLoad().
-#' @include map.R
 registered_devmode_options <- NULL
+on_load({
+  registered_devmode_options <- Map$new()
+})
 
 #' @describeIn devmode Registers a Shiny Developer Mode option with an updated
 #'   value and Developer message. This registration method allows package
@@ -341,21 +342,22 @@ get_devmode_option <- function(
 }
 
 
+on_load({
+  register_devmode_option(
+    "shiny.autoreload",
+    "Turning on shiny autoreload. To disable, call `options(shiny.autoreload = FALSE)`",
+    TRUE
+  )
 
-register_devmode_option(
-  "shiny.autoreload",
-  "Turning on shiny autoreload. To disable, call `options(shiny.autoreload = FALSE)`",
-  TRUE
-)
+  register_devmode_option(
+    "shiny.minified",
+    "Using full shiny javascript file. To use the minified version, call `options(shiny.minified = TRUE)`",
+    FALSE
+  )
 
-register_devmode_option(
-  "shiny.minified",
-  "Using full shiny javascript file. To use the minified version, call `options(shiny.minified = TRUE)`",
-  FALSE
-)
-
-register_devmode_option(
-  "shiny.fullstacktrace",
-  "Turning on full stack trace. To disable, call `options(shiny.fullstacktrace = FALSE)`",
-  TRUE
-)
+  register_devmode_option(
+    "shiny.fullstacktrace",
+    "Turning on full stack trace. To disable, call `options(shiny.fullstacktrace = FALSE)`",
+    TRUE
+  )
+})

--- a/R/globals.R
+++ b/R/globals.R
@@ -7,16 +7,9 @@
   # the private seed during load.
   withPrivateSeed(set.seed(NULL))
 
-  # Create this at the top level, but since the object is from a different
-  # package, we don't want to bake it into the built binary package.
-  restoreCtxStack <<- fastmap::faststack()
-
-  # Map objects include fastmap objects and we don't want to bake those into a
-  # built package.
-  inputHandlers <<- Map$new()
-  appsByToken <<- Map$new()
-  appsNeedingFlush <<- Map$new()
-  registered_devmode_options <<- Map$new()
+  for (expr in on_load_exprs) {
+    eval(expr, envir = environment(.onLoad))
+  }
 
   # Make sure these methods are available to knitr if shiny is loaded but not
   # attached.
@@ -29,4 +22,12 @@
   # includes a fix for this problem
   # https://github.com/rstudio/shiny/issues/2630
   register_upgrade_message("htmlwidgets", 1.5)
+}
+
+
+on_load_exprs <- list()
+# Register an expression to be evaluated when the package is loaded (in the
+# .onLoad function).
+on_load <- function(expr) {
+  on_load_exprs[[length(on_load_exprs) + 1]] <<- substitute(expr)
 }

--- a/R/globals.R
+++ b/R/globals.R
@@ -11,6 +11,13 @@
   # package, we don't want to bake it into the built binary package.
   restoreCtxStack <<- fastmap::faststack()
 
+  # Map objects include fastmap objects and we don't want to bake those into a
+  # built package.
+  inputHandlers <<- Map$new()
+  appsByToken <<- Map$new()
+  appsNeedingFlush <<- Map$new()
+  registered_devmode_options <<- Map$new()
+
   # Make sure these methods are available to knitr if shiny is loaded but not
   # attached.
   s3_register("knitr::knit_print", "reactive")

--- a/R/graph.R
+++ b/R/graph.R
@@ -559,4 +559,6 @@ MessageLogger = R6Class(
   )
 )
 
-rLog <- RLog$new("shiny.reactlog", "shiny.reactlog.console")
+on_load({
+  rLog <- RLog$new("shiny.reactlog", "shiny.reactlog.console")
+})

--- a/R/server-input-handlers.R
+++ b/R/server-input-handlers.R
@@ -1,5 +1,6 @@
-# Create a map for input handlers and register the defaults.
-inputHandlers <- Map$new()
+# Create a Map object for input handlers and register the defaults.
+# This is assigned in .onLoad time.
+inputHandlers <- NULL
 
 #' Register an Input Handler
 #'

--- a/R/server-input-handlers.R
+++ b/R/server-input-handlers.R
@@ -1,6 +1,9 @@
 # Create a Map object for input handlers and register the defaults.
 # This is assigned in .onLoad time.
 inputHandlers <- NULL
+on_load({
+  inputHandlers <- Map$new()
+})
 
 #' Register an Input Handler
 #'
@@ -126,115 +129,117 @@ applyInputHandlers <- function(inputs, shinysession = getDefaultReactiveDomain()
   inputs
 }
 
+on_load({
+  # Takes a list-of-lists and returns a matrix. The lists
+  # must all be the same length. NULL is replaced by NA.
+  registerInputHandler("shiny.matrix", function(data, ...) {
+    if (length(data) == 0)
+      return(matrix(nrow=0, ncol=0))
 
-# Takes a list-of-lists and returns a matrix. The lists
-# must all be the same length. NULL is replaced by NA.
-registerInputHandler("shiny.matrix", function(data, ...) {
-  if (length(data) == 0)
-    return(matrix(nrow=0, ncol=0))
-
-  m <- matrix(unlist(lapply(data, function(x) {
-    sapply(x, function(y) {
-      ifelse(is.null(y), NA, y)
-    })
-  })), nrow = length(data[[1]]), ncol = length(data))
-  return(m)
-})
-
-
-registerInputHandler("shiny.number", function(val, ...){
-  ifelse(is.null(val), NA, val)
-})
-
-registerInputHandler("shiny.password", function(val, shinysession, name) {
-  # Mark passwords as not serializable
-  setSerializer(name, serializerUnserializable)
-  val
-})
-
-registerInputHandler("shiny.date", function(val, ...){
-  # First replace NULLs with NA, then convert to Date vector
-  datelist <- ifelse(lapply(val, is.null), NA, val)
-
-  res <- NULL
-  tryCatch({
-      res <- as.Date(unlist(datelist))
-    },
-    error = function(e) {
-      # It's possible for client to send a string like "99999-01-01", which
-      # as.Date can't handle.
-      warning(e$message)
-      res <<- as.Date(rep(NA, length(datelist)))
-    }
-  )
-
-  res
-})
-
-registerInputHandler("shiny.datetime", function(val, ...){
-  # First replace NULLs with NA, then convert to POSIXct vector
-  times <- lapply(val, function(x) {
-    if (is.null(x)) NA
-    else x
+    m <- matrix(unlist(lapply(data, function(x) {
+      sapply(x, function(y) {
+        ifelse(is.null(y), NA, y)
+      })
+    })), nrow = length(data[[1]]), ncol = length(data))
+    return(m)
   })
-  as.POSIXct(unlist(times), origin = "1970-01-01", tz = "UTC")
-})
-
-registerInputHandler("shiny.action", function(val, shinysession, name) {
-  # mark up the action button value with a special class so we can recognize it later
-  class(val) <- c("shinyActionButtonValue", class(val))
-  val
-})
-
-registerInputHandler("shiny.file", function(val, shinysession, name) {
-  # This function is only used when restoring a Shiny fileInput. When a file is
-  # uploaded the usual way, it takes a different code path and won't hit this
-  # function.
-  if (is.null(val))
-    return(NULL)
-
-  # The data will be a named list of lists; convert to a data frame.
-  val <- as.data.frame(lapply(val, unlist), stringsAsFactors = FALSE)
-
-  # `val$datapath` should be a filename without a path, for security reasons.
-  if (basename(val$datapath) != val$datapath) {
-    stop("Invalid '/' found in file input path.")
-  }
-
-  # Prepend the persistent dir
-  oldfile <- file.path(getCurrentRestoreContext()$dir, val$datapath)
-
-  # Copy the original file to a new temp dir, so that a restored session can't
-  # modify the original.
-  newdir <- file.path(tempdir(), createUniqueId(12))
-  dir.create(newdir)
-  val$datapath <- file.path(newdir, val$datapath)
-  file.copy(oldfile, val$datapath)
-
-  # Need to mark this input value with the correct serializer. When a file is
-  # uploaded the usual way (instead of being restored), this occurs in
-  # session$`@uploadEnd`.
-  setSerializer(name, serializerFileInput)
-
-  snapshotPreprocessInput(name, snapshotPreprocessorFileInput)
-
-  val
-})
 
 
-# to be used with !!!answer
-registerInputHandler("shiny.symbolList", function(val, ...) {
-  if (is.null(val)) {
-    list()
-  } else {
-    lapply(val, as.symbol)
-  }
-})
-# to be used with !!answer
-registerInputHandler("shiny.symbol", function(val, ...) {
-  if (is.null(val) || identical(val, "")) {
-    NULL
-  } else {
-    as.symbol(val)
-  }
+  registerInputHandler("shiny.number", function(val, ...){
+    ifelse(is.null(val), NA, val)
+  })
+
+  registerInputHandler("shiny.password", function(val, shinysession, name) {
+    # Mark passwords as not serializable
+    setSerializer(name, serializerUnserializable)
+    val
+  })
+
+  registerInputHandler("shiny.date", function(val, ...){
+    # First replace NULLs with NA, then convert to Date vector
+    datelist <- ifelse(lapply(val, is.null), NA, val)
+
+    res <- NULL
+    tryCatch({
+        res <- as.Date(unlist(datelist))
+      },
+      error = function(e) {
+        # It's possible for client to send a string like "99999-01-01", which
+        # as.Date can't handle.
+        warning(e$message)
+        res <<- as.Date(rep(NA, length(datelist)))
+      }
+    )
+
+    res
+  })
+
+  registerInputHandler("shiny.datetime", function(val, ...){
+    # First replace NULLs with NA, then convert to POSIXct vector
+    times <- lapply(val, function(x) {
+      if (is.null(x)) NA
+      else x
+    })
+    as.POSIXct(unlist(times), origin = "1970-01-01", tz = "UTC")
+  })
+
+  registerInputHandler("shiny.action", function(val, shinysession, name) {
+    # mark up the action button value with a special class so we can recognize it later
+    class(val) <- c("shinyActionButtonValue", class(val))
+    val
+  })
+
+  registerInputHandler("shiny.file", function(val, shinysession, name) {
+    # This function is only used when restoring a Shiny fileInput. When a file is
+    # uploaded the usual way, it takes a different code path and won't hit this
+    # function.
+    if (is.null(val))
+      return(NULL)
+
+    # The data will be a named list of lists; convert to a data frame.
+    val <- as.data.frame(lapply(val, unlist), stringsAsFactors = FALSE)
+
+    # `val$datapath` should be a filename without a path, for security reasons.
+    if (basename(val$datapath) != val$datapath) {
+      stop("Invalid '/' found in file input path.")
+    }
+
+    # Prepend the persistent dir
+    oldfile <- file.path(getCurrentRestoreContext()$dir, val$datapath)
+
+    # Copy the original file to a new temp dir, so that a restored session can't
+    # modify the original.
+    newdir <- file.path(tempdir(), createUniqueId(12))
+    dir.create(newdir)
+    val$datapath <- file.path(newdir, val$datapath)
+    file.copy(oldfile, val$datapath)
+
+    # Need to mark this input value with the correct serializer. When a file is
+    # uploaded the usual way (instead of being restored), this occurs in
+    # session$`@uploadEnd`.
+    setSerializer(name, serializerFileInput)
+
+    snapshotPreprocessInput(name, snapshotPreprocessorFileInput)
+
+    val
+  })
+
+
+  # to be used with !!!answer
+  registerInputHandler("shiny.symbolList", function(val, ...) {
+    if (is.null(val)) {
+      list()
+    } else {
+      lapply(val, as.symbol)
+    }
+  })
+  # to be used with !!answer
+  registerInputHandler("shiny.symbol", function(val, ...) {
+    if (is.null(val) || identical(val, "")) {
+      NULL
+    } else {
+      as.symbol(val)
+    }
+  })
+
 })

--- a/R/server.R
+++ b/R/server.R
@@ -1,7 +1,8 @@
 #' @include server-input-handlers.R
 
-appsByToken <- Map$new()
-appsNeedingFlush <- Map$new()
+# These are Map objects, and are assigned in .onLoad() to avoid
+appsByToken <- NULL
+appsNeedingFlush <- NULL
 
 # Provide a character representation of the WS that can be used
 # as a key in a Map.

--- a/R/server.R
+++ b/R/server.R
@@ -1,8 +1,12 @@
 #' @include server-input-handlers.R
 
-# These are Map objects, and are assigned in .onLoad() to avoid
 appsByToken <- NULL
 appsNeedingFlush <- NULL
+on_load({
+  appsByToken <- Map$new()
+  appsNeedingFlush <- Map$new()
+})
+
 
 # Provide a character representation of the WS that can be used
 # as a key in a Map.
@@ -123,7 +127,10 @@ decodeMessage <- function(data) {
   return(mainMessage)
 }
 
-autoReloadCallbacks <- Callbacks$new()
+autoReloadCallbacks <- NULL
+on_load({
+  autoReloadCallbacks <- Callbacks$new()
+})
 
 createAppHandlers <- function(httpHandlers, serverFuncSource) {
   appvars <- new.env()


### PR DESCRIPTION
This avoids potential problems that could arise from storing `fastmap` objects into the built Shiny package.