### PR TITLE
Implements `$cancel()` method for ExtendedTask

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -108,6 +108,7 @@ Suggests:
     magrittr,
     yaml,
     future,
+    mirai,
     dygraphs,
     ragg,
     showtext,

--- a/R/extended-task.R
+++ b/R/extended-task.R
@@ -194,6 +194,23 @@ ExtendedTask <- R6Class("ExtendedTask", portable = TRUE, cloneable = FALSE,
         # default case (initial, cancelled)
         req(FALSE)
       )
+    },
+    #' @description
+    #' Attempts to cancel the current `ExtendedTask` invocation. Only supported
+    #' for tasks created using \CRANpkg{mirai}.
+    #'
+    #' Returns one of the following values:
+    #'
+    #' * `TRUE`: A cancellation request was successfully sent for this
+    #'   `ExtendedTask`.
+    #' * `FALSE`: The `ExtendedTask` has already completed or was previously
+    #'   cancelled.
+    cancel = function() {
+      if (inherits(private$task, c("mirai", "mirai_map"))) {
+        mirai::stop_mirai(private$task)
+      } else {
+        warning("Only mirai ExtendedTasks support cancellation", immediate. = TRUE)
+      }
     }
   ),
   private = list(
@@ -203,6 +220,7 @@ ExtendedTask <- R6Class("ExtendedTask", portable = TRUE, cloneable = FALSE,
     rv_value = NULL,
     rv_error = NULL,
     invocation_queue = NULL,
+    task = NULL,
 
     do_invoke = function(args) {
       private$rv_status("running")
@@ -216,6 +234,7 @@ ExtendedTask <- R6Class("ExtendedTask", portable = TRUE, cloneable = FALSE,
           # call to invoke() always returns immediately?
           result <- do.call(private$func, args)
           p <- promises::as.promise(result)
+          private$task <- result
         })
       }, error = function(e) {
         private$on_error(e)

--- a/man/ExtendedTask.Rd
+++ b/man/ExtendedTask.Rd
@@ -102,6 +102,7 @@ shinyApp(ui, server)
 \item \href{#method-ExtendedTask-invoke}{\code{ExtendedTask$invoke()}}
 \item \href{#method-ExtendedTask-status}{\code{ExtendedTask$status()}}
 \item \href{#method-ExtendedTask-result}{\code{ExtendedTask$result()}}
+\item \href{#method-ExtendedTask-cancel}{\code{ExtendedTask$cancel()}}
 }
 }
 \if{html}{\out{<hr>}}
@@ -212,6 +213,25 @@ Note that the \code{result()} method is generally not meant to be used with
 invalidation will be ignored.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{ExtendedTask$result()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-ExtendedTask-cancel"></a>}}
+\if{latex}{\out{\hypertarget{method-ExtendedTask-cancel}{}}}
+\subsection{Method \code{cancel()}}{
+Attempts to cancel the current \code{ExtendedTask} invocation. Only supported
+for tasks created using \CRANpkg{mirai}.
+
+Returns one of the following values:
+\itemize{
+\item \code{TRUE}: A cancellation request was successfully sent for this
+\code{ExtendedTask}.
+\item \code{FALSE}: The \code{ExtendedTask} has already completed or was previously
+cancelled.
+}
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{ExtendedTask$cancel()}\if{html}{\out{</div>}}
 }
 
 }

--- a/man/ExtendedTask.Rd
+++ b/man/ExtendedTask.Rd
@@ -46,12 +46,13 @@ session to immediately unblock and carry on with other user interactions.
 }
 
 \examples{
-\dontshow{if (rlang::is_interactive() && rlang::is_installed("future")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
-
+\dontshow{if (rlang::is_interactive() && rlang::is_installed("mirai")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(shiny)
 library(bslib)
-library(future)
-plan(multisession)
+library(mirai)
+
+daemons(1)
+onStop(function() daemons(0))
 
 ui <- page_fluid(
   titlePanel("Extended Task Demo"),
@@ -60,18 +61,18 @@ ui <- page_fluid(
     "that takes a while to perform."
   ),
   input_task_button("recalculate", "Recalculate"),
+  actionButton("cancel", "Cancel"),
   p(textOutput("result"))
 )
 
 server <- function(input, output) {
   rand_task <- ExtendedTask$new(function() {
-    future(
+    mirai(
       {
         # Slow operation goes here
         Sys.sleep(2)
         sample(1:100, 1)
-      },
-      seed = TRUE
+      }
     )
   })
 
@@ -81,8 +82,21 @@ server <- function(input, output) {
   bind_task_button(rand_task, "recalculate")
 
   observeEvent(input$recalculate, {
-    # Invoke the extended in an observer
+    # Invoke the task in an observer.
     rand_task$invoke()
+  })
+
+  observeEvent(input$cancel, {
+    # For cancelling the task if required.
+    rand_task$cancel()
+  })
+
+  observe({
+    # Disable cancel button when task is not running.
+    updateActionButton(
+      inputId = "cancel",
+      disabled = rand_task$status() != "running"
+    )
   })
 
   output$result <- renderText({


### PR DESCRIPTION
Closes #4093.

Adds a `$cancel()` method to `ExtendedTask`, analogous to the [python implementation](https://github.com/posit-dev/py-shiny/blob/91e86e17b8053d45666ff6df152ca6cb4f2d3ead/shiny/reactive/_extended_task.py#L83).

This keeps it simple, and is straightforward as the `do.call()` in the code creates the task object anyway, and we just need to store it in a private field.

Previously I'd thought that the promise itself might have a `$cancel` method, but looking at javascript promises, this actually doesn't exist. It's also not natural to implement it that way, as `promises::promise()` takes functions as arguments, rather than the task object itself. We'd most likely need to rely on each `as.promise()` method to create this.

We could make cancellation extendable via a S3 generic for the task object for example, but as mirai is the only known implementation with cancellation capability thus far, we might defer this.