### PR TITLE
feat: Use {watcher} for autoreload file watching

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -93,7 +93,8 @@ Imports:
     glue (>= 1.3.2),
     bslib (>= 0.6.0),
     cachem (>= 1.1.0),
-    lifecycle (>= 0.2.0)
+    lifecycle (>= 0.2.0),
+    watcher (>= 0.0.1.9000)
 Suggests:
     coro (>= 1.1.0),
     datasets,
@@ -213,3 +214,5 @@ Roxygen: list(markdown = TRUE)
 Config/testthat/edition: 3
 Config/Needs/check:
   shinytest2
+Remotes:  
+    shikokuchuo/watcher

--- a/R/shinyapp.R
+++ b/R/shinyapp.R
@@ -71,8 +71,14 @@
 #'   runApp(app)
 #' }
 #' @export
-shinyApp <- function(ui, server, onStart=NULL, options=list(),
-                     uiPattern="/", enableBookmarking=NULL) {
+shinyApp <- function(
+  ui,
+  server,
+  onStart = NULL,
+  options = list(),
+  uiPattern = "/",
+  enableBookmarking = NULL
+) {
   if (!is.function(server)) {
     stop("`server` must be a function", call. = FALSE)
   }
@@ -111,7 +117,7 @@ shinyApp <- function(ui, server, onStart=NULL, options=list(),
 #' @param appDir Path to directory that contains a Shiny app (i.e. a server.R
 #'   file and either ui.R or www/index.html)
 #' @export
-shinyAppDir <- function(appDir, options=list()) {
+shinyAppDir <- function(appDir, options = list()) {
   if (!utils::file_test('-d', appDir)) {
     rlang::abort(
       paste0("No Shiny application exists at the path \"", appDir, "\""),
@@ -138,7 +144,7 @@ shinyAppDir <- function(appDir, options=list()) {
 #' @rdname shinyApp
 #' @param appFile Path to a .R file containing a Shiny application
 #' @export
-shinyAppFile <- function(appFile, options=list()) {
+shinyAppFile <- function(appFile, options = list()) {
   appFile <- normalizePath(appFile, mustWork = TRUE)
   appDir <- dirname(appFile)
 
@@ -148,7 +154,7 @@ shinyAppFile <- function(appFile, options=list()) {
 # This reads in an app dir in the case that there's a server.R (and ui.R/www)
 # present, and returns a shiny.appobj.
 # appDir must be a normalized (absolute) path, not a relative one
-shinyAppDir_serverR <- function(appDir, options=list()) {
+shinyAppDir_serverR <- function(appDir, options = list()) {
   # Most of the complexity here comes from needing to hot-reload if the .R files
   # change on disk, or are created, or are removed.
 
@@ -165,7 +171,10 @@ shinyAppDir_serverR <- function(appDir, options=list()) {
   # uiHandlerSource is a function that returns an HTTP handler for serving up
   # ui.R as a webpage. The "cachedFuncWithFile" call makes sure that the closure
   # we're creating here only gets executed when ui.R's contents change.
-  uiHandlerSource <- cachedFuncWithFile(appDir, "ui.R", case.sensitive = FALSE,
+  uiHandlerSource <- cachedFuncWithFile(
+    appDir,
+    "ui.R",
+    case.sensitive = FALSE,
     function(uiR) {
       if (file.exists(uiR)) {
         # If ui.R contains a call to shinyUI (which sets .globals$ui), use that.
@@ -188,14 +197,19 @@ shinyAppDir_serverR <- function(appDir, options=list()) {
 
   wwwDir <- file.path.ci(appDir, "www")
   if (dirExists(wwwDir)) {
-    staticPaths <- list("/" = staticPath(wwwDir, indexhtml = FALSE, fallthrough = TRUE))
+    staticPaths <- list(
+      "/" = staticPath(wwwDir, indexhtml = FALSE, fallthrough = TRUE)
+    )
   } else {
     staticPaths <- list()
   }
 
   fallbackWWWDir <- system_file("www-dir", package = "shiny")
 
-  serverSource <- cachedFuncWithFile(appDir, "server.R", case.sensitive = FALSE,
+  serverSource <- cachedFuncWithFile(
+    appDir,
+    "server.R",
+    case.sensitive = FALSE,
     function(serverR) {
       # If server.R contains a call to shinyServer (which sets .globals$server),
       # use that. If not, then take the last expression that's returned from
@@ -220,8 +234,10 @@ shinyAppDir_serverR <- function(appDir, options=list()) {
       # This is what we normally expect; run the server function
       return(serverFunction)
     } else {
-      stop("server.R returned an object of unexpected type: ",
-        typeof(serverFunction))
+      stop(
+        "server.R returned an object of unexpected type: ",
+        typeof(serverFunction)
+      )
     }
   }
 
@@ -234,8 +250,8 @@ shinyAppDir_serverR <- function(appDir, options=list()) {
     setwd(appDir)
     # TODO: we should support hot reloading on global.R and R/*.R changes.
     if (getOption("shiny.autoload.r", TRUE)) {
-      loadSupport(appDir, renv=sharedEnv, globalrenv=globalenv())
-    }  else {
+      loadSupport(appDir, renv = sharedEnv, globalrenv = globalenv())
+    } else {
       if (file.exists(file.path.ci(appDir, "global.R")))
         sourceUTF8(file.path.ci(appDir, "global.R"))
     }
@@ -287,40 +303,54 @@ shinyAppDir_serverR <- function(appDir, options=list()) {
 # The return value is a function that halts monitoring when called.
 initAutoReloadMonitor <- function(dir) {
   if (!get_devmode_option("shiny.autoreload", FALSE)) {
-    return(function(){})
+    return(function() {
+    })
   }
 
   filePattern <- getOption(
     "shiny.autoreload.pattern",
     ".*\\.(r|html?|js|css|png|jpe?g|gif)$"
   )
+  filePattern <- getOption(
+    "shiny.autoreload.pattern",
+    ".*\\.(r|html?|js|css|png|jpe?g|gif)$"
+  )
 
   lastValue <- NULL
-  observeLabel <- paste0("File Auto-Reload - '", basename(dir), "'")
-  obs <- observe(label = observeLabel, {
+  check_file_times <- function() {
     files <- sort_c(
-      list.files(dir, pattern = filePattern, recursive = TRUE, ignore.case = TRUE)
+      list.files(
+        dir,
+        pattern = filePattern,
+        recursive = TRUE,
+        ignore.case = TRUE
+      )
     )
+
+    # We still have to check file times to know that files we care about have changed
     times <- file.info(files)$mtime
     names(times) <- files
 
-    
     if (is.null(lastValue)) {
-      # First run
       lastValue <<- times
-    } else if (!identical(lastValue, times)) {
-      # We've changed!
-      lastValue <<- times
-      autoReloadCallbacks$invoke()
-      cachedAutoReloadLastChanged(max(0, max(times, na.rm = TRUE)))
+      return()
     }
 
-    invalidateLater(getOption("shiny.autoreload.interval", 500))
-  })
+    if (identical(lastValue, times)) {
+      return()
+    }
 
-  onStop(obs$destroy)
+    autoReloadCallbacks$invoke()
+    cachedAutoReloadLastChanged(max(0, max(times, na.rm = TRUE)))
+  }
 
-  obs$destroy
+  watcher <- watcher::watcher(dir, check_file_times, latency = 0.25)
+
+  check_file_times()
+  watcher$start()
+  onStop(watcher$stop)
+
+  watcher
 }
 
 #' Load an app's supporting R files
@@ -348,34 +378,47 @@ initAutoReloadMonitor <- function(dir) {
 #' @param globalrenv The environment in which `global.R` should be evaluated. If
 #'   `NULL`, `global.R` will not be evaluated at all.
 #' @export
-loadSupport <- function(appDir=NULL, renv=new.env(parent=globalenv()), globalrenv=globalenv()){
+loadSupport <- function(
+  appDir = NULL,
+  renv = new.env(parent = globalenv()),
+  globalrenv = globalenv()
+) {
   require(shiny)
 
   if (is.null(appDir)) {
     appDir <- findEnclosingApp(".")
   }
 
-  if (!is.null(globalrenv)){
+  if (!is.null(globalrenv)) {
     # Evaluate global.R, if it exists.
     globalPath <- file.path.ci(appDir, "global.R")
-    if (file.exists(globalPath)){
+    if (file.exists(globalPath)) {
       withr::with_dir(appDir, {
-        sourceUTF8(basename(globalPath), envir=globalrenv)
+        sourceUTF8(basename(globalPath), envir = globalrenv)
       })
     }
   }
 
-
   helpersDir <- file.path(appDir, "R")
 
-  disabled <- list.files(helpersDir, pattern="^_disable_autoload\\.r$", recursive=FALSE, ignore.case=TRUE)
+  disabled <- list.files(
+    helpersDir,
+    pattern = "^_disable_autoload\\.r$",
+    recursive = FALSE,
+    ignore.case = TRUE
+  )
   if (length(disabled) > 0) {
     return(invisible(renv))
   }
 
   warn_if_app_dir_is_package(appDir)
 
-  helpers <- list.files(helpersDir, pattern="\\.[rR]$", recursive=FALSE, full.names=TRUE)
+  helpers <- list.files(
+    helpersDir,
+    pattern = "\\.[rR]$",
+    recursive = FALSE,
+    full.names = TRUE
+  )
   # Ensure files in R/ are sorted according to the 'C' locale before sourcing.
   # This convention is based on the default for packages. For details, see:
   # https://cran.r-project.org/doc/manuals/r-release/R-exts.html#The-DESCRIPTION-file
@@ -383,7 +426,7 @@ loadSupport <- function(appDir=NULL, renv=new.env(parent=globalenv()), globalren
   helpers <- normalizePath(helpers)
 
   withr::with_dir(appDir, {
-    lapply(helpers, sourceUTF8, envir=renv)
+    lapply(helpers, sourceUTF8, envir = renv)
   })
 
   invisible(renv)
@@ -398,7 +441,7 @@ warn_if_app_dir_is_package <- function(appDir) {
 
     has_desc_pkg <-
       file.exists(descFile) &&
-      identical(as.character(read.dcf(descFile, fields = "Type")), "Package")
+        identical(as.character(read.dcf(descFile, fields = "Type")), "Package")
   }
 
   if (has_namespace || has_desc_pkg) {
@@ -413,14 +456,16 @@ warn_if_app_dir_is_package <- function(appDir) {
 # This reads in an app dir for a single-file application (e.g. app.R), and
 # returns a shiny.appobj.
 # appDir must be a normalized (absolute) path, not a relative one
-shinyAppDir_appR <- function(fileName, appDir, options=list())
-{
+shinyAppDir_appR <- function(fileName, appDir, options = list()) {
   fullpath <- file.path.ci(appDir, fileName)
 
   # This sources app.R and caches the content. When appObj() is called but
   # app.R hasn't changed, it won't re-source the file. But if called and
   # app.R has changed, it'll re-source the file and return the result.
-  appObj <- cachedFuncWithFile(appDir, fileName, case.sensitive = FALSE,
+  appObj <- cachedFuncWithFile(
+    appDir,
+    fileName,
+    case.sensitive = FALSE,
     function(appR) {
       wasDir <- setwd(appDir)
       on.exit(setwd(wasDir))
@@ -431,7 +476,7 @@ shinyAppDir_appR <- function(fileName, appDir, options=list())
         # Create a child env which contains all the helpers and will be the shared parent
         # of the ui.R and server.R load.
         sharedEnv <- new.env(parent = globalenv())
-        loadSupport(appDir, renv=sharedEnv, globalrenv=NULL)
+        loadSupport(appDir, renv = sharedEnv, globalrenv = NULL)
       } else {
         sharedEnv <- globalenv()
       }
@@ -466,7 +511,9 @@ shinyAppDir_appR <- function(fileName, appDir, options=list())
     #
     # The call to staticPath normalizes the path, so that if the working dir
     # later changes, it will continue to point to the right place.
-    staticPaths <- list("/" = staticPath(wwwDir, indexhtml = FALSE, fallthrough = TRUE))
+    staticPaths <- list(
+      "/" = staticPath(wwwDir, indexhtml = FALSE, fallthrough = TRUE)
+    )
   } else {
     staticPaths <- list()
   }
@@ -519,7 +566,6 @@ shinyAppDir_appR <- function(fileName, appDir, options=list())
   )
 }
 
-
 #' Shiny App object
 #'
 #' Internal methods for the `shiny.appobj` S3 class.
@@ -550,9 +596,7 @@ as.shiny.appobj.list <- function(x) {
 #' @rdname shiny.appobj
 #' @export
 as.shiny.appobj.character <- function(x) {
-  if (identical(tolower(tools::file_ext(x)), "r"))
-    shinyAppFile(x)
-  else
+  if (identical(tolower(tools::file_ext(x)), "r")) shinyAppFile(x) else
     shinyAppDir(x)
 }
 
@@ -606,8 +650,10 @@ as.tags.shiny.appobj <- function(x, ...) {
 # and let the client load them when convenient. (See the initIframes function in
 # init_shiny.js.)
 deferredIFrame <- function(path, width, height) {
-  tags$iframe("data-deferred-src" = path,
-    width = width, height = height,
+  tags$iframe(
+    "data-deferred-src" = path,
+    width = width,
+    height = height,
     class = "shiny-frame shiny-frame-deferred"
   )
 }


### PR DESCRIPTION
Replaces the current `observe()` + `invalidateLater()` approach to file polling for autoreload changes with [watcher](https://github.com/shikokuchuo/watcher), based on libfswatch.

This change lets us avoid file system polling; instead we're notified directly by watcher when files change.

Note: this PR uses `pak::pak("shikokuchuo/watcher@dev")` for shikokuchuo/watcher#3