### PR TITLE
fix(shiny.scss): Ensure `$body-emphasis-color` is defined for all BS5

### DIFF
--- a/inst/www/shared/shiny_scss/shiny.bootstrap5.scss
+++ b/inst/www/shared/shiny_scss/shiny.bootstrap5.scss
@@ -1,3 +1,5 @@
+$body-emphasis-color: $body-color !default; // introduced in BS 5.3
+
 $shiny-emphasis-color-rgb:          var(--#{$prefix}emphasis-color-rgb, 0,0,0) !default;
 
 $shiny-disconnected-bg:             RGBA($shiny-emphasis-color-rgb, 0.42) !default;


### PR DESCRIPTION
Fixes #3922 

`$body-emphasis-color` was the only Sass variable we were using unconditionally.

<details>
<summary>App Code</summary>

```r
withr::local_temp_libpaths()

pkgs <- c(
  "rstudio/shiny#3924",
  "bslib",         # cran 0.5.1
  "rstudio/bslib", # dev 0.5.1.9000
  "learnr"
)
pak::pak(pkgs)

ui <- bslib::page_fluid(
  actionButton("notify", "Notify Me")
)

server <- function(input, output, session) {
  observeEvent(input$notify, {
    showNotification(learnr::random_praise())
  })
}

shinyApp(ui, server)
```

</details>

| bslib 0.5.1 | bslib dev |
|:--:|:---:|
| ![image](https://github.com/rstudio/shiny/assets/5420529/f1722db1-801b-4a81-888a-50b9beca3495) | ![image](https://github.com/rstudio/shiny/assets/5420529/a15c25dc-eed2-4dbc-a2e8-51c9618c7a49) |