### PR TITLE
Don't treat input/output as draggable inside of `absolutePanel(draggable = T)`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,7 +13,7 @@
 
 * Default styles for `showNotification()` were tweaked slightly to improve accessibility, sizing, and padding. (#3913)
 
-* `absolutePanel()`/`fixedPanel()` with `draggable = TRUE` no longer interfere with click events on children that are inputs or `{htmlwidgets}`, meaning that things like zooming and panning now work as expected with widgets like `{plotly}` and `{leaflet}`. (#3752, #3933) 
+* Shiny inputs and `{htmlwidgets}` are no longer treated as draggable inside of `absolutePanel()`/`fixedPanel()` with `draggable = TRUE`. As a result, interactions like zooming and panning now work as expected with widgets like `{plotly}` and `{leaflet}` when they appear in a draggable panel. (#3752, #3933) 
 
 * For `InputBinding`s, the `.receiveMessage()` method can now be asynchronous or synchronous (previously it could only be synchronous). (#3930)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,8 @@
 
 * Default styles for `showNotification()` were tweaked slightly to improve accessibility, sizing, and padding. (#3913)
 
+* `absolutePanel()`/`fixedPanel()` with `draggable = TRUE` no longer interfere with click events on children that are inputs or `{htmlwidgets}`, meaning that things like zooming and panning now work as expected with widgets like `{plotly}` and `{leaflet}`. (#3752, #3933) 
+
 * For `InputBinding`s, the `.receiveMessage()` method can now be asynchronous or synchronous (previously it could only be synchronous). (#3930)
 
 ## Bug fixes

--- a/R/jqueryui.R
+++ b/R/jqueryui.R
@@ -81,14 +81,9 @@ absolutePanel <- function(...,
     return(divTag)
   }
 
-  # CPS (2023-10-31): it'd be nice if draggable could be a list of options for
-  # the draggable() method, but to do that properly (i.e., support JS functions,
-  # per element options, etc) would be non-trivial. For now, we'll just add a
-  # smart cancel option default to prevent dragging on input/output elements.
-  # This is particularly important for widgets (e.g. plotly, leaflet) and
-  # selectize.js https://github.com/rstudio/shiny/issues/3752
-  # https://github.com/rstudio/shiny/issues/3933
-  dragOpts <- "{cancel: '.shiny-input-container, .html-widget'}"
+  # Add Shiny inputs and htmlwidgets to 'non-draggable' elements
+  # Cf. https://api.jqueryui.com/draggable/#option-cancel
+  dragOpts <- '{cancel: ".shiny-input-container,.html-widget,input,textarea,button,select,option"}'
   dragJS <- sprintf('$(".draggable").draggable(%s);', dragOpts)
   tagList(
     tagAppendAttributes(divTag, class='draggable'),

--- a/R/jqueryui.R
+++ b/R/jqueryui.R
@@ -76,16 +76,25 @@ absolutePanel <- function(...,
 
   style <- paste(paste(names(cssProps), cssProps, sep = ':', collapse = ';'), ';', sep='')
   divTag <- tags$div(style=style, ...)
-  if (isTRUE(draggable)) {
-    divTag <- tagAppendAttributes(divTag, class='draggable')
-    return(tagList(
-      divTag,
-      jqueryuiDependency(),
-      tags$script('$(".draggable").draggable();')
-    ))
-  } else {
+
+  if (identical(draggable, FALSE)) {
     return(divTag)
   }
+
+  # CPS (2023-10-31): it'd be nice if draggable could be a list of options for
+  # the draggable() method, but to do that properly (i.e., support JS functions,
+  # per element options, etc) would be non-trivial. For now, we'll just add a
+  # smart cancel option default to prevent dragging on input/output elements.
+  # This is particularly important for widgets (e.g. plotly, leaflet) and
+  # selectize.js https://github.com/rstudio/shiny/issues/3752
+  # https://github.com/rstudio/shiny/issues/3933
+  dragOpts <- "{cancel: '.shiny-input-container, .html-widget'}"
+  dragJS <- sprintf('$(".draggable").draggable(%s);', dragOpts)
+  tagList(
+    tagAppendAttributes(divTag, class='draggable'),
+    jqueryuiDependency(),
+    tags$script(HTML(dragJS))
+  )
 }
 
 #' @rdname absolutePanel


### PR DESCRIPTION
Closes #3933 
Closes #3752

As a side note, it'd be nice if `draggable` could be a list of options for the `draggable()` method, but to do that properly (i.e., support JS functions, per element options, etc) would be non-trivial, and probably best be done via a web component (which could fix other problems with this approach, such as every element with a `.draggable` class getting instiantiated everytime a draggable element gets rendered).  

For now, since we mainly want a targeted fix for #3933, we'll just add a smarter default behavior to prevent input/outputs from being draggable (so we also #3752 for free, virtually).