### PR TITLE
chore: Remove zipfs from recommended vscode extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,5 @@
 {
   "recommendations": [
-    "arcanis.vscode-zipfs",
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode"
   ]


### PR DESCRIPTION
Removes [zipfs](https://marketplace.visualstudio.com/items?itemName=arcanis.vscode-zipfs) from the recommended extensions. @schloerke indicated this is related to editing zip files in the yarn cache. I haven't needed the extensions in the last 2 years. It seems niche enough that it could be installed individually by someone who needs it but it doesn't need to be recommended for daily dev work.

I'd be happy to leave a note about the extension in a dev README if there's a good place for this.