### PR TITLE
feat(options): shiny.client_devmode

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 * Added new functions, `useBusyIndicators()` and `busyIndicatorOptions()`, for enabling and customizing busy indication. Busy indicators provide a visual cue to users when the server is busy calculating outputs or otherwise serving requests to the client. When enabled, a spinner is shown on each calculating/recalculating output, and a pulsing banner is shown at the top of the page when the app is otherwise busy. (#4040)
 * Output bindings now include the `.recalculating` CSS class when they are first bound, up until the first render. This makes it possible/easier to show progress indication when the output is calculating for the first time. (#4039)
+* A new `shiny.client_devmode` option controls client-side devmode features, in particular the client-side error console introduced in shiny 1.8.1, independently of the R-side features of `shiny::devmode()`. This usage is primarily intended for automatic use in Shinylive. (#4073)
 
 ## Bug fixes
 

--- a/R/devmode.R
+++ b/R/devmode.R
@@ -128,6 +128,12 @@ in_devmode <- function() {
     !identical(Sys.getenv("TESTTHAT"), "true")
 }
 
+in_client_devmode <- function() {
+  # Client-side devmode enables client-side only dev features without local
+  # devmode. Currently, the main feature is the client-side error console.
+  isTRUE(getOption("shiny.client_devmode", FALSE))
+}
+
 #' @describeIn devmode Temporarily set Shiny Developer Mode and Developer
 #'   message verbosity
 #' @param code Code to execute with the temporary Dev Mode options set

--- a/R/shiny-options.R
+++ b/R/shiny-options.R
@@ -151,6 +151,11 @@ getShinyOption <- function(name, default = NULL) {
 # ' \item{shiny.devmode.verbose (defaults to `TRUE`)}{If `TRUE`, will display messages printed
 # '   about which options are being set. See [devmode()] for more details. }
 ### (end not documenting 'shiny.devmode.verbose')
+### start shiny.client_devmode is primarily for niche, internal shinylive usage
+# ' \item{shiny.client_devmode (defaults to `FALSE`)}{If `TRUE`, enables client-
+# '  side devmode features. Currently the primary feature is the client-side
+# '  error console.}
+### end shiny.client.devmode
 #' }
 #'
 #'

--- a/R/shiny-options.R
+++ b/R/shiny-options.R
@@ -155,7 +155,7 @@ getShinyOption <- function(name, default = NULL) {
 # ' \item{shiny.client_devmode (defaults to `FALSE`)}{If `TRUE`, enables client-
 # '  side devmode features. Currently the primary feature is the client-side
 # '  error console.}
-### end shiny.client.devmode
+### end shiny.client_devmode
 #' }
 #'
 #'

--- a/R/shinyui.R
+++ b/R/shinyui.R
@@ -69,7 +69,7 @@ renderPage <- function(ui, showcase=0, testMode=FALSE) {
       )
   }
 
-  if (in_devmode()) {
+  if (in_devmode() || in_client_devmode()) {
     # If we're in dev mode, add a simple script to the head that injects a
     # global variable for the client to use to detect dev mode.
     shiny_deps[[length(shiny_deps) + 1]] <-


### PR DESCRIPTION
Adds a `shiny.client_devmode` option that, when `TRUE`, enables client-side devmode features independently of the local R-side devmode features.

In particular, this usage is intended for enabling the client error console in Shinylive. As such, I added internal documentation to shiny-options.