### PR TITLE
fix: Timing of throttle/debounce reactivity test

### DIFF
--- a/tests/testthat/test-reactivity.r
+++ b/tests/testthat/test-reactivity.r
@@ -1259,14 +1259,14 @@ test_that("debounce/throttle work properly (with priming)", {
   dr_fired <- 0
   dr_monitor <- observeEvent(dr(), {
     dr_fired <<- dr_fired + 1
-    message(the_time(), "debounced ", dr_fired)
+    message(the_time(), "debounced ", dr(), " (fired: ", dr_fired, ")")
   })
   on.exit(dr_monitor$destroy(), add = TRUE)
 
   tr_fired <- 0
   tr_monitor <- observeEvent(tr(), {
     tr_fired <<- tr_fired + 1
-    message(the_time(), "throttle ", tr_fired)
+    message(the_time(), "throttled ", tr(), " (fired: ", tr_fired, ")")
   })
   on.exit(tr_monitor$destroy(), add = TRUE)
 
@@ -1281,7 +1281,7 @@ test_that("debounce/throttle work properly (with priming)", {
 
   # Pump timer and reactives for about 1.3 seconds
   start_time <- Sys.time()
-  the_time <- function() sprintf("%0.5f ", Sys.time() - start_time)
+  the_time <- function() sprintf("%0.3f ", Sys.time() - start_time)
   message(the_time(), "==== start [run for 1.3s]")
   stopAt <- start_time + 1.3
   while (Sys.time() < stopAt) {
@@ -1304,13 +1304,13 @@ test_that("debounce/throttle work properly (with priming)", {
   # Now let some time pass without any more updates.
   src$destroy() # No more updates
   stopAt <- Sys.time() + 1
-  message(the_time(), "==== start [finish running]")
+  message(the_time(), "==== start [settle for 1s]")
   while (Sys.time() < stopAt) {
     timerCallbacks$executeElapsed()
     flushReact()
     Sys.sleep(0.001)
   }
-  message(the_time(), "==== end [finish running]")
+  message(the_time(), "==== end [settle for 1s]")
 
   # dr should've fired, and we should have converged on the right answer.
   expect_identical(dr_fired, 2)

--- a/tests/testthat/test-reactivity.r
+++ b/tests/testthat/test-reactivity.r
@@ -1245,7 +1245,6 @@ test_that("debounce/throttle work properly (with priming)", {
   src <- observe({
     invalidateLater(300)
     rv$a <- isolate(rv$a) + 1
-    message(the_time(), "input ", isolate(rv$a))
   })
   on.exit(src$destroy(), add = TRUE)
 
@@ -1259,14 +1258,12 @@ test_that("debounce/throttle work properly (with priming)", {
   dr_fired <- 0
   dr_monitor <- observeEvent(dr(), {
     dr_fired <<- dr_fired + 1
-    message(the_time(), "debounced ", dr(), " (fired: ", dr_fired, ")")
   })
   on.exit(dr_monitor$destroy(), add = TRUE)
 
   tr_fired <- 0
   tr_monitor <- observeEvent(tr(), {
     tr_fired <<- tr_fired + 1
-    message(the_time(), "throttled ", tr(), " (fired: ", tr_fired, ")")
   })
   on.exit(tr_monitor$destroy(), add = TRUE)
 
@@ -1280,28 +1277,12 @@ test_that("debounce/throttle work properly (with priming)", {
   }
 
   # Pump timer and reactives for about 1.3 seconds
-  start_time <- Sys.time()
-  the_time <- local({
-    last <- start_time
-    function() {
-      now <- Sys.time()
-      diff <- round(as.numeric(now - last, "secs") * 1000)
-      last <<- now
-      sprintf(
-        "%0.3f (%03d) ",
-        Sys.time() - start_time,
-        diff
-      )
-    }
-  })
-  message(the_time(), "==== start [run for 1.3s]")
-  stopAt <- start_time + 1.3
+  stopAt <- Sys.time() + 1.3
   while (Sys.time() < stopAt) {
     timerCallbacks$executeElapsed()
     flushReact()
     Sys.sleep(0.001)
   }
-  message(the_time(), "==== end [run for 1.3s]")
 
   # dr() should not have had time to fire, other than the initial run, since
   # there haven't been long enough gaps between invalidations.
@@ -1316,13 +1297,11 @@ test_that("debounce/throttle work properly (with priming)", {
   # Now let some time pass without any more updates.
   src$destroy() # No more updates
   stopAt <- Sys.time() + 1
-  message(the_time(), "==== start [settle for 1s]")
   while (Sys.time() < stopAt) {
     timerCallbacks$executeElapsed()
     flushReact()
     Sys.sleep(0.001)
   }
-  message(the_time(), "==== end [settle for 1s]")
 
   # dr should've fired, and we should have converged on the right answer.
   expect_identical(dr_fired, 2)

--- a/tests/testthat/test-reactivity.r
+++ b/tests/testthat/test-reactivity.r
@@ -1232,162 +1232,85 @@ test_that("event handling helpers take correct dependencies", {
 })
 
 
-test_that("debounce/throttle work properly (with priming)", {
-  do_priming <- TRUE
-  # Some of the CRAN test machines are heavily loaded and so the timing for
-  # these tests isn't reliable. https://github.com/rstudio/shiny/pull/2789
-  skip_on_cran()
+for (do_priming in c(TRUE, FALSE)) {
+  label <- if (do_priming) "with priming" else "without priming"
+  test_that(sprintf("debounce/throttle work properly (%s)", label), {
+    # Some of the CRAN test machines are heavily loaded and so the timing for
+    # these tests isn't reliable. https://github.com/rstudio/shiny/pull/2789
+    skip_on_cran()
 
-  # The changing of rv$a will be the (chatty) source of reactivity.
-  rv <- reactiveValues(a = 0)
+    # The changing of rv$a will be the (chatty) source of reactivity.
+    rv <- reactiveValues(a = 0)
 
-  # This observer will be what changes rv$a.
-  src <- observe({
-    invalidateLater(300)
-    rv$a <- isolate(rv$a) + 1
-  })
-  on.exit(src$destroy(), add = TRUE)
+    # This observer will be what changes rv$a.
+    src <- observe({
+      invalidateLater(300)
+      rv$a <- isolate(rv$a) + 1
+    })
+    on.exit(src$destroy(), add = TRUE)
 
-  # Make a debounced reactive to test.
-  dr <- debounce(reactive(rv$a), 500)
+    # Make a debounced reactive to test.
+    dr <- debounce(reactive(rv$a), 500)
 
-  # Make a throttled reactive to test.
-  tr <- throttle(reactive(rv$a), 500)
+    # Make a throttled reactive to test.
+    tr <- throttle(reactive(rv$a), 500)
 
-  # Keep track of how often dr/tr are fired
-  dr_fired <- 0
-  dr_monitor <- observeEvent(dr(), {
-    dr_fired <<- dr_fired + 1
-  })
-  on.exit(dr_monitor$destroy(), add = TRUE)
+    # Keep track of how often dr/tr are fired
+    dr_fired <- 0
+    dr_monitor <- observeEvent(dr(), {
+      dr_fired <<- dr_fired + 1
+    })
+    on.exit(dr_monitor$destroy(), add = TRUE)
 
-  tr_fired <- 0
-  tr_monitor <- observeEvent(tr(), {
-    tr_fired <<- tr_fired + 1
-  })
-  on.exit(tr_monitor$destroy(), add = TRUE)
+    tr_fired <- 0
+    tr_monitor <- observeEvent(tr(), {
+      tr_fired <<- tr_fired + 1
+    })
+    on.exit(tr_monitor$destroy(), add = TRUE)
 
-  # Starting values are both 0. Earlier I found that the tests behaved
-  # differently if I accessed the values of dr/tr before the first call to
-  # flushReact(). That bug was fixed, but to ensure that similar bugs don't
-  # appear undetected, we run this test with and without do_priming.
-  if (do_priming) {
+    # Starting values are both 0. Earlier I found that the tests behaved
+    # differently if I accessed the values of dr/tr before the first call to
+    # flushReact(). That bug was fixed, but to ensure that similar bugs don't
+    # appear undetected, we run this test with and without do_priming.
+    if (do_priming) {
+      expect_identical(isolate(dr()), 0)
+      expect_identical(isolate(tr()), 0)
+    }
+
+    # Pump timer and reactives for about 1.3 seconds
+    stopAt <- Sys.time() + 1.3
+    while (Sys.time() < stopAt) {
+      timerCallbacks$executeElapsed()
+      flushReact()
+      Sys.sleep(0.001)
+    }
+
+    # dr() should not have had time to fire, other than the initial run, since
+    # there haven't been long enough gaps between invalidations.
+    expect_identical(dr_fired, 1)
+    # The value of dr() should not have updated either.
     expect_identical(isolate(dr()), 0)
-    expect_identical(isolate(tr()), 0)
-  }
 
-  # Pump timer and reactives for about 1.3 seconds
-  stopAt <- Sys.time() + 1.3
-  while (Sys.time() < stopAt) {
-    timerCallbacks$executeElapsed()
-    flushReact()
-    Sys.sleep(0.001)
-  }
+    # tr() however, has had time to fire multiple times and update its value.
+    expect_identical(tr_fired, 3)
+    expect_identical(isolate(tr()), 4)
 
-  # dr() should not have had time to fire, other than the initial run, since
-  # there haven't been long enough gaps between invalidations.
-  expect_identical(dr_fired, 1)
-  # The value of dr() should not have updated either.
-  expect_identical(isolate(dr()), 0)
+    # Now let some time pass without any more updates.
+    src$destroy() # No more updates
+    stopAt <- Sys.time() + 1
+    while (Sys.time() < stopAt) {
+      timerCallbacks$executeElapsed()
+      flushReact()
+      Sys.sleep(0.001)
+    }
 
-  # tr() however, has had time to fire multiple times and update its value.
-  expect_identical(tr_fired, 3)
-  expect_identical(isolate(tr()), 4)
-
-  # Now let some time pass without any more updates.
-  src$destroy() # No more updates
-  stopAt <- Sys.time() + 1
-  while (Sys.time() < stopAt) {
-    timerCallbacks$executeElapsed()
-    flushReact()
-    Sys.sleep(0.001)
-  }
-
-  # dr should've fired, and we should have converged on the right answer.
-  expect_identical(dr_fired, 2)
-  isolate(expect_identical(rv$a, dr()))
-  expect_identical(tr_fired, 4)
-  isolate(expect_identical(rv$a, tr()))
-})
-
-# Identical to test block above, but with do_priming set to FALSE.
-test_that("debounce/throttle work properly (without priming)", {
-  do_priming <- FALSE
-  # Some of the CRAN test machines are heavily loaded and so the timing for
-  # these tests isn't reliable. https://github.com/rstudio/shiny/pull/2789
-  skip_on_cran()
-
-  # The changing of rv$a will be the (chatty) source of reactivity.
-  rv <- reactiveValues(a = 0)
-
-  # This observer will be what changes rv$a.
-  src <- observe({
-    invalidateLater(300)
-    rv$a <- isolate(rv$a) + 1
+    # dr should've fired, and we should have converged on the right answer.
+    expect_identical(dr_fired, 2)
+    isolate(expect_identical(rv$a, dr()))
+    expect_identical(tr_fired, 4)
+    isolate(expect_identical(rv$a, tr()))
   })
-  on.exit(src$destroy(), add = TRUE)
-
-  # Make a debounced reactive to test.
-  dr <- debounce(reactive(rv$a), 500)
-
-  # Make a throttled reactive to test.
-  tr <- throttle(reactive(rv$a), 500)
-
-  # Keep track of how often dr/tr are fired
-  dr_fired <- 0
-  dr_monitor <- observeEvent(dr(), {
-    dr_fired <<- dr_fired + 1
-  })
-  on.exit(dr_monitor$destroy(), add = TRUE)
-
-  tr_fired <- 0
-  tr_monitor <- observeEvent(tr(), {
-    tr_fired <<- tr_fired + 1
-  })
-  on.exit(tr_monitor$destroy(), add = TRUE)
-
-  # Starting values are both 0. Earlier I found that the tests behaved
-  # differently if I accessed the values of dr/tr before the first call to
-  # flushReact(). That bug was fixed, but to ensure that similar bugs don't
-  # appear undetected, we run this test with and without do_priming.
-  if (do_priming) {
-    expect_identical(isolate(dr()), 0)
-    expect_identical(isolate(tr()), 0)
-  }
-
-  # Pump timer and reactives for about 1.3 seconds
-  stopAt <- Sys.time() + 1.3
-  while (Sys.time() < stopAt) {
-    timerCallbacks$executeElapsed()
-    flushReact()
-    Sys.sleep(0.001)
-  }
-
-  # dr() should not have had time to fire, other than the initial run, since
-  # there haven't been long enough gaps between invalidations.
-  expect_identical(dr_fired, 1)
-  # The value of dr() should not have updated either.
-  expect_identical(isolate(dr()), 0)
-
-  # tr() however, has had time to fire multiple times and update its value.
-  expect_identical(tr_fired, 3)
-  expect_identical(isolate(tr()), 4)
-
-  # Now let some time pass without any more updates.
-  src$destroy() # No more updates
-  stopAt <- Sys.time() + 1
-  while (Sys.time() < stopAt) {
-    timerCallbacks$executeElapsed()
-    flushReact()
-    Sys.sleep(0.001)
-  }
-
-  # dr should've fired, and we should have converged on the right answer.
-  expect_identical(dr_fired, 2)
-  isolate(expect_identical(rv$a, dr()))
-  expect_identical(tr_fired, 4)
-  isolate(expect_identical(rv$a, tr()))
-})
+}
 
 test_that("reactive domain works across async handlers", {
   obj <- new.env()

--- a/tests/testthat/test-reactivity.r
+++ b/tests/testthat/test-reactivity.r
@@ -1322,7 +1322,7 @@ test_that("debounce/throttle work properly (without priming)", {
 
   # This observer will be what changes rv$a.
   src <- observe({
-    invalidateLater(100)
+    invalidateLater(300)
     rv$a <- isolate(rv$a) + 1
   })
   on.exit(src$destroy(), add = TRUE)
@@ -1371,7 +1371,7 @@ test_that("debounce/throttle work properly (without priming)", {
 
   # tr() however, has had time to fire multiple times and update its value.
   expect_identical(tr_fired, 3)
-  expect_identical(isolate(tr()), 10)
+  expect_identical(isolate(tr()), 4)
 
   # Now let some time pass without any more updates.
   src$destroy() # No more updates


### PR DESCRIPTION
Fixes #4133 
Closes #4132 

I think @dvg-p4 was on the right track in #4132 (thanks @dvg-p4!). The flaky test currently uses a input that is invalidated every 100ms and then debounces and throttles the updated input at 500ms intervals. I think the race condition results from both an input update and a throttle event being scheduled to coincide every 500ms.

| Time (ms) | Input | Throttled | Debounced |
|--------|--------|--------|--------|
| 0 | 1 | 1 | 0 |
| 100 | 2 | | |
| 200 | 3 | | |
| 300 | 4 | | |
| 400 | 5 | | |
| 500 | 6 | 5 | |
| 600 | 7 | | |
| 700 | 8 | | |
| 800 | 9 | | |
| 900 | 10 | | |
| 1000 | 11 | 10 | |
| ... | | | |
| 1299 | 13 | | | 
| 1500 | 13 | 13 | 13

This PR increases the time between input updates to happen every 300ms. This ensures that we're testing the same behavior, but each event now happens at a discrete time point not shared by any other event.

| Time (ms) | Input | Throttled | Debounced |
|--------|--------|--------|--------|
| 0 | 1 | 1 | 0 |
| 300 | 2 | | |
| 500 | | 2 | |
| 600 | 3 | | |
| 900 | 4 | | |
| 1000 | | 4 | |
| 1200 | 5 | | |
| ... | no more updates | | |
| 1500 | | 5 | |
| 1700 | | | 5 |

---

Also, while here, this test was duplicated with `do_priming <- TRUE` and `do_priming <- FALSE`. I usually prefer repetition over abstraction in unit tests, but this particular test doesn't fit on a single screen (it's about 80 lines long), which made it a lot harder to update this test.

I modified the test to run inside a for loop over `do_priming in c(TRUE, FALSE)`, which makes it much clearer that the two test scenarios are _exactly identical_ other than the value of `do_priming`.