### PR TITLE
tests(busyIndicatorOptions): set seed in the test without a helper

### DIFF
--- a/tests/testthat/_snaps/busy-indication.md
+++ b/tests/testthat/_snaps/busy-indication.md
@@ -17,32 +17,32 @@
 # busyIndicatorOptions()
 
     Code
-      tagList(busy_indicator_options(), busy_indicator_options(spinner_type = "bars"),
-      busy_indicator_options(spinner_type = "pulse"), busy_indicator_options(
-        spinner_type = "dots"), busy_indicator_options(spinner_color = "red"),
-      busy_indicator_options(spinner_size = "10px"), busy_indicator_options(
-        spinner_delay = "1s"), busy_indicator_options(pulse_background = "blue"),
-      busy_indicator_options(pulse_height = "10px"), busy_indicator_options(
-        pulse_speed = "1s"), busy_indicator_options(spinner_color = "red",
-        spinner_size = "10px", spinner_delay = "1s", pulse_background = "blue",
-        pulse_height = "10px", pulse_speed = "1s"))
+      tagList(busyIndicatorOptions(), busyIndicatorOptions(spinner_type = "bars"),
+      busyIndicatorOptions(spinner_type = "pulse"), busyIndicatorOptions(
+        spinner_type = "dots"), busyIndicatorOptions(spinner_color = "red"),
+      busyIndicatorOptions(spinner_size = "10px"), busyIndicatorOptions(
+        spinner_delay = "1s"), busyIndicatorOptions(pulse_background = "blue"),
+      busyIndicatorOptions(pulse_height = "10px"), busyIndicatorOptions(pulse_speed = "1s"),
+      busyIndicatorOptions(spinner_color = "red", spinner_size = "10px",
+        spinner_delay = "1s", pulse_background = "blue", pulse_height = "10px",
+        pulse_speed = "1s"))
     Output
       <style id="spinner-options-606810">:has(> #spinner-options-606810) {--shiny-spinner-url:url('spinners/bars.svg');}</style>
-      <style id="spinner-options-606810">:has(> #spinner-options-606810) {--shiny-spinner-url:url('spinners/pulse.svg');}</style>
-      <style id="spinner-options-606810">:has(> #spinner-options-606810) {--shiny-spinner-url:url('spinners/dots.svg');}</style>
-      <style id="spinner-options-606810">:has(> #spinner-options-606810) {--shiny-spinner-color:#FF0000;}</style>
-      <style id="spinner-options-606810">:has(> #spinner-options-606810) {--shiny-spinner-size:10px;}</style>
-      <style id="spinner-options-606810">:has(> #spinner-options-606810) {--shiny-spinner-delay:1s;}</style>
+      <style id="spinner-options-331475">:has(> #spinner-options-331475) {--shiny-spinner-url:url('spinners/pulse.svg');}</style>
+      <style id="spinner-options-162876">:has(> #spinner-options-162876) {--shiny-spinner-url:url('spinners/dots.svg');}</style>
+      <style id="spinner-options-614193">:has(> #spinner-options-614193) {--shiny-spinner-color:#FF0000;}</style>
+      <style id="spinner-options-732154">:has(> #spinner-options-732154) {--shiny-spinner-size:10px;}</style>
+      <style id="spinner-options-353895">:has(> #spinner-options-353895) {--shiny-spinner-delay:1s;}</style>
       <style>:root {--shiny-pulse-background:blue;}</style>
       <style>:root {--shiny-pulse-height:10px;}</style>
       <style>:root {--shiny-pulse-speed:1s;}</style>
-      <style id="spinner-options-606810">:has(> #spinner-options-606810) {--shiny-spinner-color:#FF0000;--shiny-spinner-size:10px;--shiny-spinner-delay:1s;}</style>
+      <style id="spinner-options-437161">:has(> #spinner-options-437161) {--shiny-spinner-color:#FF0000;--shiny-spinner-size:10px;--shiny-spinner-delay:1s;}</style>
       <style>:root {--shiny-pulse-background:blue;--shiny-pulse-height:10px;--shiny-pulse-speed:1s;}</style>
 
 # Can provide svg file for busyIndicatorOptions(spinner_type)
 
     Code
-      busy_indicator_options(spinner_type = tmpsvg)
+      busyIndicatorOptions(spinner_type = tmpsvg)
     Output
       [[1]]
       <style id="spinner-options-606810">:has(> #spinner-options-606810) {--shiny-spinner-url:url('data:image/svg+xml;base64,PHN2Zz48L3N2Zz4K');}</style>

--- a/tests/testthat/test-busy-indication.R
+++ b/tests/testthat/test-busy-indication.R
@@ -12,26 +12,22 @@ test_that("useBusyIndicators()", {
   expect_error(useBusyIndicators(foo = "bar"))
 })
 
-busy_indicator_options <- function(...) {
-  withPrivateSeed(set.seed(100))
-  busyIndicatorOptions(...)
-}
-
 test_that("busyIndicatorOptions()", {
+  withPrivateSeed(set.seed(100))
 
   expect_snapshot(
     tagList(
-      busy_indicator_options(),
-      busy_indicator_options(spinner_type = "bars"),
-      busy_indicator_options(spinner_type = "pulse"),
-      busy_indicator_options(spinner_type = "dots"),
-      busy_indicator_options(spinner_color = "red"),
-      busy_indicator_options(spinner_size = "10px"),
-      busy_indicator_options(spinner_delay = "1s"),
-      busy_indicator_options(pulse_background = "blue"),
-      busy_indicator_options(pulse_height = "10px"),
-      busy_indicator_options(pulse_speed = "1s"),
-      busy_indicator_options(
+      busyIndicatorOptions(),
+      busyIndicatorOptions(spinner_type = "bars"),
+      busyIndicatorOptions(spinner_type = "pulse"),
+      busyIndicatorOptions(spinner_type = "dots"),
+      busyIndicatorOptions(spinner_color = "red"),
+      busyIndicatorOptions(spinner_size = "10px"),
+      busyIndicatorOptions(spinner_delay = "1s"),
+      busyIndicatorOptions(pulse_background = "blue"),
+      busyIndicatorOptions(pulse_height = "10px"),
+      busyIndicatorOptions(pulse_speed = "1s"),
+      busyIndicatorOptions(
         spinner_color = "red",
         spinner_size = "10px",
         spinner_delay = "1s",
@@ -42,12 +38,12 @@ test_that("busyIndicatorOptions()", {
     )
   )
 
-  expect_error(busy_indicator_options("foo"))
-  expect_error(busy_indicator_options(foo = "bar"))
-  expect_error(busy_indicator_options(spinner_type = "dsflds"))
-  expect_error(busy_indicator_options(spinner_color = "dsflds"))
-  expect_error(busy_indicator_options(spinner_size = "dsflds"))
-  expect_error(busy_indicator_options(pulse_height = "dsflds"))
+  expect_error(busyIndicatorOptions("foo"))
+  expect_error(busyIndicatorOptions(foo = "bar"))
+  expect_error(busyIndicatorOptions(spinner_type = "dsflds"))
+  expect_error(busyIndicatorOptions(spinner_color = "dsflds"))
+  expect_error(busyIndicatorOptions(spinner_size = "dsflds"))
+  expect_error(busyIndicatorOptions(pulse_height = "dsflds"))
 })
 
 
@@ -58,7 +54,8 @@ test_that("Can provide svg file for busyIndicatorOptions(spinner_type)", {
   writeLines("<svg></svg>", tmpsvg)
   on.exit(unlink(tmpsvg))
 
+  withPrivateSeed(set.seed(100))
   expect_snapshot(
-    busy_indicator_options(spinner_type = tmpsvg)
+    busyIndicatorOptions(spinner_type = tmpsvg)
   )
 })


### PR DESCRIPTION
Very small update to the `busyIndicatorOptions()` test to set the seed in each test block so that:

1. The ID changes with each call (this otherwise looks like an error in the snapshot)
1. The `busyIndicatorOptions()` calls show up in the snapshot (otherwise it looks like that's the function in shiny).