### PR TITLE
Allow for `shiny:::toJSON()` to respect if `digits` has class `AsIs` to represent `use_signif=`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 * `Map` objects are now initialized at load time instead of build time. This avoids potential problems that could arise from storing `fastmap` objects into the built Shiny package. (#3775)
 
+* Allow for `shiny:::toJSON()` to respect if `digits=` has class `"AsIs"` which represents if `use_signif=` is `TRUE` or `FALSE`. This is useful for testing to keep the digits smaller. For example, setting `options(shiny.json.digits = 4)` will save 4 digits after the decimal, rather than the default of `I(16)` which will save 16 significant digits. (#3819)
+
 ### Bug fixes
 
 * Fixed #3771: Sometimes the error `ion.rangeSlider.min.js: i.stopPropagation is not a function` would appear in the JavaScript console. (#3772)

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -33,8 +33,12 @@ createUniqueId <- function(bytes, prefix = "", suffix = "") {
 }
 
 toJSON <- function(x, ...,  dataframe = "columns", null = "null", na = "null",
-  auto_unbox = TRUE, digits = getOption("shiny.json.digits", 16),
-  use_signif = TRUE, force = TRUE, POSIXt = "ISO8601", UTC = TRUE,
+  auto_unbox = TRUE,
+  # Shiny has had a legacy value of 16 significant digits
+  # We can use `I(16)` mixed with the default behavior in jsonlite's `use_signif=`
+  # https://github.com/jeroen/jsonlite/commit/728efa9
+  digits = getOption("shiny.json.digits", I(16)), use_signif = is(digits, "AsIs"),
+  force = TRUE, POSIXt = "ISO8601", UTC = TRUE,
   rownames = FALSE, keep_vec_names = TRUE, strict_atomic = TRUE) {
 
   if (strict_atomic) {

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -268,3 +268,27 @@ test_that("quoToFunction handles nested quosures", {
   func <- quoToFunction(quo_outer, "foo")
   expect_identical(func(), 2)
 })
+
+
+
+test_that("toJSON can set digits using options - default", {
+  # withr::local_options(list())
+  expect_equal(
+    as.character(toJSON(pi)),
+    "[3.14159265358979]"
+  )
+})
+test_that("toJSON can set digits using options - number", {
+  withr::local_options(list(shiny.json.digits = 4))
+  expect_equal(
+    as.character(toJSON(pi)),
+    "[3.1416]"
+  )
+})
+test_that("toJSON can set digits using options - asis number", {
+  withr::local_options(list(shiny.json.digits = I(4)))
+  expect_equal(
+    as.character(toJSON(pi)),
+    "[3.142]"
+  )
+})


### PR DESCRIPTION
If `digits` is of type `AsIs`, then `use_signif = TRUE`

Related: https://github.com/jeroen/jsonlite/commit/728efa9