### PR TITLE
docs(MockShinySession): document unhandled error param

### DIFF
--- a/R/mock-session.R
+++ b/R/mock-session.R
@@ -574,6 +574,8 @@ MockShinySession <- R6Class(
     },
     #' @description Called by observers when a reactive expression errors.
     #' @param e An error object.
+    #' @param close If `TRUE`, the session will be closed after the error is
+    #'  handled, defaults to `FALSE`.
     unhandledError = function(e, close = TRUE) {
       if (close) {
         class(e) <- c("shiny.error.fatal", class(e))

--- a/man/MockShinySession.Rd
+++ b/man/MockShinySession.Rd
@@ -547,6 +547,9 @@ Called by observers when a reactive expression errors.
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{e}}{An error object.}
+
+\item{\code{close}}{If \code{TRUE}, the session will be closed after the error is
+handled, defaults to \code{FALSE}.}
 }
 \if{html}{\out{</div>}}
 }


### PR DESCRIPTION
Adds documentation for the `close` param of `MockShinySession$unhandledError()`, fixing the error below when calling `devtools::document()`.

```
ℹ Updating shiny documentation
ℹ Loading shiny
✖ mock-session.R:213: Must use one @param for each argument.
✖ $unhandledError(close) is not documented
```