### PR TITLE
feat: Add `shiny.error.unhandled` error handler

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 * Added a new `ExtendedTask` abstraction, for long-running asynchronous tasks that you don't want to block the rest of the app, or even the rest of the session. Designed to be used with new `bslib::input_task_button()` and `bslib::bind_task_button()` functions that help give user feedback and prevent extra button clicks. (#3958)
 
+* Added a `shiny.error.unhandled` option that can be set to a function that will be called when an unhandled error occurs in a Shiny app. Note that this handler doesn't stop the error or prevent the session from closing, but it can be used to log the error or to clean up session-specific resources. (thanks @JohnCoene, #3989)
+
 ## Bug fixes
 
 * Notifications are now constrained to the width of the viewport for window widths smaller the default notification panel size. (#3949)

--- a/R/mock-session.R
+++ b/R/mock-session.R
@@ -563,6 +563,7 @@ MockShinySession <- R6Class(
     #' @description Called by observers when a reactive expression errors.
     #' @param e An error object.
     unhandledError = function(e) {
+      shinyUserErrorUnhandled(e)
       self$close()
     },
     #' @description Freeze a value until the flush cycle completes.

--- a/R/shiny-options.R
+++ b/R/shiny-options.R
@@ -83,7 +83,10 @@ getShinyOption <- function(name, default = NULL) {
 #'   the debugger prompt when an error occurs.}
 #' \item{shiny.error.unhandled (defaults to `NULL`)}{A function that will be
 #'   called when an unhandled error that will stop the app session occurs. This
-#'   function should take the error condition object as its first argument.}
+#'   function should take the error condition object as its first argument.
+#'   Note that this function will not stop the error or prevent the session
+#'   from ending, but it will provide you with an opportunity to log the error
+#'   or clean up resources before the session is closed.}
 #' \item{shiny.fullstacktrace (defaults to `FALSE`)}{Controls whether "pretty" (`FALSE`) or full
 #'   stack traces (`TRUE`) are dumped to the console when errors occur during Shiny app execution.
 #'   Pretty stack traces attempt to only show user-supplied code, but this pruning can't always

--- a/R/shiny-options.R
+++ b/R/shiny-options.R
@@ -81,6 +81,9 @@ getShinyOption <- function(name, default = NULL) {
 #' \item{shiny.error (defaults to `NULL`)}{This can be a function which is called when an error
 #'   occurs. For example, `options(shiny.error=recover)` will result a
 #'   the debugger prompt when an error occurs.}
+#' \item{shiny.error.unhandled (defaults to `NULL`)}{A function that will be
+#'   called when an unhandled error that will stop the app session occurs. This
+#'   function should take the error condition object as its first argument.}
 #' \item{shiny.fullstacktrace (defaults to `FALSE`)}{Controls whether "pretty" (`FALSE`) or full
 #'   stack traces (`TRUE`) are dumped to the console when errors occur during Shiny app execution.
 #'   Pretty stack traces attempt to only show user-supplied code, but this pruning can't always

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -1045,24 +1045,8 @@ ShinySession <- R6Class(
     },
     unhandledError = function(e) {
       "Call the user's unhandled error handler and then close the session."
-      on.exit(self$close())
-
-      handler  <- getShinyOption("shiny.error.unhandled", NULL)
-      if (is.null(handler)) return()
-
-      if (!is.function(handler) || length(formals(handler)) == 0) {
-        warning(
-          "`shiny.error.unhandled` must be a function ",
-          "that takes an error object as its first argument",
-          immediate. = TRUE
-        )
-        return()
-      }
-
-      tryCatch(
-        shinyCallingHandlers(handler(error)),
-        error = printError
-      )
+      shinyUserErrorUnhandled(e)
+      self$close()
     },
     close = function() {
       if (!self$closed) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -493,6 +493,30 @@ shinyCallingHandlers <- function(expr) {
   )
 }
 
+shinyUserErrorUnhandled <- function(error, handler = NULL) {
+  if (is.null(handler)) {
+    handler <- getShinyOption(
+      "shiny.error.unhandled",
+      getOption("shiny.error.unhandled", NULL)
+    )
+  }
+
+  if (is.null(handler)) return()
+
+  if (!is.function(handler) || length(formals(handler)) == 0) {
+    warning(
+      "`shiny.error.unhandled` must be a function ",
+      "that takes an error object as its first argument",
+      immediate. = TRUE
+    )
+    return()
+  }
+
+  tryCatch(
+    shinyCallingHandlers(handler(error)),
+    error = printError
+  )
+}
 
 #' Register a function with the debugger (if one is active).
 #'

--- a/man/shinyOptions.Rd
+++ b/man/shinyOptions.Rd
@@ -60,6 +60,9 @@ deprecated functions in Shiny will be printed. See
 \item{shiny.error (defaults to \code{NULL})}{This can be a function which is called when an error
 occurs. For example, \code{options(shiny.error=recover)} will result a
 the debugger prompt when an error occurs.}
+\item{shiny.error.unhandled (defaults to \code{NULL})}{A function that will be
+called when an unhandled error that will stop the app session occurs. This
+function should take the error condition object as its first argument.}
 \item{shiny.fullstacktrace (defaults to \code{FALSE})}{Controls whether "pretty" (\code{FALSE}) or full
 stack traces (\code{TRUE}) are dumped to the console when errors occur during Shiny app execution.
 Pretty stack traces attempt to only show user-supplied code, but this pruning can't always

--- a/man/shinyOptions.Rd
+++ b/man/shinyOptions.Rd
@@ -62,7 +62,10 @@ occurs. For example, \code{options(shiny.error=recover)} will result a
 the debugger prompt when an error occurs.}
 \item{shiny.error.unhandled (defaults to \code{NULL})}{A function that will be
 called when an unhandled error that will stop the app session occurs. This
-function should take the error condition object as its first argument.}
+function should take the error condition object as its first argument.
+Note that this function will not stop the error or prevent the session
+from ending, but it will provide you with an opportunity to log the error
+or clean up resources before the session is closed.}
 \item{shiny.fullstacktrace (defaults to \code{FALSE})}{Controls whether "pretty" (\code{FALSE}) or full
 stack traces (\code{TRUE}) are dumped to the console when errors occur during Shiny app execution.
 Pretty stack traces attempt to only show user-supplied code, but this pruning can't always


### PR DESCRIPTION
This PR replaces #3987 to add a new user-provided error handler that's applied to unhandled errors that are in the process of bringing down a running app.

## Background

I wasn't aware of prior efforts along these lines when I wrote #3987, but there are two previous PRs that are relevant. Apparently @JohnCoene and I went on very similar journeys when approaching this problem.

1. https://github.com/rstudio/shiny/pull/3724
	* #3724 takes a similar approach to my previous approach and intended to update `shiny.error` to pass the error object to the handler. 
	* But in practice people use `shiny.error` like the base R `error` option, where the function doesn't handle the error. These functions sometimes take more than one argument, which widens the scope of potential breakage.
	* It was closed in favor of the PR below, from what I can tell because #3726 identified a better place to catch unhandled errors.
2. https://github.com/rstudio/shiny/pull/3726
	* #3726 introduces a new option `shiny.unhandled.error` in the `ShinySession$unhandledError()` method. I think this is the right place to handle the error, but I have a slightly different implementation to propose.

## This PR

This PR adds `shiny.error.unhandled` as a global `options()` or `shinyOptions()` option. It is expected to take at least one argument, the first of which receives the error condition object that is about to take down the app.

I added `shinyUserErrorUnhandled()` to take the condition and apply the `shiny.error.unhandled` handler to it. `shinyUserErrorUnhandled()` is careful to not introduce new errors -- if the handler itself throws, the error is downgraded to a warning and printed using the same methods that are applied to the unhandled error.

I also updated `MockSession` and added a test that shows:

1. Shiny's internal error signals are ignored, e.g. the error from `req()` isn't passed to the `shiny.error.unhandled` handler.
2. Unhandled errors are caught and passed to the handler before closing the session.
3. Errors _inside_ the handler are also caught, printed, and downgraded to a warning.