### PR TITLE
docs(runExample): `display.mode` follows DESCRIPTION

### DIFF
--- a/R/runapp.R
+++ b/R/runapp.R
@@ -445,7 +445,9 @@ stopApp <- function(returnValue = invisible()) {
 #' @param host The IPv4 address that the application should listen on. Defaults
 #'   to the `shiny.host` option, if set, or `"127.0.0.1"` if not.
 #' @param display.mode The mode in which to display the example. Defaults to
-#'   `showcase`, but may be set to `normal` to see the example without
+#'   `"auto"`, which uses the value of `DisplayMode` in the example's
+#'   `DESCRIPTION` file. Set to `"showcase"` to show the app code and
+#'   description with the running app, or `"normal"` to see the example without
 #'   code or commentary.
 #' @param package The package in which to find the example (defaults to
 #'   `"shiny"`).

--- a/man/runExample.Rd
+++ b/man/runExample.Rd
@@ -33,7 +33,9 @@ interactive sessions only.}
 to the \code{shiny.host} option, if set, or \code{"127.0.0.1"} if not.}
 
 \item{display.mode}{The mode in which to display the example. Defaults to
-\code{showcase}, but may be set to \code{normal} to see the example without
+\code{"auto"}, which uses the value of \code{DisplayMode} in the example's
+\code{DESCRIPTION} file. Set to \code{"showcase"} to show the app code and
+description with the running app, or \code{"normal"} to see the example without
 code or commentary.}
 
 \item{package}{The package in which to find the example (defaults to


### PR DESCRIPTION
Fixes #4077

The argument documentation hadn't been updated to reflect that `runExample()` can run more than just Shiny's examples.