### PR TITLE
chore: restyle new `examples-shiny` apps

### DIFF
--- a/inst/examples-shiny/01_hello/app.R
+++ b/inst/examples-shiny/01_hello/app.R
@@ -3,7 +3,6 @@ library(bslib)
 
 # Define UI for app that draws a histogram ----
 ui <- page_sidebar(
-
   # App title ----
   title = "Hello Shiny!",
 
@@ -18,7 +17,6 @@ ui <- page_sidebar(
       max = 50,
       value = 30
     )
-
   ),
 
   # Output: Histogram ----
@@ -27,7 +25,6 @@ ui <- page_sidebar(
 
 # Define server logic required to draw a histogram ----
 server <- function(input, output) {
-
   # Histogram of the Old Faithful Geyser Data ----
   # with requested number of bins
   # This expression that generates a histogram is wrapped in a call
@@ -37,16 +34,18 @@ server <- function(input, output) {
   #    re-executed when inputs (input$bins) change
   # 2. Its output type is a plot
   output$distPlot <- renderPlot({
-
-    x    <- faithful$waiting
+    x <- faithful$waiting
     bins <- seq(min(x), max(x), length.out = input$bins + 1)
 
-    hist(x, breaks = bins, col = "#75AADB", border = "white",
-         xlab = "Waiting time to next eruption (in mins)",
-         main = "Histogram of waiting times")
-
-    })
-
+    hist(
+      x,
+      breaks = bins,
+      col = "#75AADB",
+      border = "white",
+      xlab = "Waiting time to next eruption (in mins)",
+      main = "Histogram of waiting times"
+    )
+  })
 }
 
 # Create Shiny app ----

