### PR TITLE
docs(navbarPage): Be less specific about collapsible breakpoint

### DIFF
--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -374,8 +374,7 @@ collapseSizes <- function(padding) {
 #' @param inverse `TRUE` to use a dark background and light text for the
 #'   navigation bar
 #' @param collapsible `TRUE` to automatically collapse the navigation
-#'   elements into a menu when the width of the browser is less than 940 pixels
-#'   (useful for viewing on smaller touchscreen device)
+#'   elements into an expandable menu on mobile devices or narrow window widths.
 #' @param fluid `TRUE` to use a fluid layout. `FALSE` to use a fixed
 #'   layout.
 #' @param windowTitle the browser window title (as a character string). The

--- a/man/navbarPage.Rd
+++ b/man/navbarPage.Rd
@@ -58,8 +58,7 @@ tabPanels}
 navigation bar}
 
 \item{collapsible}{\code{TRUE} to automatically collapse the navigation
-elements into a menu when the width of the browser is less than 940 pixels
-(useful for viewing on smaller touchscreen device)}
+elements into an expandable menu on mobile devices or narrow window widths.}
 
 \item{fluid}{\code{TRUE} to use a fluid layout. \code{FALSE} to use a fixed
 layout.}


### PR DESCRIPTION
Fixes rstudio/bslib#663

The documentation for `navbarPage(collapsible = )` is used in `bslib::page_navbar()` and `bslib::navset_bar()`, but the specific pixel width where the navbar is expanded or collapsed varies between Bootstrap version. Specifically in BS3 it's the currently documented pixel width, 940px, and in BS4+ it's at a smaller screen width (576px).

This PR updates the documentation to be less specific about the pixels width where the change occurs and to focus on the key motivation of the behavior.