### PR TITLE
feat: Deprecate with warnings, expect `renderDataTable()` to be deprecated

### DIFF
--- a/R/deprecated.R
+++ b/R/deprecated.R
@@ -30,7 +30,13 @@ shinyDeprecated <- function(
   }
 
   # lifecycle::deprecate_soft(when, what, with = with, details = details, id = id, env = env)
-  rlang::inform(message = msg, .frequency = "always", .frequency_id = msg, .file = stderr())
+  rlang::warn(
+    message = msg,
+    .frequency = "always",
+    .frequency_id = msg,
+    .file = stderr(),
+    class = "lifecycle_warning_deprecated"
+  )
 }
 
 

--- a/tests/testthat/test-bind-cache.R
+++ b/tests/testthat/test-bind-cache.R
@@ -1209,7 +1209,11 @@ test_that("Custom render functions that call exprToFunction", {
 
 test_that("Some render functions can't be cached", {
   m <- cachem::cache_mem()
-  expect_error(renderDataTable({ cars }) %>% bindCache(1, cache = m))
+  expect_error(
+    lifecycle::expect_deprecated(
+      renderDataTable({ cars }) %>% bindCache(1, cache = m)
+    )
+  )
   expect_error(renderCachedPlot({ plot(1) }, 1) %>% bindCache(1, cache = m))
   expect_error(renderImage({ cars }) %>% bindCache(1, cache = m))
 })

--- a/tests/testthat/test-bind-cache.R
+++ b/tests/testthat/test-bind-cache.R
@@ -1209,8 +1209,8 @@ test_that("Custom render functions that call exprToFunction", {
 
 test_that("Some render functions can't be cached", {
   m <- cachem::cache_mem()
-  expect_error(
-    lifecycle::expect_deprecated(
+  lifecycle::expect_deprecated(
+    expect_error(
       renderDataTable({ cars }) %>% bindCache(1, cache = m)
     )
   )

--- a/tests/testthat/test-mock-session.R
+++ b/tests/testthat/test-mock-session.R
@@ -76,13 +76,15 @@ test_that("reactivePoll supported", {
 
 test_that("renderDataTable supported", {
   session <- MockShinySession$new()
-  isolate({
-    rt <- renderDataTable({
-      head(iris)
+  lifecycle::expect_deprecated(
+    isolate({
+      rt <- renderDataTable({
+        head(iris)
+      })
+      res <- rt(session, "name")
+      expect_equal(res$colnames, colnames(iris))
     })
-    res <- rt(session, "name")
-    expect_equal(res$colnames, colnames(iris))
-  })
+  )
 })
 
 test_that("renderImage supported", {


### PR DESCRIPTION
In `shinyDeprecated()` we emulate a mix between `lifecycle::deprecate_soft()` and `lifecycle::deprecate_warn()`. But because this function used `rlang::inform()` instead of `rlang::warn()`, it's a plain message printed to stderr instead of a signal with a traceback, etc.

This PR updates `shinyDeprecated()` to use `rlang::warn()` and to apply the same class used by lifecycle to the warning so that other lifecycle helpers, such as `expect_deprecated()`, can work as expected.

The motivation here was to test that `renderDataTable()` is deprecated and to avoid printing additional output when running our test suite. This provides a good example of the change in the message:

### Before

```
`shiny::renderDataTable()` is deprecated as of shiny 1.8.1.
Please use `DT::renderDT()` instead.
See <https://rstudio.github.io/DT/shiny.html> for more information.
```

### After

```
Warning (test-bind-cache.R:1212:3): Some render functions can't be cached
`shiny::renderDataTable()` is deprecated as of shiny 1.8.1.
Please use `DT::renderDT()` instead.
See <https://rstudio.github.io/DT/shiny.html> for more information.
Backtrace:
     ▆
  1. ├─testthat::expect_error(...) at test-bind-cache.R:1212:3
  2. │ └─testthat:::expect_condition_matching(...)
  3. │   └─testthat:::quasi_capture(...)
  4. │     ├─testthat (local) .capture(...)
  5. │     │ └─base::withCallingHandlers(...)
  6. │     └─rlang::eval_bare(quo_get_expr(.quo), quo_get_env(.quo))
  7. ├─... %>% bindCache(1, cache = m)
  8. ├─shiny::bindCache(., 1, cache = m)
  9. └─shiny::renderDataTable(...) at shiny/R/bind-cache.R:469:3
 10.   └─shiny:::useLegacyDataTable(...) at shiny/R/shinywrappers.R:888:3
 11.     └─shiny:::shinyDeprecated("1.8.1", from, to, details) at shiny/R/bootstrap.R:1176:3
```