### PR TITLE
chore(desc): Add GitHub repo to URL

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -111,7 +111,8 @@ Suggests:
     ragg,
     showtext,
     sass
-URL: https://shiny.posit.co/
+URL: https://shiny.posit.co/,
+    https://github.com/rstudio/shiny
 BugReports: https://github.com/rstudio/shiny/issues
 Collate:
     'globals.R'


### PR DESCRIPTION
Fixes #3863 and adds shiny's GitHub repo to `URL` in `DESCRIPTION`