### PR TITLE
Correctly set width on `textarea` input element

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,7 @@
 * Fixed #3771: Sometimes the error `ion.rangeSlider.min.js: i.stopPropagation is not a function` would appear in the JavaScript console. (#3772)
 
 * Fixed #3833: When `width` is provided to `textAreaInput()`, we now correctly set the width of the `<textarea>` element. (#3838)
+
 # shiny 1.7.4
 
 ## Full changelog

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@
 
 * Fixed #3771: Sometimes the error `ion.rangeSlider.min.js: i.stopPropagation is not a function` would appear in the JavaScript console. (#3772)
 
+* Fixed #3833: When `width` is provided to `textAreaInput()`, we now correctly set the width of the `<textarea>` element. (#3838)
 # shiny 1.7.4
 
 ## Full changelog

--- a/R/input-textarea.R
+++ b/R/input-textarea.R
@@ -52,7 +52,7 @@ textAreaInput <- function(inputId, label, value = "", width = NULL, height = NUL
 
   style <- css(
     # The width is specified on the parent div.
-    width = if (!is.null(width)) "width: 100%;",
+    width = if (!is.null(width)) "100%",
     height = validateCssUnit(height),
     resize = resize
   )

--- a/man/memoryCache.Rd
+++ b/man/memoryCache.Rd
@@ -17,7 +17,7 @@ memoryCache(
 \arguments{
 \item{max_size}{Maximum size of the cache, in bytes. If the cache exceeds
 this size, cached objects will be removed according to the value of the
-\code{evict}. Use \code{Inf} for no size limit. The default is 1 gigabyte.}
+\code{evict}. Use \code{Inf} for no size limit. The default is 512 megabytes.}
 
 \item{max_age}{Maximum age of files in cache before they are evicted, in
 seconds. Use \code{Inf} for no age limit.}


### PR DESCRIPTION
Fixes #3833

As pointed out in #3833, setting width in `textAreaInput()` resulted in the `<textarea>` element having `style="width:width: 100%;;"`. We were using `css()` but accidentally repeating the property name.

**Before this PR**

```r
textAreaInput('new','NULL', width='100%')
#> <div class="form-group shiny-input-container" style="width: 100%;">
#>   <label class="control-label" id="new-label" for="new">NULL</label>
#>  <textarea id="new" class="form-control" style="width:width: 100%;;"></textarea>
#> </div>
```

**After this PR**

```r
textAreaInput('new', 'LABEL', width='100%')
#> <div class="form-group shiny-input-container" style="width: 100%;">
#>  <label class="control-label" id="new-label" for="new">LABEL</label>
#>   <textarea id="new" class="form-control" style="width:100%;"></textarea>
#> </div>
```