### PR TITLE
Fix race condition in throttle/debounce tests

### DIFF
--- a/tests/testthat/test-reactivity.r
+++ b/tests/testthat/test-reactivity.r
@@ -1243,7 +1243,10 @@ test_that("debounce/throttle work properly (with priming)", {
 
   # This observer will be what changes rv$a.
   src <- observe({
-    invalidateLater(100)
+    if (isolate(rv$a) == 0)
+      invalidateLater(120) # delay 20ms extra once to avoid threshold errors
+    else
+      invalidateLater(100)
     rv$a <- isolate(rv$a) + 1
   })
   on.exit(src$destroy(), add = TRUE)
@@ -1322,7 +1325,10 @@ test_that("debounce/throttle work properly (without priming)", {
 
   # This observer will be what changes rv$a.
   src <- observe({
-    invalidateLater(100)
+    if (isolate(rv$a) == 0)
+      invalidateLater(120) # delay 20ms extra once to avoid threshold errors
+    else
+      invalidateLater(100)
     rv$a <- isolate(rv$a) + 1
   })
   on.exit(src$destroy(), add = TRUE)

--- a/tests/testthat/test-reactivity.r
+++ b/tests/testthat/test-reactivity.r
@@ -1244,7 +1244,7 @@ test_that("debounce/throttle work properly (with priming)", {
   # This observer will be what changes rv$a.
   src <- observe({
     if (isolate(rv$a) == 0)
-      invalidateLater(120) # delay 20ms extra once to avoid threshold errors
+      invalidateLater(120) # delay 20ms extra once to avoid race condition
     else
       invalidateLater(100)
     rv$a <- isolate(rv$a) + 1
@@ -1326,7 +1326,7 @@ test_that("debounce/throttle work properly (without priming)", {
   # This observer will be what changes rv$a.
   src <- observe({
     if (isolate(rv$a) == 0)
-      invalidateLater(120) # delay 20ms extra once to avoid threshold errors
+      invalidateLater(120) # delay 20ms extra once to avoid race condition
     else
       invalidateLater(100)
     rv$a <- isolate(rv$a) + 1


### PR DESCRIPTION
This should resolve the spurious failure that's been showing up in all recent PRs to this repo.

This test updates a reactive value every 100 ms, and tests the behavior of a throttle and debounce with delays set to 500 ms. Since 500 is a multiple of 100, this makes the test sensitive to the precise specifics of CPU scheduling and/or shiny queueing, since the throttle timer expiring (at 2 * 500ms) and the invalidateLater timer triggering  (at 10 * 100ms) both occur at ~1 second. This makes the test sensitive to implementation specifics, since it's not clear which one will happen first. (Empirically, the behavior appears to depend on the particular environment, with the throttle only catching the new value on ubuntu-20.04/R4.1.3.)

This PR fixes the issue by adding an additional 20ms delay to the first `invalidateLater()` loop, offsetting it from the throttle enough to consistently avert the race condition.

Closes #4133 

(dunno why it took me so long to remember the term "race condition" lol)