### PR TITLE
ExtendedTask should not be cloneable

### DIFF
--- a/R/extended-task.R
+++ b/R/extended-task.R
@@ -42,7 +42,7 @@
 #'   session to immediately unblock and carry on with other user interactions.
 #'
 #' @export
-ExtendedTask <- R6Class("ExtendedTask", portable = TRUE,
+ExtendedTask <- R6Class("ExtendedTask", portable = TRUE, cloneable = FALSE,
   public = list(
     #' @description
     #' Creates a new `ExtendedTask` object. `ExtendedTask` should generally be

--- a/man/ExtendedTask.Rd
+++ b/man/ExtendedTask.Rd
@@ -52,7 +52,6 @@ session to immediately unblock and carry on with other user interactions.
 \item \href{#method-ExtendedTask-invoke}{\code{ExtendedTask$invoke()}}
 \item \href{#method-ExtendedTask-status}{\code{ExtendedTask$status()}}
 \item \href{#method-ExtendedTask-result}{\code{ExtendedTask$result()}}
-\item \href{#method-ExtendedTask-clone}{\code{ExtendedTask$clone()}}
 }
 }
 \if{html}{\out{<hr>}}
@@ -165,22 +164,5 @@ invalidation will be ignored.
 \if{html}{\out{<div class="r">}}\preformatted{ExtendedTask$result()}\if{html}{\out{</div>}}
 }
 
-}
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-ExtendedTask-clone"></a>}}
-\if{latex}{\out{\hypertarget{method-ExtendedTask-clone}{}}}
-\subsection{Method \code{clone()}}{
-The objects of this class are cloneable with this method.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{ExtendedTask$clone(deep = FALSE)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{deep}}{Whether to make a deep clone.}
-}
-\if{html}{\out{</div>}}
-}
 }
 }


### PR DESCRIPTION
I was reviewing the docs for ExtendedTask and noticed that the `$clone()` method was documented. I'm not sure what it would mean if an ExtendedTask object was cloned, but I'm pretty sure it wouldn't be good, given that it contains reactive values inside. And I don't know why someone would want to clone it anyway. Better to just prevent it.