### PR TITLE
Documentation: fixing typos

### DIFF
--- a/R/bind-cache.R
+++ b/R/bind-cache.R
@@ -453,7 +453,7 @@ utils::globalVariables(".GenericCallEnv", add = TRUE)
 #'       bindEvent(input$go)
 #'       # The cached, eventified reactive takes a reactive dependency on
 #'       # input$go, but doesn't use it for the cache key. It uses input$x and
-#'       # input$y for the cache key, but doesn't take a reactive depdency on
+#'       # input$y for the cache key, but doesn't take a reactive dependency on
 #'       # them, because the reactive dependency is superseded by addEvent().
 #'
 #'     output$txt <- renderText(r())

--- a/R/history.R
+++ b/R/history.R
@@ -14,7 +14,7 @@ NULL
 #' depending on the values in the query string / hash (e.g. instead of basing
 #' the conditional on an input or a calculated reactive, you can base it on the
 #' query string). However, note that, if you're changing the query string / hash
-#' programatically from within the server code, you must use
+#' programmatically from within the server code, you must use
 #' `updateQueryString(_yourNewQueryString_, mode = "push")`. The default
 #' `mode` for `updateQueryString` is `"replace"`, which doesn't
 #' raise any events, so any observers or reactives that depend on it will

--- a/R/shiny-options.R
+++ b/R/shiny-options.R
@@ -113,7 +113,7 @@ getShinyOption <- function(name, default = NULL) {
 #'   production.}
 #' \item{shiny.sanitize.errors (defaults to `FALSE`)}{If `TRUE`, then normal errors (i.e.
 #'   errors not wrapped in `safeError`) won't show up in the app; a simple
-#'   generic error message is printed instead (the error and strack trace printed
+#'   generic error message is printed instead (the error and stack trace printed
 #'   to the console remain unchanged). If you want to sanitize errors in general, but you DO want a
 #'   particular error `e` to get displayed to the user, then set this option
 #'   to `TRUE` and use `stop(safeError(e))` for errors you want the

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -215,7 +215,7 @@ workerId <- local({
 #'   Sends a custom message to the web page. `type` must be a
 #'   single-element character vector giving the type of message, while
 #'   `message` can be any jsonlite-encodable value. Custom messages
-#'   have no meaning to Shiny itself; they are used soley to convey information
+#'   have no meaning to Shiny itself; they are used solely to convey information
 #'   to custom JavaScript logic in the browser. You can do this by adding
 #'   JavaScript code to the browser that calls
 #'   \code{Shiny.addCustomMessageHandler(type, function(message){...})}

--- a/R/shinyui.R
+++ b/R/shinyui.R
@@ -159,7 +159,7 @@ shinyDependencyCSS <- function(theme) {
 #' This function is kept for backwards compatibility with older applications. It
 #' returns the value that is passed to it.
 #'
-#' @param ui A user interace definition
+#' @param ui A user interface definition
 #' @return The user interface definition, without modifications or side effects.
 #' @keywords internal
 #' @export

--- a/R/update-input.R
+++ b/R/update-input.R
@@ -148,13 +148,13 @@ updateCheckboxInput <- function(session = getDefaultReactiveDomain(), inputId, l
 #'       label = "New label",
 #'       icon = icon("calendar"))
 #'
-#'     # Leaves goButton2's label unchaged and
+#'     # Leaves goButton2's label unchanged and
 #'     # removes its icon
 #'     updateActionButton(session, "goButton2",
 #'       icon = character(0))
 #'
 #'     # Leaves goButton3's icon, if it exists,
-#'     # unchaged and changes its label
+#'     # unchanged and changes its label
 #'     updateActionButton(session, "goButton3",
 #'       label = "New label 3")
 #'

--- a/R/utils.R
+++ b/R/utils.R
@@ -1093,7 +1093,7 @@ need <- function(expr, message = paste(label, "must be provided"), label) {
 #'
 #' You can use `req(FALSE)` (i.e. no condition) if you've already performed
 #' all the checks you needed to by that point and just want to stop the reactive
-#' chain now. There is no advantange to this, except perhaps ease of readibility
+#' chain now. There is no advantage to this, except perhaps ease of readability
 #' if you have a complicated condition to check for (or perhaps if you'd like to
 #' divide your condition into nested `if` statements).
 #'

--- a/man/bindCache.Rd
+++ b/man/bindCache.Rd
@@ -448,7 +448,7 @@ shinyApp(
       bindEvent(input$go)
       # The cached, eventified reactive takes a reactive dependency on
       # input$go, but doesn't use it for the cache key. It uses input$x and
-      # input$y for the cache key, but doesn't take a reactive depdency on
+      # input$y for the cache key, but doesn't take a reactive dependency on
       # them, because the reactive dependency is superseded by addEvent().
 
     output$txt <- renderText(r())

--- a/man/getQueryString.Rd
+++ b/man/getQueryString.Rd
@@ -26,7 +26,7 @@ These can be particularly useful if you want to display different content
 depending on the values in the query string / hash (e.g. instead of basing
 the conditional on an input or a calculated reactive, you can base it on the
 query string). However, note that, if you're changing the query string / hash
-programatically from within the server code, you must use
+programmatically from within the server code, you must use
 \verb{updateQueryString(_yourNewQueryString_, mode = "push")}. The default
 \code{mode} for \code{updateQueryString} is \code{"replace"}, which doesn't
 raise any events, so any observers or reactives that depend on it will

--- a/man/memoryCache.Rd
+++ b/man/memoryCache.Rd
@@ -17,7 +17,7 @@ memoryCache(
 \arguments{
 \item{max_size}{Maximum size of the cache, in bytes. If the cache exceeds
 this size, cached objects will be removed according to the value of the
-\code{evict}. Use \code{Inf} for no size limit. The default is 512 megabytes.}
+\code{evict}. Use \code{Inf} for no size limit. The default is 1 gigabyte.}
 
 \item{max_age}{Maximum age of files in cache before they are evicted, in
 seconds. Use \code{Inf} for no age limit.}

--- a/man/plotPNG.Rd
+++ b/man/plotPNG.Rd
@@ -41,7 +41,7 @@ set to \code{FALSE}), then use \code{\link[ragg:agg_png]{ragg::agg_png()}}.
 \item If a quartz device is available (i.e., \code{capabilities("aqua")} is
 \code{TRUE}), then use \code{png(type = "quartz")}.
 \item If the Cairo package is installed (and the \code{shiny.usecairo} option
-is not set to \code{FALSE}), then use \code{\link[Cairo:Cairo]{Cairo::CairoPNG()}}.
+is not set to \code{FALSE}), then use \code{\link[Cairo:CairoPNG]{Cairo::CairoPNG()}}.
 \item Otherwise, use \code{\link[grDevices:png]{grDevices::png()}}. In this case, Linux and Windows
 may not antialias some point shapes, resulting in poor quality output.
 }

--- a/man/req.Rd
+++ b/man/req.Rd
@@ -59,7 +59,7 @@ way to check for a value "inline" with its first use.
 
 You can use \code{req(FALSE)} (i.e. no condition) if you've already performed
 all the checks you needed to by that point and just want to stop the reactive
-chain now. There is no advantange to this, except perhaps ease of readibility
+chain now. There is no advantage to this, except perhaps ease of readability
 if you have a complicated condition to check for (or perhaps if you'd like to
 divide your condition into nested \code{if} statements).
 }

--- a/man/session.Rd
+++ b/man/session.Rd
@@ -121,7 +121,7 @@ any \code{imageOutput} or \code{plotOutput} in the app.
 Sends a custom message to the web page. \code{type} must be a
 single-element character vector giving the type of message, while
 \code{message} can be any jsonlite-encodable value. Custom messages
-have no meaning to Shiny itself; they are used soley to convey information
+have no meaning to Shiny itself; they are used solely to convey information
 to custom JavaScript logic in the browser. You can do this by adding
 JavaScript code to the browser that calls
 \code{Shiny.addCustomMessageHandler(type, function(message){...})}

--- a/man/shinyOptions.Rd
+++ b/man/shinyOptions.Rd
@@ -92,7 +92,7 @@ This incurs a substantial performance penalty and should not be used in
 production.}
 \item{shiny.sanitize.errors (defaults to \code{FALSE})}{If \code{TRUE}, then normal errors (i.e.
 errors not wrapped in \code{safeError}) won't show up in the app; a simple
-generic error message is printed instead (the error and strack trace printed
+generic error message is printed instead (the error and stack trace printed
 to the console remain unchanged). If you want to sanitize errors in general, but you DO want a
 particular error \code{e} to get displayed to the user, then set this option
 to \code{TRUE} and use \code{stop(safeError(e))} for errors you want the

--- a/man/shinyUI.Rd
+++ b/man/shinyUI.Rd
@@ -7,7 +7,7 @@
 shinyUI(ui)
 }
 \arguments{
-\item{ui}{A user interace definition}
+\item{ui}{A user interface definition}
 }
 \value{
 The user interface definition, without modifications or side effects.

--- a/man/updateActionButton.Rd
+++ b/man/updateActionButton.Rd
@@ -74,13 +74,13 @@ server <- function(input, output, session) {
       label = "New label",
       icon = icon("calendar"))
 
-    # Leaves goButton2's label unchaged and
+    # Leaves goButton2's label unchanged and
     # removes its icon
     updateActionButton(session, "goButton2",
       icon = character(0))
 
     # Leaves goButton3's icon, if it exists,
-    # unchaged and changes its label
+    # unchanged and changes its label
     updateActionButton(session, "goButton3",
       label = "New label 3")
 


### PR DESCRIPTION
This PR fixes a few typos I spotted in the documentation.