### PR TITLE
Clarify what's ignored by ignoreNULL

### DIFF
--- a/R/reactives.R
+++ b/R/reactives.R
@@ -2187,8 +2187,8 @@ maskReactiveContext <- function(expr) {
 #' @param autoDestroy If `TRUE` (the default), the observer will be
 #'   automatically destroyed when its domain (if any) ends.
 #' @param ignoreNULL Whether the action should be triggered (or value
-#'   calculated, in the case of `eventReactive`) when the input is
-#'   `NULL`. See Details.
+#'   calculated, in the case of `eventReactive`) when the input event expression
+#'   is `NULL`. See Details.
 #' @param ignoreInit If `TRUE`, then, when this `observeEvent` is
 #'   first created/initialized, ignore the `handlerExpr` (the second
 #'   argument), whether it is otherwise supposed to run or not. The default is

--- a/man/bindCache.Rd
+++ b/man/bindCache.Rd
@@ -166,8 +166,8 @@ instead of the default 200 MB:
 }\if{html}{\out{</div>}}
 
 To use different settings for a session-scoped cache, you can set
-\code{self$cache} at the top of your server function. By default, it will create
-a 200 MB memory cache for each session, but you can replace it with
+\code{session$cache} at the top of your server function. By default, it will
+create a 200 MB memory cache for each session, but you can replace it with
 something different. To use the session-scoped cache, you must also call
 \code{bindCache()} with \code{cache="session"}. This will create a 100 MB cache for
 the session:

--- a/man/observeEvent.Rd
+++ b/man/observeEvent.Rd
@@ -86,8 +86,8 @@ Positive, negative, and zero values are allowed.}
 automatically destroyed when its domain (if any) ends.}
 
 \item{ignoreNULL}{Whether the action should be triggered (or value
-calculated, in the case of \code{eventReactive}) when the input is
-\code{NULL}. See Details.}
+calculated, in the case of \code{eventReactive}) when the input event expression
+is \code{NULL}. See Details.}
 
 \item{ignoreInit}{If \code{TRUE}, then, when this \code{observeEvent} is
 first created/initialized, ignore the \code{handlerExpr} (the second


### PR DESCRIPTION
Fixes #3826

Currently the parameter docs for `ignoreNULL` say "when the input is `NULL`". The word _input_ is not code-formatted because it's intended to generically mean the input to the function (`ignoreNULL` is also used in `bindEvent()`), but that small distinction is easy to miss.

This PR changes the phrase to: _when the input event expression is `NULL`_. This hopefully retains the generality while putting some distance between the referenced input and the server's `input` object.