### PR TITLE
Address r-devel's change in `is.atomic(NULL)` behavior

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -79,7 +79,7 @@ Imports:
     jsonlite (>= 0.9.16),
     xtable,
     fontawesome (>= 0.4.0),
-    htmltools (>= 0.5.4),
+    htmltools (> 0.5.6),
     R6 (>= 2.0),
     sourcetools,
     later (>= 1.0.0),
@@ -210,3 +210,5 @@ RdMacros: lifecycle
 Config/testthat/edition: 3
 Config/Needs/check:
   shinytest2
+Remotes:
+  rstudio/htmltools@null-is-atomic

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -79,7 +79,7 @@ Imports:
     jsonlite (>= 0.9.16),
     xtable,
     fontawesome (>= 0.4.0),
-    htmltools (> 0.5.6),
+    htmltools (>= 0.5.4),
     R6 (>= 2.0),
     sourcetools,
     later (>= 1.0.0),
@@ -210,5 +210,3 @@ RdMacros: lifecycle
 Config/testthat/edition: 3
 Config/Needs/check:
   shinytest2
-Remotes:
-  rstudio/htmltools@null-is-atomic

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 * Fixed #3898: `wrapFunctionLabel()` no longer throws an error if the `name` is longer than 10000 bytes. (#3903)
 
+* On r-devel (R > 4.3.1), `isTruthy(NULL)` now returns `FALSE` (as it does with older versions of R). (#3906)
+
 # shiny 1.7.5
 
 ## Possibly breaking changes

--- a/R/utils.R
+++ b/R/utils.R
@@ -1240,15 +1240,12 @@ dotloop <- function(fun_, ...) {
 #' @param x An expression whose truthiness value we want to determine
 #' @export
 isTruthy <- function(x) {
-  if (inherits(x, 'try-error'))
-    return(FALSE)
-
   if (is.null(x))
     return(FALSE)
-
+  if (inherits(x, 'try-error'))
+    return(FALSE)
   if (!is.atomic(x))
     return(TRUE)
-
   if (length(x) == 0)
     return(FALSE)
   if (all(is.na(x)))

--- a/R/utils.R
+++ b/R/utils.R
@@ -1243,11 +1243,12 @@ isTruthy <- function(x) {
   if (inherits(x, 'try-error'))
     return(FALSE)
 
+  if (is.null(x))
+    return(FALSE)
+
   if (!is.atomic(x))
     return(TRUE)
 
-  if (is.null(x))
-    return(FALSE)
   if (length(x) == 0)
     return(FALSE)
   if (all(is.na(x)))

--- a/tests/testthat/test-tabPanel.R
+++ b/tests/testthat/test-tabPanel.R
@@ -18,6 +18,9 @@ expect_snapshot2 <- function(...) {
   if (getRversion() < "3.6.0") {
     skip("Skipping snapshots on R < 3.6 because of different RNG method")
   }
+  if (packageVersion("htmltools") <= "0.5.6") {
+    skip("Skipping snapshots since htmltools is 'outdated'")
+  }
   expect_snapshot(...)
 }
 

--- a/tests/testthat/test-tabPanel.R
+++ b/tests/testthat/test-tabPanel.R
@@ -18,7 +18,7 @@ expect_snapshot2 <- function(...) {
   if (getRversion() < "3.6.0") {
     skip("Skipping snapshots on R < 3.6 because of different RNG method")
   }
-  if (packageVersion("htmltools") <= "0.5.6") {
+  if (packageVersion("htmltools") <= "0.5.6" && getRversion() > "4.3.1") {
     skip("Skipping snapshots since htmltools is 'outdated'")
   }
   expect_snapshot(...)


### PR DESCRIPTION
Closes #3906 