### PR TITLE
test(json digits): Try unsetting option in test to get default behavior

### DIFF
--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -272,7 +272,7 @@ test_that("quoToFunction handles nested quosures", {
 
 
 test_that("toJSON can set digits using options - default", {
-  # withr::local_options(list())
+  withr::local_options(list(shiny.json.digits = NULL))
   expect_equal(
     as.character(toJSON(pi)),
     "[3.14159265358979]"


### PR DESCRIPTION
Related to #3819 
Error first seen in #3816 