### PR TITLE
Disable private seed in testmode

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -52,6 +52,11 @@ repeatable <- function(rngfunc, seed = stats::runif(1, 0, .Machine$integer.max))
 # Evaluate an expression using Shiny's own private stream of
 # randomness (not affected by set.seed).
 withPrivateSeed <- function(expr) {
+  # Don't use the private seed in testmode for deterministic tests
+  if (isTRUE(getOption("shiny.testmode", getShinyOption("testmode")))) {
+    return(expr)
+  }
+
   # Save the old seed if present.
   if (exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE)) {
     hasOrigSeed <- TRUE

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -50,6 +50,18 @@ test_that("Setting the private seed explicitly results in identical values", {
   expect_identical(id7, id8)
 })
 
+test_that("Private seed is disabled in testmode", {
+  oldopts <- options(shiny.testmode = TRUE)
+  on.exit(options(oldopts), add = TRUE)
+
+  set.seed(0)
+  id1 <- createUniqueId(4)
+  set.seed(0)
+  id2 <- createUniqueId(4)
+
+  expect_identical(id1, id2)
+})
+
 test_that("Private and 'public' random streams are independent and work the same", {
   set.seed(0)
   public <- c(runif(1), runif(1), runif(1))


### PR DESCRIPTION
Fixes #3816

This PR enables deterministic tests when the `shiny.testmode` option is `TRUE` or when an app is run with `test.mode = TRUE`. When testing, app authors who set a seed prior to calling shiny app or UI code most likely want the entire app run to be deterministic, e.g. as described in #3816.

In #3816, I considered a few other options, e.g. following `testthat::is_testing()` (an envvar) or adding a new global option to disable the private seed. Instead I think the best option is to use the existing public `shiny.testmode` option. This option is set automatically by shinytest2, so the private seed will automatically be disabled for testing there. Using a shiny-specific option also provides greater flexibility to opt out of or keep the private seed during tests.

Checking the `shiny.testmode` option adds a small amount of overhead to `withPrivateSeed()`. Because `getShinyOption()` checks the R option last, it's fastest to invert the order in `withPrivateSeed()` and fall back to the Shiny global/session option if unset. We could tighten this up if we only need to consider the R option.

Here's a quick comparison of the timing of `withPrivateSeed(runif(1))` before and after this change.

<details><summary>Boiler plate</summary>

``` r
check_private_seed_timing <- function(branch) {
  gert::git_branch_checkout(branch)
  pkgload::load_all()
  
  set.seed(0)

  tm_on <- withr::with_options(
    list(shiny.testmode = TRUE),
    bench::mark(
      tm_on = withPrivateSeed(runif(1)),
      check = FALSE
    )
  )
  tm_unset <- withr::with_options(
    list(shiny.testmode = NULL),
    bench::mark(
      tm_unset = withPrivateSeed(runif(1)),
      check = FALSE
    )
  )
  
  ret <- dplyr::bind_rows(tm_on, tm_unset)
  ret$expression <- paste0("tm_", c("on", "unset"), "_", branch)
  ret[1:5]
}
```

</details>

Timing of RNG calls with private seed on main, private seed always used.

``` r
check_private_seed_timing("main")
#> ℹ Loading shiny
#> # A tibble: 2 × 5
#>   expression         min   median `itr/sec` mem_alloc
#>   <chr>         <bch:tm> <bch:tm>     <dbl> <bch:byt>
#> 1 tm_on_main      4.18µs   5.33µs   149545.    7.38KB
#> 2 tm_unset_main   4.26µs   5.33µs   175199.    4.98KB
```

Timing of RNG calls with private seed on main, private seed disabled with test mode.

``` r
check_private_seed_timing("private-seed-test-mode")
#> ℹ Loading shiny
#> # A tibble: 2 × 5
#>   expression                           min   median `itr/sec` mem_alloc
#>   <chr>                           <bch:tm> <bch:tm>     <dbl> <bch:byt>
#> 1 tm_on_private-seed-test-mode      1.56µs   1.89µs   488486.    2.49KB
#> 2 tm_unset_private-seed-test-mode   7.17µs   8.36µs   113350.    4.98KB
```