### PR TITLE
feat: Fully reload ui/server when autoreload occurs

### DIFF
--- a/R/shinyapp.R
+++ b/R/shinyapp.R
@@ -290,8 +290,10 @@ initAutoReloadMonitor <- function(dir) {
     return(function(){})
   }
 
-  filePattern <- getOption("shiny.autoreload.pattern",
-    ".*\\.(r|html?|js|css|png|jpe?g|gif)$")
+  filePattern <- getOption(
+    "shiny.autoreload.pattern",
+    ".*\\.(r|html?|js|css|png|jpe?g|gif)$"
+  )
 
   lastValue <- NULL
   observeLabel <- paste0("File Auto-Reload - '", basename(dir), "'")
@@ -302,6 +304,7 @@ initAutoReloadMonitor <- function(dir) {
     times <- file.info(files)$mtime
     names(times) <- files
 
+    
     if (is.null(lastValue)) {
       # First run
       lastValue <<- times
@@ -309,6 +312,7 @@ initAutoReloadMonitor <- function(dir) {
       # We've changed!
       lastValue <<- times
       autoReloadCallbacks$invoke()
+      cachedAutoReloadLastChanged(max(0, max(times, na.rm = TRUE)))
     }
 
     invalidateLater(getOption("shiny.autoreload.interval", 500))


### PR DESCRIPTION
This PR updates the auto reload to fully reload both the UI and server source code when any change is detected in the watched autoreload files.

Previously, auto reload would trigger a refresh of the app but the UI or server functions would be updated only if the `ui.R` or `server.R` files themselves changed (or both if using a single-file app source).

This PR updates auto reloading so that any change to the files matching `shiny.autoreload.pattern` causes _both_ the UI and server source to be reloaded.

This fixes two long-standing open issues:

Fixes #2711 
Fixes #1142

## Example app

For testing, the following app sources R files and uses stylesheets outside the main `app.R`. Currently, in `main`, any changes to the supporting files causes the app to be reloaded but the reloaded app does not reflect the changes.

After this PR, changes to support files are reflected after the reload.

[Example app on shinylive](https://shinylive.io/r/editor/#h=0&code=NobwRAdghgtgpmAXGKAHVA6ASmANGAYwHsIAXOMpMAGwEsAjAJykYE8AKAZwAtaJWAlAB0IdJiw71OY4RBGciAV0YE47IWE60AJnHotsG2SMW0ABAB4AtGdRQA5nAD6W3fsbqIZs6VqlqcGYAvGYaACpwnKRmAILoGrgi3q56LMFmnPSJXmZ8BNSKugDCAMol6pqkrAGcGAScnEbZ3gQs2p7eLW1O3HBQuh4aJa2k5IxmAArURKRNSZ2o06QA8oqkqGsVizNG87LGEJxwjABux5Y2AGaKEAS+JOx8G6S4ZkrrawJmIPMKyqpbJaGMAHbzvZ4AEm20WsZkYFAGUxm7BgrCc0MeEGeAlkAF8RPJePw4qh2KZXkdTsdZGBcbhwNB4FRodg8IQSORKMhUeilhczNdbvcIJjsd95hj5t5GBAiIwYKK1hCIAJmp0ZXKFU8lSq1S0iNR0trSBDiNNGHrbARuOkAIwANilZgAxGZVAAPI1YpVaABegVdAElbvCoEcfL0MrR-W9LhHAqgiHxSI0cniRLT6ZBYAhkCl3Kz8MQyBRSFRMvz8ywOmYIIp4IxaARg88KnI8KEwAA5ev0c5EOOJ5ONDsAVgADKrfnAAncW5sNGa5QlO0UDcuO9ak6pOOkCBV4doVxp6AU4MewPZ4RQjFOctIdMd56QKn7zx2htH368YHw7T+oE9EIACYABZXhOKAzztScRBpOkGRzcsqhqOoGjZYtOTLZAMCkMQrDsRwrCrcYAD4zAwaATncbJcIfegCIcOArF8fxAh+HJ9XNRBbCguB7ANXQIEYIhtAAbidfQCAAayvJQIG0Kwl0YHi+G0WgBIkiBcVpABdIA).