### PR TITLE
Set cache control headers to avoid caching UI

### DIFF
--- a/R/shinyui.R
+++ b/R/shinyui.R
@@ -244,7 +244,12 @@ uiHttpHandler <- function(ui, uiPattern = "^/$") {
       uiValue <- httpResponse(200, content=html)
     }
 
-    if (!"Cache-Control" %in% names(uiValue$headers)) {
+    if (
+      # A {bslib} theme has been set while generating the UI
+      !is.null(getCurrentTheme()) &&
+        # The user has not set a `Cache-Control` policy within their UI func
+        !"Cache-Control" %in% names(uiValue$headers)
+    ) {
       # A custom UI func could set cache-control, otherwise disable UI caching
       uiValue$headers <- utils::modifyList(uiValue$headers, no_cache_headers)
     }


### PR DESCRIPTION
Fixes #3806

A PR to get the conversation started.

[Root of issue](https://github.com/rstudio/shiny/issues/3806#issuecomment-1513495170):
> When the UI isn't re-rendered in the R process that's serving the Shiny app, we don't have access to global theme information in the server logic. This drives the behavior seen in this issue: the server doesn't know that the UI is expecting BS4+ markup for the nav items and instead emits BS3 markup, and the mismatch results in broken client logic.

Approach:
* If a theme has been set while creating the UI and the current UI response does not have a caching policy
	* Do not allow caching of the UI