### PR TITLE
Set `typescript.tsdk` so VSCode's TS language features work properly

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,5 +20,6 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "files.trimTrailingWhitespace": true,
     "files.insertFinalNewline": true,
-},
+  },
+  "typescript.tsdk": "./node_modules/typescript/lib",
 }


### PR DESCRIPTION
EDIT: The real solution to the problem I was having was simply to configure the TypeScript version used, via VSCode UI. Hit the braces on the bottom right:

![image](https://github.com/user-attachments/assets/87aee5fe-633d-4b1c-8d59-d38f3206833b)

Then "Select Version":

![image](https://github.com/user-attachments/assets/33d55bfd-8880-4e91-ab0c-235af8431e46)

Then "Use Workspace Version".

------

This prevents spurious linting warnings, and makes type detection work properly with the complex constructions used in [some places](https://github.com/rstudio/shiny/blob/abf71389becd29f7999765da93e5aee152b271f7/srcts/src/utils/object.ts#L17-L27).