### PR TITLE
In re: Issue #3844--Updating note on selectInput()

### DIFF
--- a/R/input-select.R
+++ b/R/input-select.R
@@ -186,6 +186,7 @@ needOptgroup <- function(choices) {
 #'   value when it is a single choice input and the empty string is not in the
 #'   `choices` argument. This is to keep compatibility with
 #'   `selectInput(..., selectize = FALSE)`.
+#'   The selectize input created from `selectInput(..., selectize = TRUE, multiple = TRUE)` allows deletion of all selected options, which will then return NULL as its value. Because the default behavior of an `observeEvent()` is to ignore expressions that evaluate to NULL, a change from a single selected option to no selected options in such a `selectInput()` would not constitute an event that would trigger an `observeEvent()` by default. If this behavior is undesirable in your context, it may be useful to set the `ignoreNULL` (and perhaps also the `ignoreInit`) parameter of `observeEvent()` to TRUE; see [observeEvent()] for details. 
 #' @export
 selectizeInput <- function(inputId, ..., options = NULL, width = NULL) {
   selectizeIt(

--- a/R/input-select.R
+++ b/R/input-select.R
@@ -186,17 +186,17 @@ needOptgroup <- function(choices) {
 #'   value when it is a single choice input and the empty string is not in the
 #'   `choices` argument. This is to keep compatibility with
 #'   `selectInput(..., selectize = FALSE)`.
-#'   
-#'   The selectize input created from `selectInput(..., selectize = TRUE, 
-#'   multiple = TRUE)` allows deletion of all selected options, which will 
-#'   then return NULL as its value. Because the default behavior of an 
-#'   `observeEvent()` is to ignore expressions that evaluate to NULL, a change 
-#'   from a single selected option to no selected options in such a 
-#'   `selectInput()` would not constitute an event that would trigger an 
-#'   `observeEvent()` by default. If this behavior is undesirable in your 
-#'   context, it may be useful to set the `ignoreNULL` (and perhaps also the 
-#'   `ignoreInit`) parameter of `observeEvent()` to TRUE; see [observeEvent()]
-#'   for details. 
+#'
+#'   When `multiple = TRUE` is used with `selectizeInput()`, users can select
+#'   multiple options as well as delete all selected options. When no options
+#'   are selected, the server will receive a value of `NULL`. Because the
+#'   default behavior of an `observeEvent()` is to ignore expressions that
+#'   evaluate to NULL, a change from a single selected option to no selected
+#'   options in such a `selectizeInput()` will not invalidate (cause to update)
+#'   an `observeEvent()` by default. If this behavior is undesirable in your
+#'   context, it may be useful to set `ignoreNULL = TRUE` in `observeEvent()`
+#'   (and possibly also `ignoreInit = TRUE` as well). See [observeEvent()] for
+#'   details.
 #' @export
 selectizeInput <- function(inputId, ..., options = NULL, width = NULL) {
   selectizeIt(

--- a/R/input-select.R
+++ b/R/input-select.R
@@ -186,7 +186,17 @@ needOptgroup <- function(choices) {
 #'   value when it is a single choice input and the empty string is not in the
 #'   `choices` argument. This is to keep compatibility with
 #'   `selectInput(..., selectize = FALSE)`.
-#'   The selectize input created from `selectInput(..., selectize = TRUE, multiple = TRUE)` allows deletion of all selected options, which will then return NULL as its value. Because the default behavior of an `observeEvent()` is to ignore expressions that evaluate to NULL, a change from a single selected option to no selected options in such a `selectInput()` would not constitute an event that would trigger an `observeEvent()` by default. If this behavior is undesirable in your context, it may be useful to set the `ignoreNULL` (and perhaps also the `ignoreInit`) parameter of `observeEvent()` to TRUE; see [observeEvent()] for details. 
+#'   
+#'   The selectize input created from `selectInput(..., selectize = TRUE, 
+#'   multiple = TRUE)` allows deletion of all selected options, which will 
+#'   then return NULL as its value. Because the default behavior of an 
+#'   `observeEvent()` is to ignore expressions that evaluate to NULL, a change 
+#'   from a single selected option to no selected options in such a 
+#'   `selectInput()` would not constitute an event that would trigger an 
+#'   `observeEvent()` by default. If this behavior is undesirable in your 
+#'   context, it may be useful to set the `ignoreNULL` (and perhaps also the 
+#'   `ignoreInit`) parameter of `observeEvent()` to TRUE; see [observeEvent()]
+#'   for details. 
 #' @export
 selectizeInput <- function(inputId, ..., options = NULL, width = NULL) {
   selectizeIt(

--- a/man/selectInput.Rd
+++ b/man/selectInput.Rd
@@ -87,6 +87,17 @@ return an empty string as its value. This is the default behavior of
 value when it is a single choice input and the empty string is not in the
 \code{choices} argument. This is to keep compatibility with
 \code{selectInput(..., selectize = FALSE)}.
+
+When \code{multiple = TRUE} is used with \code{selectizeInput()}, users can select
+multiple options as well as delete all selected options. When no options
+are selected, the server will receive a value of \code{NULL}. Because the
+default behavior of an \code{observeEvent()} is to ignore expressions that
+evaluate to NULL, a change from a single selected option to no selected
+options in such a \code{selectizeInput()} will not invalidate (cause to update)
+an \code{observeEvent()} by default. If this behavior is undesirable in your
+context, it may be useful to set \code{ignoreNULL = TRUE} in \code{observeEvent()}
+(and possibly also \code{ignoreInit = TRUE} as well). See \code{\link[=observeEvent]{observeEvent()}} for
+details.
 }
 \section{Server value}{
  A vector of character strings, usually of length


### PR DESCRIPTION
Pursuant to Issue #3844, I've updated the note for selectInput()/selectizeInput() to note that, when a selectize input is created via selectInput(..., selectize = T, multiple = T), there exists the ability to delete selections and reduce the value of the selector to NULL, which can then make observeEvents watching the input fail to trip silently given their default behavior of ignoring NULL expressions. 

Editing the note is all I did, and I tried to match the formatting styles of other notes in this function as much as possible, though the formatting and conventions here are new and unfamiliar to me. 