### PR TITLE
docs: Link to `outputOptions()` from render functions

### DIFF
--- a/R/shinywrappers.R
+++ b/R/shinywrappers.R
@@ -383,8 +383,10 @@ markOutputAttrs <- function(renderFunc, snapshotExclude = NULL,
 #' The corresponding HTML output tag should be `div` or `img` and have
 #' the CSS class name `shiny-image-output`.
 #'
-#' @seealso For more details on how the images are generated, and how to control
+#' @seealso 
+#' * For more details on how the images are generated, and how to control
 #'   the output, see [plotPNG()].
+#' * Use [outputOptions()] to set general output options for an image output.
 #'
 #' @param expr An expression that returns a list.
 #' @inheritParams renderUI
@@ -598,6 +600,7 @@ isTemp <- function(path, tempDir = tempdir(), mustExist) {
 #'   used in an interactive RMarkdown document.
 #'
 #' @example res/text-example.R
+#' @seealso [outputOptions()]
 #' @export
 renderPrint <- function(expr, env = parent.frame(), quoted = FALSE,
                         width = getOption('width'), outputArgs=list())
@@ -719,7 +722,7 @@ renderText <- function(expr, env = parent.frame(), quoted = FALSE,
 #'   call to [uiOutput()] when `renderUI` is used in an
 #'   interactive R Markdown document.
 #'
-#' @seealso [uiOutput()]
+#' @seealso [uiOutput()], [outputOptions()]
 #' @export
 #' @examples
 #' ## Only run examples in interactive R sessions

--- a/R/shinywrappers.R
+++ b/R/shinywrappers.R
@@ -809,6 +809,13 @@ renderUI <- function(expr, env = parent.frame(), quoted = FALSE,
 #'
 #' shinyApp(ui, server)
 #' }
+#'
+#' @seealso
+#' * The download handler, like other outputs, is suspended (disabled) by
+#'   default for download buttons and links that are hidden. Use 
+#'   [outputOptions()] to control this behavior, e.g. to set 
+#'   `suspendWhenHidden = FALSE` if the download is initiated by 
+#'   programmatically clicking on the download button using JavaScript.
 #' @export
 downloadHandler <- function(filename, content, contentType=NULL, outputArgs=list()) {
   renderFunc <- function(shinysession, name, ...) {

--- a/man/downloadHandler.Rd
+++ b/man/downloadHandler.Rd
@@ -60,4 +60,14 @@ server <- function(input, output) {
 
 shinyApp(ui, server)
 }
+
+}
+\seealso{
+\itemize{
+\item The download handler, like other outputs, is suspended (disabled) by
+default for download buttons and links that are hidden. Use
+\code{\link[=outputOptions]{outputOptions()}} to control this behavior, e.g. to set
+\code{suspendWhenHidden = FALSE} if the download is initiated by
+programmatically clicking on the download button using JavaScript.
+}
 }

--- a/man/renderImage.Rd
+++ b/man/renderImage.Rd
@@ -125,6 +125,9 @@ shinyApp(ui, server)
 }
 }
 \seealso{
-For more details on how the images are generated, and how to control
+\itemize{
+\item For more details on how the images are generated, and how to control
 the output, see \code{\link[=plotPNG]{plotPNG()}}.
+\item Use \code{\link[=outputOptions]{outputOptions()}} to set general output options for an image output.
+}
 }

--- a/man/renderPrint.Rd
+++ b/man/renderPrint.Rd
@@ -126,3 +126,6 @@ vecFun()
 
 })
 }
+\seealso{
+\code{\link[=outputOptions]{outputOptions()}}
+}

--- a/man/renderUI.Rd
+++ b/man/renderUI.Rd
@@ -52,5 +52,5 @@ shinyApp(ui, server)
 
 }
 \seealso{
-\code{\link[=uiOutput]{uiOutput()}}
+\code{\link[=uiOutput]{uiOutput()}}, \code{\link[=outputOptions]{outputOptions()}}
 }


### PR DESCRIPTION
Fixes #4191 by adding a link from `downloadHandler()` to `outputOptions()` with a short description about why that would be useful.

While here, I also added a link to `outputOptions()` in the see also sections of other renderers, like `renderPlot()`, `renderPrint()`, etc.