### PR TITLE
Fix observeEvent stack trace stripping

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,8 @@
 
 * Updating the choices of a `selectizeInput()` via `updateSelectizeInput()` with `server = TRUE` no longer retains the selected choice as a deselected option if the current value is not part of the new choices. (@dvg-p4 #4142)
 
+* Fixed a bug where stack traces from `observeEvent` were being stripped of stack frames too aggressively.
+
 # shiny 1.9.1
 
 ## Bug fixes

--- a/R/reactives.R
+++ b/R/reactives.R
@@ -2304,7 +2304,7 @@ observeEvent <- function(eventExpr, handlerExpr,
     priority = priority,
     domain = domain,
     autoDestroy = TRUE,
-    ..stacktraceon = FALSE # TODO: Does this go in the bindEvent?
+    ..stacktraceon = TRUE
   ))
 
   o <- inject(bindEvent(

--- a/tests/testthat/test-stacks.R
+++ b/tests/testthat/test-stacks.R
@@ -206,6 +206,26 @@ test_that("validation error logging", {
   captureErrorLog(validate("boom"))
   expect_null(caught)
 
+  caught <- NULL
   captureErrorLog(stop("boom"))
   expect_true(!is.null(caught))
+})
+
+test_that("observeEvent is not overly stripped (#4162)", {
+  caught <- NULL
+  ..stacktraceoff..(
+    ..stacktracefloor..({
+      observeEvent(1, {
+        tryCatch(
+          captureStackTraces(stop("boom")),
+          error = function(cond) {
+            caught <<- cond
+          }
+        )
+      })
+      flushReact()
+    })
+  )
+  st_str <- capture.output(printStackTrace(caught), type = "message")
+  expect_true(any(grepl("observeEvent\\(1\\)", st_str)))
 })


### PR DESCRIPTION
Fixes #4162.

- [x] Unit test

## Explanation

Reactive objects have a lot of machinery that we generally want to hide, so they call `..stacktraceoff..` before they begin executing and `..stacktraceon..` right before they call user-provided code.

In the specific case of `observeEvent`, the inner `observe()` call had an explicit `..stacktraceon = FALSE`. Once upon a time this was correct, as a [line slightly preceding it](https://github.com/rstudio/shiny/blob/b25d72f6987fb93124c75e23a27007755c4d6efa/R/reactives.R#L2259) took care of turning the stack trace back on. But during the introduction of `bindEvent`, that previous line went away.