### PR TITLE
Revert changes to `shinyDeprecated()` & update `renderDataTables()` tests to always use shiny's datatables implementation

### DIFF
--- a/R/deprecated.R
+++ b/R/deprecated.R
@@ -30,13 +30,7 @@ shinyDeprecated <- function(
   }
 
   # lifecycle::deprecate_soft(when, what, with = with, details = details, id = id, env = env)
-  rlang::warn(
-    message = msg,
-    .frequency = "always",
-    .frequency_id = msg,
-    .file = stderr(),
-    class = "lifecycle_warning_deprecated"
-  )
+  rlang::inform(message = msg, .frequency = "always", .frequency_id = msg, .file = stderr())
 }
 
 

--- a/tests/testthat/test-bind-cache.R
+++ b/tests/testthat/test-bind-cache.R
@@ -1209,11 +1209,7 @@ test_that("Custom render functions that call exprToFunction", {
 
 test_that("Some render functions can't be cached", {
   m <- cachem::cache_mem()
-  lifecycle::expect_deprecated(
-    expect_error(
-      renderDataTable({ cars }) %>% bindCache(1, cache = m)
-    )
-  )
+  expect_error(renderDataTable({ cars }) %>% bindCache(1, cache = m))
   expect_error(renderCachedPlot({ plot(1) }, 1) %>% bindCache(1, cache = m))
   expect_error(renderImage({ cars }) %>% bindCache(1, cache = m))
 })

--- a/tests/testthat/test-bind-cache.R
+++ b/tests/testthat/test-bind-cache.R
@@ -1208,6 +1208,8 @@ test_that("Custom render functions that call exprToFunction", {
 
 
 test_that("Some render functions can't be cached", {
+  withr::local_options(list(shiny.legacy.datatable = TRUE))
+
   m <- cachem::cache_mem()
   expect_error(renderDataTable({ cars }) %>% bindCache(1, cache = m))
   expect_error(renderCachedPlot({ plot(1) }, 1) %>% bindCache(1, cache = m))

--- a/tests/testthat/test-mock-session.R
+++ b/tests/testthat/test-mock-session.R
@@ -76,15 +76,13 @@ test_that("reactivePoll supported", {
 
 test_that("renderDataTable supported", {
   session <- MockShinySession$new()
-  lifecycle::expect_deprecated(
-    isolate({
-      rt <- renderDataTable({
-        head(iris)
-      })
-      res <- rt(session, "name")
-      expect_equal(res$colnames, colnames(iris))
+  isolate({
+    rt <- renderDataTable({
+      head(iris)
     })
-  )
+    res <- rt(session, "name")
+    expect_equal(res$colnames, colnames(iris))
+  })
 })
 
 test_that("renderImage supported", {

--- a/tests/testthat/test-mock-session.R
+++ b/tests/testthat/test-mock-session.R
@@ -75,6 +75,8 @@ test_that("reactivePoll supported", {
 # })
 
 test_that("renderDataTable supported", {
+  withr::local_options(list(shiny.legacy.datatable = TRUE))
+
   session <- MockShinySession$new()
   isolate({
     rt <- renderDataTable({


### PR DESCRIPTION
This PR does two things:

1. Reverts #4007. Unfortunately, this would cause 7 reverse dependencies to start failing, so the change doesn't feel worth our time (or other maintainers time).
2. In looking in these `renderDataTables()` tests again, I realized that the return value of `renderDataTable()` will change when the next version of `{DT}` goes to CRAN (which will break the relevant shiny unit test). Instead of updating that unit test to reflect what `{DT}` gives us, I've set the relevant option to use shiny's implementation (so that future changes to DT doen't break shiny's tests).