### PR TITLE
Update srcts/README with info about using `window.Shiny`

### DIFF
--- a/srcts/README.md
+++ b/srcts/README.md
@@ -1,14 +1,22 @@
 # Using Shiny TypeScript Definitions
 
-When developing TypeScript projects that use `window.Shiny`, we recommend installing the Shiny TypeScript definitions to your package. To install the latest stable definitions, call
+When developing TypeScript projects that use `window.Shiny`, we recommend installing the Shiny TypeScript definitions to your package. To install the latest stable definitions, run one of the following (depending on if you're using `npm` or `yarn`):
 
 ```bash
-yarn add https://github.com/rstudio/shiny\#v1.7.0
+npm install https://github.com/rstudio/shiny\#v1.10.0 --save-dev
+# or
+yarn add https://github.com/rstudio/shiny\#v1.10.0 --dev
 ```
 
-, matching the GitHub tag to your current the Shiny CRAN release (ex: `v1.7.0`).  If you are asked to select a version of `@types/jquery`, please select the closest matching version.
+, matching the GitHub tag to your current the Shiny CRAN release (ex: `v1.10.0`).  If you are asked to select a version of `@types/jquery`, please select the closest matching version.
 
-This will provide a global type definition of `Shiny`, let your IDE know that `window.Shiny` is of type `Shiny`, and declare a globally available variable `Shiny` within your project. You **should not** need to import anything. Similar to `jQuery`, it should _Just Work_<sup>TM</sup>.
+This will provide a global type definition of `window.Shiny`. In your code, you can access the Shiny object via `window.Shiny` or just `Shiny`. However, note that if you are using TypeScript, it will be OK with `window.Shiny` but it will flag uses of `Shiny` (without the `window.` prefix), because TypeScript won't know that it's a global variable. We consider it better practice to use `window.Shiny` instead of `Shiny`, but if you want TypeScript to know that `Shiny` is available as a global variable, you can add the following to a TypeScript file in your code base.
+
+```ts
+ declare global {
+  const Shiny: ShinyClass;
+}
+```
 
 When loading your compiled file, it should be loaded after `shiny.js` is loaded. If you are using an `htmlDependency()` to add your code to the page, your script will automatically be loaded after has been loaded.
 


### PR DESCRIPTION
This updates the srcts/README to reflect the types we have in version of Shiny since 1.9.0. See #4197.