### PR TITLE
docs(NEWS): Fix name of `sliderInput()` function

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 
 * Fixed a bug in `conditionalPanel()` that would cause the panel to repeatedly show/hide itself when the provided condition was not boolean. (@kamilzyla, #4127)
 
-* Fixed a bug with `input_slider()` when used as a range slider that made it impossible to change the slider value when both handles were at the maximum value. (#4131)
+* Fixed a bug with `sliderInput()` when used as a range slider that made it impossible to change the slider value when both handles were at the maximum value. (#4131)
 
 # shiny 1.9.1
 


### PR DESCRIPTION
🫣 I wrote `input_slider()` but meant `sliderInput()`