### PR TITLE
fix(downloadButton): Return tag directly

### DIFF
--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -1233,13 +1233,13 @@ downloadButton <- function(outputId,
                            class=NULL,
                            ...,
                            icon = shiny::icon("download")) {
-  aTag <- tags$a(id=outputId,
-                 class=paste('btn btn-default shiny-download-link', class),
-                 href='',
-                 target='_blank',
-                 download=NA,
-                 validateIcon(icon),
-                 label, ...)
+  tags$a(id=outputId,
+         class=paste('btn btn-default shiny-download-link', class),
+         href='',
+         target='_blank',
+         download=NA,
+         validateIcon(icon),
+         label, ...)
 }
 
 #' @rdname downloadButton


### PR DESCRIPTION
Fixes #2392 by returning the link tag directly from `downloadButton()`. 

Previously, we were storing the tag in an unused variable and returning the assignment expression, causing the tag to be returned invisibly and breaking the print methods relied on by knitr for RMarkdown and Quarto support.