--- a/inst/examples-shiny/01_hello/app.R
+++ b/inst/examples-shiny/01_hello/app.R
@@ -3,6 +3,7 @@ library(bslib)
 
 # Define UI for app that draws a histogram ----
 ui <- page_sidebar(
+
   # App title ----
   title = "Hello Shiny!",
 
@@ -25,6 +26,7 @@ ui <- page_sidebar(
 
 # Define server logic required to draw a histogram ----
 server <- function(input, output) {
+
   # Histogram of the Old Faithful Geyser Data ----
   # with requested number of bins
   # This expression that generates a histogram is wrapped in a call

--- a/inst/examples-shiny/02_text/app.R
+++ b/inst/examples-shiny/02_text/app.R
@@ -9,6 +9,7 @@ ui <- page_sidebar(
 
   # Sidebar panel for inputs ----
   sidebar = sidebar(
+
     # Input: Selector for choosing dataset ----
     selectInput(
       inputId = "dataset",

--- a/inst/examples-shiny/02_text/app.R
+++ b/inst/examples-shiny/02_text/app.R
@@ -3,6 +3,7 @@ library(bslib)
 
 # Define UI for dataset viewer app ----
 ui <- page_sidebar(
+
   # App title ----
   title = "Shiny Text",
 
@@ -32,6 +33,7 @@ ui <- page_sidebar(
 
 # Define server logic to summarize and view selected dataset ----
 server <- function(input, output) {
+
   # Return the requested dataset ----
   datasetInput <- reactive({
     switch(

--- a/inst/examples-shiny/02_text/app.R
+++ b/inst/examples-shiny/02_text/app.R
@@ -3,13 +3,11 @@ library(bslib)
 
 # Define UI for dataset viewer app ----
 ui <- page_sidebar(
-
   # App title ----
   title = "Shiny Text",
 
   # Sidebar panel for inputs ----
   sidebar = sidebar(
-
     # Input: Selector for choosing dataset ----
     selectInput(
       inputId = "dataset",
@@ -23,7 +21,6 @@ ui <- page_sidebar(
       label = "Number of observations to view:",
       value = 10
     )
-
   ),
 
   # Output: Verbatim text for data summary ----
@@ -35,13 +32,14 @@ ui <- page_sidebar(
 
 # Define server logic to summarize and view selected dataset ----
 server <- function(input, output) {
-
   # Return the requested dataset ----
   datasetInput <- reactive({
-    switch(input$dataset,
-           "rock" = rock,
-           "pressure" = pressure,
-           "cars" = cars)
+    switch(
+      input$dataset,
+      "rock" = rock,
+      "pressure" = pressure,
+      "cars" = cars
+    )
   })
 
   # Generate a summary of the dataset ----
@@ -54,7 +52,6 @@ server <- function(input, output) {
   output$view <- renderTable({
     head(datasetInput(), n = input$obs)
   })
-
 }
 
 # Create Shiny app ----

--- a/inst/examples-shiny/03_reactivity/app.R
+++ b/inst/examples-shiny/03_reactivity/app.R
@@ -3,29 +3,33 @@ library(bslib)
 
 # Define UI for dataset viewer app ----
 ui <- page_sidebar(
-
   # App title ----
   title = "Reactivity",
 
   # Sidebar panel for inputs ----
   sidebar = sidebar(
+    # Input: Text for providing a caption ----
+    # Note: Changes made to the caption in the textInput control
+    # are updated in the output area immediately as you type
+    textInput(
+      inputId = "caption",
+      label = "Caption:",
+      value = "Data Summary"
+    ),
 
-      # Input: Text for providing a caption ----
-      # Note: Changes made to the caption in the textInput control
-      # are updated in the output area immediately as you type
-      textInput(inputId = "caption",
-                label = "Caption:",
-                value = "Data Summary"),
+    # Input: Selector for choosing dataset ----
+    selectInput(
+      inputId = "dataset",
+      label = "Choose a dataset:",
+      choices = c("rock", "pressure", "cars")
+    ),
 
-      # Input: Selector for choosing dataset ----
-      selectInput(inputId = "dataset",
-                  label = "Choose a dataset:",
-                  choices = c("rock", "pressure", "cars")),
-
-      # Input: Numeric entry for number of obs to view ----
-      numericInput(inputId = "obs",
-                   label = "Number of observations to view:",
-                   value = 10)
+    # Input: Numeric entry for number of obs to view ----
+    numericInput(
+      inputId = "obs",
+      label = "Number of observations to view:",
+      value = 10
+    )
   ),
 
   # Output: Formatted text for caption ----
@@ -40,7 +44,6 @@ ui <- page_sidebar(
 
 # Define server logic to summarize and view selected dataset ----
 server <- function(input, output) {
-
   # Return the requested dataset ----
   # By declaring datasetInput as a reactive expression we ensure
   # that:
@@ -49,10 +52,12 @@ server <- function(input, output) {
   # 2. The computation and result are shared by all the callers,
   #    i.e. it only executes a single time
   datasetInput <- reactive({
-    switch(input$dataset,
-           "rock" = rock,
-           "pressure" = pressure,
-           "cars" = cars)
+    switch(
+      input$dataset,
+      "rock" = rock,
+      "pressure" = pressure,
+      "cars" = cars
+    )
   })
 
   # Create caption ----
@@ -86,7 +91,6 @@ server <- function(input, output) {
   output$view <- renderTable({
     head(datasetInput(), n = input$obs)
   })
-
 }
 
 # Create Shiny app ----

--- a/inst/examples-shiny/03_reactivity/app.R
+++ b/inst/examples-shiny/03_reactivity/app.R
@@ -3,6 +3,7 @@ library(bslib)
 
 # Define UI for dataset viewer app ----
 ui <- page_sidebar(
+
   # App title ----
   title = "Reactivity",
 
@@ -44,6 +45,7 @@ ui <- page_sidebar(
 
 # Define server logic to summarize and view selected dataset ----
 server <- function(input, output) {
+
   # Return the requested dataset ----
   # By declaring datasetInput as a reactive expression we ensure
   # that:

--- a/inst/examples-shiny/03_reactivity/app.R
+++ b/inst/examples-shiny/03_reactivity/app.R
@@ -9,6 +9,7 @@ ui <- page_sidebar(
 
   # Sidebar panel for inputs ----
   sidebar = sidebar(
+
     # Input: Text for providing a caption ----
     # Note: Changes made to the caption in the textInput control
     # are updated in the output area immediately as you type

--- a/inst/examples-shiny/04_mpg/app.R
+++ b/inst/examples-shiny/04_mpg/app.R
@@ -12,6 +12,7 @@ mpgData$am <- factor(mpgData$am, labels = c("Automatic", "Manual"))
 
 # Define UI for miles per gallon app ----
 ui <- page_sidebar(
+
   # App title ----
   title = "Miles Per Gallon",
 
@@ -41,6 +42,7 @@ ui <- page_sidebar(
 
 # Define server logic to plot various variables against mpg ----
 server <- function(input, output) {
+
   # Compute the formula text ----
   # This is in a reactive expression since it is shared by the
   # output$caption and output$mpgPlot functions

--- a/inst/examples-shiny/04_mpg/app.R
+++ b/inst/examples-shiny/04_mpg/app.R
@@ -12,22 +12,24 @@ mpgData$am <- factor(mpgData$am, labels = c("Automatic", "Manual"))
 
 # Define UI for miles per gallon app ----
 ui <- page_sidebar(
-
   # App title ----
   title = "Miles Per Gallon",
 
   # Sidebar panel for inputs ----
   sidebar = sidebar(
+    # Input: Selector for variable to plot against mpg ----
+    selectInput(
+      "variable",
+      "Variable:",
+      c(
+        "Cylinders" = "cyl",
+        "Transmission" = "am",
+        "Gears" = "gear"
+      )
+    ),
 
-      # Input: Selector for variable to plot against mpg ----
-      selectInput("variable", "Variable:",
-                  c("Cylinders" = "cyl",
-                    "Transmission" = "am",
-                    "Gears" = "gear")),
-
-      # Input: Checkbox for whether outliers should be included ----
-      checkboxInput("outliers", "Show outliers", TRUE)
-
+    # Input: Checkbox for whether outliers should be included ----
+    checkboxInput("outliers", "Show outliers", TRUE)
   ),
 
   # Output: Formatted text for caption ----
@@ -39,7 +41,6 @@ ui <- page_sidebar(
 
 # Define server logic to plot various variables against mpg ----
 server <- function(input, output) {
-
   # Compute the formula text ----
   # This is in a reactive expression since it is shared by the
   # output$caption and output$mpgPlot functions
@@ -55,12 +56,14 @@ server <- function(input, output) {
   # Generate a plot of the requested variable against mpg ----
   # and only exclude outliers if requested
   output$mpgPlot <- renderPlot({
-    boxplot(as.formula(formulaText()),
-            data = mpgData,
-            outline = input$outliers,
-            col = "#75AADB", pch = 19)
+    boxplot(
+      as.formula(formulaText()),
+      data = mpgData,
+      outline = input$outliers,
+      col = "#75AADB",
+      pch = 19
+    )
   })
-
 }
 
 # Create Shiny app ----

--- a/inst/examples-shiny/04_mpg/app.R
+++ b/inst/examples-shiny/04_mpg/app.R
@@ -18,6 +18,7 @@ ui <- page_sidebar(
 
   # Sidebar panel for inputs ----
   sidebar = sidebar(
+
     # Input: Selector for variable to plot against mpg ----
     selectInput(
       "variable",

--- a/inst/examples-shiny/05_sliders/app.R
+++ b/inst/examples-shiny/05_sliders/app.R
@@ -3,11 +3,13 @@ library(bslib)
 
 # Define UI for slider demo app ----
 ui <- page_sidebar(
+
   # App title ----
   title = "Sliders",
 
   # Sidebar panel for inputs ----
   sidebar = sidebar(
+
     # Input: Simple integer interval ----
     sliderInput(
       "integer",
@@ -69,6 +71,7 @@ ui <- page_sidebar(
 
 # Define server logic for slider examples ----
 server <- function(input, output) {
+
   # Reactive expression to create data frame of all input values ----
   sliderValues <- reactive({
     data.frame(

--- a/inst/examples-shiny/05_sliders/app.R
+++ b/inst/examples-shiny/05_sliders/app.R
@@ -3,43 +3,64 @@ library(bslib)
 
 # Define UI for slider demo app ----
 ui <- page_sidebar(
-
   # App title ----
   title = "Sliders",
 
   # Sidebar panel for inputs ----
   sidebar = sidebar(
+    # Input: Simple integer interval ----
+    sliderInput(
+      "integer",
+      "Integer:",
+      min = 0,
+      max = 1000,
+      value = 500
+    ),
 
-      # Input: Simple integer interval ----
-      sliderInput("integer", "Integer:",
-                  min = 0, max = 1000,
-                  value = 500),
+    # Input: Decimal interval with step value ----
+    sliderInput(
+      "decimal",
+      "Decimal:",
+      min = 0,
+      max = 1,
+      value = 0.5,
+      step = 0.1
+    ),
 
-      # Input: Decimal interval with step value ----
-      sliderInput("decimal", "Decimal:",
-                  min = 0, max = 1,
-                  value = 0.5, step = 0.1),
+    # Input: Specification of range within an interval ----
+    sliderInput(
+      "range",
+      "Range:",
+      min = 1,
+      max = 1000,
+      value = c(200, 500)
+    ),
 
-      # Input: Specification of range within an interval ----
-      sliderInput("range", "Range:",
-                  min = 1, max = 1000,
-                  value = c(200,500)),
+    # Input: Custom currency format for with basic animation ----
+    sliderInput(
+      "format",
+      "Custom Format:",
+      min = 0,
+      max = 10000,
+      value = 0,
+      step = 2500,
+      pre = "$",
+      sep = ",",
+      animate = TRUE
+    ),
 
-      # Input: Custom currency format for with basic animation ----
-      sliderInput("format", "Custom Format:",
-                  min = 0, max = 10000,
-                  value = 0, step = 2500,
-                  pre = "$", sep = ",",
-                  animate = TRUE),
-
-      # Input: Animation with custom interval (in ms) ----
-      # to control speed, plus looping
-      sliderInput("animation", "Looping Animation:",
-                  min = 1, max = 2000,
-                  value = 1, step = 10,
-                  animate =
-                    animationOptions(interval = 300, loop = TRUE))
-
+    # Input: Animation with custom interval (in ms) ----
+    # to control speed, plus looping
+    sliderInput(
+      "animation",
+      "Looping Animation:",
+      min = 1,
+      max = 2000,
+      value = 1,
+      step = 10,
+      animate =
+        animationOptions(interval = 300, loop = TRUE)
+    )
   ),
 
   # Output: Table summarizing the values entered ----
@@ -48,30 +69,31 @@ ui <- page_sidebar(
 
 # Define server logic for slider examples ----
 server <- function(input, output) {
-
   # Reactive expression to create data frame of all input values ----
   sliderValues <- reactive({
-
     data.frame(
-      Name = c("Integer",
-               "Decimal",
-               "Range",
-               "Custom Format",
-               "Animation"),
-      Value = as.character(c(input$integer,
-                             input$decimal,
-                             paste(input$range, collapse = " "),
-                             input$format,
-                             input$animation)),
-      stringsAsFactors = FALSE)
-
+      Name = c(
+        "Integer",
+        "Decimal",
+        "Range",
+        "Custom Format",
+        "Animation"
+      ),
+      Value = as.character(c(
+        input$integer,
+        input$decimal,
+        paste(input$range, collapse = " "),
+        input$format,
+        input$animation
+      )),
+      stringsAsFactors = FALSE
+    )
   })
 
   # Show the values in an HTML table ----
   output$values <- renderTable({
     sliderValues()
   })
-
 }
 
 # Create Shiny app ----

--- a/inst/examples-shiny/06_tabsets/app.R
+++ b/inst/examples-shiny/06_tabsets/app.R
@@ -4,11 +4,13 @@ library(bslib)
 # Define UI for random distribution app ----
 # Sidebar layout with input and output definitions ----
 ui <- page_sidebar(
+
   # App title ----
   title = "Tabsets",
 
   # Sidebar panel for inputs ----
   sidebar = sidebar(
+
     # Input: Select the random distribution type ----
     radioButtons(
       "dist",
@@ -48,6 +50,7 @@ ui <- page_sidebar(
 
 # Define server logic for random distribution app ----
 server <- function(input, output) {
+
   # Reactive expression to generate the requested distribution ----
   # This is called whenever the inputs change. The output functions
   # defined below then use the value computed from this expression

--- a/inst/examples-shiny/06_tabsets/app.R
+++ b/inst/examples-shiny/06_tabsets/app.R
@@ -4,33 +4,37 @@ library(bslib)
 # Define UI for random distribution app ----
 # Sidebar layout with input and output definitions ----
 ui <- page_sidebar(
-
   # App title ----
   title = "Tabsets",
 
   # Sidebar panel for inputs ----
   sidebar = sidebar(
-
     # Input: Select the random distribution type ----
-    radioButtons("dist", "Distribution type:",
-                 c("Normal" = "norm",
-                   "Uniform" = "unif",
-                   "Log-normal" = "lnorm",
-                   "Exponential" = "exp")),
+    radioButtons(
+      "dist",
+      "Distribution type:",
+      c(
+        "Normal" = "norm",
+        "Uniform" = "unif",
+        "Log-normal" = "lnorm",
+        "Exponential" = "exp"
+      )
+    ),
     # br() element to introduce extra vertical spacing ----
     br(),
     # Input: Slider for the number of observations to generate ----
-    sliderInput("n",
-                "Number of observations:",
-                value = 500,
-                min = 1,
-                max = 1000)
+    sliderInput(
+      "n",
+      "Number of observations:",
+      value = 500,
+      min = 1,
+      max = 1000
+    )
   ),
 
   # Main panel for displaying outputs ----
   # Output: A tabset that combines three panels ----
   navset_card_underline(
-
     # Panel with plot ----
     nav_panel("Plot", plotOutput("plot")),
 
@@ -44,17 +48,18 @@ ui <- page_sidebar(
 
 # Define server logic for random distribution app ----
 server <- function(input, output) {
-
   # Reactive expression to generate the requested distribution ----
   # This is called whenever the inputs change. The output functions
   # defined below then use the value computed from this expression
   d <- reactive({
-    dist <- switch(input$dist,
-                   norm = rnorm,
-                   unif = runif,
-                   lnorm = rlnorm,
-                   exp = rexp,
-                   rnorm)
+    dist <- switch(
+      input$dist,
+      norm = rnorm,
+      unif = runif,
+      lnorm = rlnorm,
+      exp = rexp,
+      rnorm
+    )
 
     dist(input$n)
   })
@@ -68,9 +73,12 @@ server <- function(input, output) {
     dist <- input$dist
     n <- input$n
 
-    hist(d(),
-         main = paste("r", dist, "(", n, ")", sep = ""),
-         col = "#75AADB", border = "white")
+    hist(
+      d(),
+      main = paste("r", dist, "(", n, ")", sep = ""),
+      col = "#75AADB",
+      border = "white"
+    )
   })
 
   # Generate a summary of the data ----
@@ -82,7 +90,6 @@ server <- function(input, output) {
   output$table <- renderTable({
     d()
   })
-
 }
 
 # Create Shiny app ----

--- a/inst/examples-shiny/07_widgets/app.R
+++ b/inst/examples-shiny/07_widgets/app.R
@@ -3,11 +3,13 @@ library(bslib)
 
 # Define UI for slider demo app ----
 ui <- page_sidebar(
+
   # App title ----
   title = "More Widgets",
 
   # Sidebar panel for inputs ----
   sidebar = sidebar(
+
     # Input: Select a dataset ----
     selectInput(
       "dataset",
@@ -44,6 +46,7 @@ ui <- page_sidebar(
 
 # Define server logic to summarize and view selected dataset ----
 server <- function(input, output) {
+
   # Return the requested dataset ----
   # Note that we use eventReactive() here, which depends on
   # input$update (the action button), so that the output is only

--- a/inst/examples-shiny/07_widgets/app.R
+++ b/inst/examples-shiny/07_widgets/app.R
@@ -3,32 +3,34 @@ library(bslib)
 
 # Define UI for slider demo app ----
 ui <- page_sidebar(
-
   # App title ----
   title = "More Widgets",
 
   # Sidebar panel for inputs ----
   sidebar = sidebar(
+    # Input: Select a dataset ----
+    selectInput(
+      "dataset",
+      "Choose a dataset:",
+      choices = c("rock", "pressure", "cars")
+    ),
 
-      # Input: Select a dataset ----
-      selectInput("dataset", "Choose a dataset:",
-                  choices = c("rock", "pressure", "cars")),
+    # Input: Specify the number of observations to view ----
+    numericInput("obs", "Number of observations to view:", 10),
 
-      # Input: Specify the number of observations to view ----
-      numericInput("obs", "Number of observations to view:", 10),
+    # Include clarifying text ----
+    helpText(
+      "Note: while the data view will show only the specified",
+      "number of observations, the summary will still be based",
+      "on the full dataset."
+    ),
 
-      # Include clarifying text ----
-      helpText("Note: while the data view will show only the specified",
-               "number of observations, the summary will still be based",
-               "on the full dataset."),
-
-      # Input: actionButton() to defer the rendering of output ----
-      # until the user explicitly clicks the button (rather than
-      # doing it immediately when inputs change). This is useful if
-      # the computations required to render output are inordinately
-      # time-consuming.
-      actionButton("update", "Update View")
-
+    # Input: actionButton() to defer the rendering of output ----
+    # until the user explicitly clicks the button (rather than
+    # doing it immediately when inputs change). This is useful if
+    # the computations required to render output are inordinately
+    # time-consuming.
+    actionButton("update", "Update View")
   ),
 
   # Output: Header + summary of distribution ----
@@ -42,17 +44,22 @@ ui <- page_sidebar(
 
 # Define server logic to summarize and view selected dataset ----
 server <- function(input, output) {
-
   # Return the requested dataset ----
   # Note that we use eventReactive() here, which depends on
   # input$update (the action button), so that the output is only
   # updated when the user clicks the button
-  datasetInput <- eventReactive(input$update, {
-    switch(input$dataset,
-           "rock" = rock,
-           "pressure" = pressure,
-           "cars" = cars)
-  }, ignoreNULL = FALSE)
+  datasetInput <- eventReactive(
+    input$update,
+    {
+      switch(
+        input$dataset,
+        "rock" = rock,
+        "pressure" = pressure,
+        "cars" = cars
+      )
+    },
+    ignoreNULL = FALSE
+  )
 
   # Generate a summary of the dataset ----
   output$summary <- renderPrint({
@@ -67,7 +74,6 @@ server <- function(input, output) {
   output$view <- renderTable({
     head(datasetInput(), n = isolate(input$obs))
   })
-
 }
 
 # Create Shiny app ----

--- a/inst/examples-shiny/08_html/app.R
+++ b/inst/examples-shiny/08_html/app.R
@@ -2,6 +2,7 @@ library(shiny)
 
 # Define server logic for random distribution app ----
 server <- function(input, output) {
+
   # Reactive expression to generate the requested distribution ----
   # This is called whenever the inputs change. The output functions
   # defined below then use the value computed from this expression

--- a/inst/examples-shiny/08_html/app.R
+++ b/inst/examples-shiny/08_html/app.R
@@ -2,17 +2,18 @@ library(shiny)
 
 # Define server logic for random distribution app ----
 server <- function(input, output) {
-
   # Reactive expression to generate the requested distribution ----
   # This is called whenever the inputs change. The output functions
   # defined below then use the value computed from this expression
   d <- reactive({
-    dist <- switch(input$dist,
-                   norm = rnorm,
-                   unif = runif,
-                   lnorm = rlnorm,
-                   exp = rexp,
-                   rnorm)
+    dist <- switch(
+      input$dist,
+      norm = rnorm,
+      unif = runif,
+      lnorm = rlnorm,
+      exp = rexp,
+      rnorm
+    )
 
     dist(input$n)
   })
@@ -26,9 +27,12 @@ server <- function(input, output) {
     dist <- input$dist
     n <- input$n
 
-    hist(d(),
-         main = paste("r", dist, "(", n, ")", sep = ""),
-         col = "#75AADB", border = "white")
+    hist(
+      d(),
+      main = paste("r", dist, "(", n, ")", sep = ""),
+      col = "#75AADB",
+      border = "white"
+    )
   })
 
   # Generate a summary of the data ----
@@ -40,7 +44,6 @@ server <- function(input, output) {
   output$table <- renderTable({
     head(data.frame(x = d()))
   })
-
 }
 
 # Create Shiny app ----

--- a/inst/examples-shiny/09_upload/app.R
+++ b/inst/examples-shiny/09_upload/app.R
@@ -3,49 +3,66 @@ library(bslib)
 
 # Define UI for slider demo app ----
 ui <- page_sidebar(
-
   # App title ----
   title = "Uploading Files",
 
   # Sidebar panel for inputs ----
   sidebar = sidebar(
+    # Input: Select a file ----
+    fileInput(
+      "file1",
+      "Choose CSV File",
+      multiple = TRUE,
+      accept = c(
+        "text/csv",
+        "text/comma-separated-values,text/plain",
+        ".csv"
+      )
+    ),
 
-      # Input: Select a file ----
-      fileInput("file1", "Choose CSV File",
-                multiple = TRUE,
-                accept = c("text/csv",
-                         "text/comma-separated-values,text/plain",
-                         ".csv")),
+    # Horizontal line ----
+    tags$hr(),
 
-      # Horizontal line ----
-      tags$hr(),
+    # Input: Checkbox if file has header ----
+    checkboxInput("header", "Header", TRUE),
 
-      # Input: Checkbox if file has header ----
-      checkboxInput("header", "Header", TRUE),
+    # Input: Select separator ----
+    radioButtons(
+      "sep",
+      "Separator",
+      choices = c(
+        Comma = ",",
+        Semicolon = ";",
+        Tab = "\t"
+      ),
+      selected = ","
+    ),
 
-      # Input: Select separator ----
-      radioButtons("sep", "Separator",
-                   choices = c(Comma = ",",
-                               Semicolon = ";",
-                               Tab = "\t"),
-                   selected = ","),
+    # Input: Select quotes ----
+    radioButtons(
+      "quote",
+      "Quote",
+      choices = c(
+        None = "",
+        "Double Quote" = '"',
+        "Single Quote" = "'"
+      ),
+      selected = '"'
+    ),
 
-      # Input: Select quotes ----
-      radioButtons("quote", "Quote",
-                   choices = c(None = "",
-                               "Double Quote" = '"',
-                               "Single Quote" = "'"),
-                   selected = '"'),
+    # Horizontal line ----
+    tags$hr(),
 
-      # Horizontal line ----
-      tags$hr(),
-
-      # Input: Select number of rows to display ----
-      radioButtons("disp", "Display",
-                   choices = c(Head = "head",
-                               All = "all"),
-                   selected = "head")
-
+    # Input: Select number of rows to display ----
+    radioButtons(
+      "disp",
+      "Display",
+      choices = c(
+        Head = "head",
+        All = "all"
+      ),
+      selected = "head"
+    )
   ),
 
   # Output: Data file ----
@@ -54,29 +71,26 @@ ui <- page_sidebar(
 
 # Define server logic to read selected file ----
 server <- function(input, output) {
-
   output$contents <- renderTable({
-
     # input$file1 will be NULL initially. After the user selects
     # and uploads a file, head of that data file by default,
     # or all rows if selected, will be shown.
 
     req(input$file1)
 
-    df <- read.csv(input$file1$datapath,
-             header = input$header,
-             sep = input$sep,
-             quote = input$quote)
+    df <- read.csv(
+      input$file1$datapath,
+      header = input$header,
+      sep = input$sep,
+      quote = input$quote
+    )
 
-    if(input$disp == "head") {
+    if (input$disp == "head") {
       return(head(df))
-    }
-    else {
+    } else {
       return(df)
     }
-
   })
-
 }
 
 # Create Shiny app ----

--- a/inst/examples-shiny/09_upload/app.R
+++ b/inst/examples-shiny/09_upload/app.R
@@ -3,6 +3,7 @@ library(bslib)
 
 # Define UI for slider demo app ----
 ui <- page_sidebar(
+
   # App title ----
   title = "Uploading Files",
 

--- a/inst/examples-shiny/09_upload/app.R
+++ b/inst/examples-shiny/09_upload/app.R
@@ -9,6 +9,7 @@ ui <- page_sidebar(
 
   # Sidebar panel for inputs ----
   sidebar = sidebar(
+
     # Input: Select a file ----
     fileInput(
       "file1",

--- a/inst/examples-shiny/10_download/app.R
+++ b/inst/examples-shiny/10_download/app.R
@@ -3,34 +3,34 @@ library(bslib)
 
 # Define UI for slider demo app ----
 ui <- page_sidebar(
-
   # App title ----
   title = "Downloading Data",
 
   # Sidebar panel for inputs ----
   sidebar = sidebar(
+    # Input: Choose dataset ----
+    selectInput(
+      "dataset",
+      "Choose a dataset:",
+      choices = c("rock", "pressure", "cars")
+    ),
 
-      # Input: Choose dataset ----
-      selectInput("dataset", "Choose a dataset:",
-                  choices = c("rock", "pressure", "cars")),
-
-      # Button
-      downloadButton("downloadData", "Download")
-
+    # Button
+    downloadButton("downloadData", "Download")
   ),
-
   tableOutput("table")
 )
 
 # Define server logic to display and download selected file ----
 server <- function(input, output) {
-
   # Reactive value for selected dataset ----
   datasetInput <- reactive({
-    switch(input$dataset,
-           "rock" = rock,
-           "pressure" = pressure,
-           "cars" = cars)
+    switch(
+      input$dataset,
+      "rock" = rock,
+      "pressure" = pressure,
+      "cars" = cars
+    )
   })
 
   # Table of selected dataset ----
@@ -47,7 +47,6 @@ server <- function(input, output) {
       write.csv(datasetInput(), file, row.names = FALSE)
     }
   )
-
 }
 
 # Create Shiny app ----

--- a/inst/examples-shiny/10_download/app.R
+++ b/inst/examples-shiny/10_download/app.R
@@ -3,6 +3,7 @@ library(bslib)
 
 # Define UI for slider demo app ----
 ui <- page_sidebar(
+
   # App title ----
   title = "Downloading Data",
 
@@ -23,6 +24,7 @@ ui <- page_sidebar(
 
 # Define server logic to display and download selected file ----
 server <- function(input, output) {
+
   # Reactive value for selected dataset ----
   datasetInput <- reactive({
     switch(

--- a/inst/examples-shiny/10_download/app.R
+++ b/inst/examples-shiny/10_download/app.R
@@ -9,6 +9,7 @@ ui <- page_sidebar(
 
   # Sidebar panel for inputs ----
   sidebar = sidebar(
+
     # Input: Choose dataset ----
     selectInput(
       "dataset",

--- a/inst/examples-shiny/11_timer/app.R
+++ b/inst/examples-shiny/11_timer/app.R
@@ -8,12 +8,10 @@ ui <- page_fluid(
 
 # Define server logic to show current time, update every second ----
 server <- function(input, output, session) {
-
   output$currentTime <- renderText({
     invalidateLater(1000, session)
     paste("The current time is", Sys.time())
   })
-
 }
 
 # Create Shiny app ----


### PR DESCRIPTION
Re-styles the example apps using `grkstyle::grk_style_dir("inst/examples-shiny")` (powered by `styler` and using the tidyverse style rules, with an exception for [the style described here](https://github.com/rstudio/shiny/pull/3963#pullrequestreview-1950123480)).

This did have the effect of removing some leading empty lines between the open `(` of a function call and the next comment. I don't think this affects readability, but we could add these newlines back if desired.

Note: stacks on top of #4003. We can merge this into #4003 so we can merge the examples changes all at once.