### PR TITLE
Doc updateQueryString: / cleans URL with no query

### DIFF
--- a/R/bookmark-state.R
+++ b/R/bookmark-state.R
@@ -550,7 +550,8 @@ restoreInput <- function(id, default) {
 #' When `mode = "push"`, the function called is
 #' `window.history.pushState(null, null, queryString)`.
 #'
-#' @param queryString The new query string to show in the location bar.
+#' @param queryString The new query string to show in the location bar. "?" for
+#'   empty query arguments, "/" to reset to a clean URL.
 #' @param mode When the query string is updated, should the the current history
 #'   entry be replaced (default), or should a new history entry be pushed onto
 #'   the history stack? The former should only be used in a live bookmarking


### PR DESCRIPTION
I wanted my app to set the URL to the starting value, with no "?query=value" at the end. I've found out that using `updateQueryString("/")` does the trick, while using `""`, `NA` or `NULL` as the argument didn't do anything.
I'm sure this could be useful to someone else, so I wrote about it in the function documentation.