### PR TITLE
Fix opacity dimming on recalculating `uiOutput()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # shiny (development version)
 
+## Bug fixes
+
+* Fixed a recent issue with `uiOutput()` and `conditionalPanel()` not properly lower opacity when recalculation (in a Bootstrap 5 context). (#4027)
 
 # shiny 1.8.1.1
 

--- a/inst/www/shared/shiny_scss/shiny.bootstrap5.scss
+++ b/inst/www/shared/shiny_scss/shiny.bootstrap5.scss
@@ -44,9 +44,9 @@ div:where(.shiny-html-output) {
   /* uiOutput()/ conditionalPanel() are "pass-through" containers when they have children. */
   &:has(> *) {
     display: contents;
-  }
-  /* And since they display:contents, forward any styles that are applied to them to their children */
-  &.recalculating > * {
-    opacity: 0.3;
+      /* Pass along styles that no longer impact the pass-through container */
+    &.recalculating > * {
+      opacity: 0.3;
+    }
   }
 }

--- a/inst/www/shared/shiny_scss/shiny.bootstrap5.scss
+++ b/inst/www/shared/shiny_scss/shiny.bootstrap5.scss
@@ -38,8 +38,15 @@ $datepicker-disabled-color:         $dropdown-link-disabled-color !default;
 
 $shiny-file-active-shadow:          $input-focus-box-shadow !default;
 
-/* Treat conditional panels and uiOutput as "pass-through" containers */
+
 .shiny-panel-conditional,
 div:where(.shiny-html-output) {
-  display: contents;
+  /* uiOutput()/ conditionalPanel() are "pass-through" containers when they have children. */
+  &:has(> *) {
+    display: contents;
+  }
+  /* And since they display:contents, forward any styles that are applied to them to their children */
+  &.recalculating > * {
+    opacity: 0.3;
+  }
 }


### PR DESCRIPTION
Closes #4027

In addition to fixing the example provided in #4027, this PR also fixes the scenario where no child elements are present, for example:

```r
library(shiny)
library(bslib)

ui <- page_fixed(
  actionButton("btn", "Press me"),
  uiOutput("foo")
)

server <- function(input, output, session) {
  
  output$foo <- renderUI({
    input$btn
    Sys.sleep(3)

    # Return value is just a string, not a HTML element
    paste("Number of clicks:", input$btn)
  })
  
}

shinyApp(ui, server)
```


It also, more generally, ensures the layout doesn't change when no children are present (e.g., if `renderUI()` returns just a string, it'll render inline, just as it normally would before the `display:contents` change)