### PR TITLE
increase ellipsis dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -93,7 +93,7 @@ Imports:
     glue (>= 1.3.2),
     bslib (>= 0.3.0),
     cachem,
-    ellipsis,
+    ellipsis (>= 0.2.0),
     lifecycle (>= 0.2.0)
 Suggests:
     datasets,


### PR DESCRIPTION
`check_dots_empty` is exported starting from version `0.2` - without it it is possible to end-up with the following install error:
```
Error: object ‘check_dots_empty’ is not exported by 'namespace:ellipsis'
```