### PR TITLE
More complete `downloadButton()` example

### DIFF
--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -1200,19 +1200,25 @@ uiOutput <- htmlOutput
 #' @examples
 #' \dontrun{
 #' ui <- fluidPage(
+#'   p("Choose a dataset to download."),
+#'   selectInput("dataset", "Dataset", choices = c("mtcars", "airquality")),
 #'   downloadButton("downloadData", "Download")
 #' )
 #'
 #' server <- function(input, output) {
-#'   # Our dataset
-#'   data <- mtcars
+#'   # The requested dataset
+#'   data <- reactive({
+#'     get(input$dataset)
+#'   })
 #'
 #'   output$downloadData <- downloadHandler(
 #'     filename = function() {
-#'       paste("data-", Sys.Date(), ".csv", sep="")
+#'       # Use the selected dataset as the suggested file name
+#'       paste0(input$dataset, ".csv")
 #'     },
 #'     content = function(file) {
-#'       write.csv(data, file)
+#'       # Write the dataset to the `file` that will be downloaded
+#'       write.csv(data(), file)
 #'     }
 #'   )
 #' }

--- a/man/downloadButton.Rd
+++ b/man/downloadButton.Rd
@@ -36,19 +36,25 @@ function.
 \examples{
 \dontrun{
 ui <- fluidPage(
+  p("Choose a dataset to download."),
+  selectInput("dataset", "Dataset", choices = c("mtcars", "airquality")),
   downloadButton("downloadData", "Download")
 )
 
 server <- function(input, output) {
-  # Our dataset
-  data <- mtcars
+  # The requested dataset
+  data <- reactive({
+    get(input$dataset)
+  })
 
   output$downloadData <- downloadHandler(
     filename = function() {
-      paste("data-", Sys.Date(), ".csv", sep="")
+      # Use the selected dataset as the suggested file name
+      paste0(input$dataset, ".csv")
     },
     content = function(file) {
-      write.csv(data, file)
+      # Write the dataset to the `file` that will be downloaded
+      write.csv(data(), file)
     }
   )
 }


### PR DESCRIPTION
This PR proposes a small change to the `downloadButton()` example. The updated example uses reactive values (from an input) in the `filename` and a reactive dataset in the `content`. This better matches the typical use case for `downloadHandler()`. Previously, neither the filename nor the content used reactive values.

Inspired by two recent issues:

* #3803
* #3783