### PR TITLE
Fix performance regression related to limiting deep call stack growth

### DIFF
--- a/R/conditions.R
+++ b/R/conditions.R
@@ -75,6 +75,16 @@ getCallNames <- function(calls) {
   })
 }
 
+# Do less to speed things up, just need to keep call stack unique for hashing
+getCallNamesForHash <- function(calls) {
+  lapply(calls, function(call) {
+    name <- call[[1L]]
+    if (is.function(name)) return("<Anonymous>")
+    if (typeof(name) == "promise") return("<Promise>")
+    name
+  })
+}
+
 getLocs <- function(calls) {
   vapply(calls, function(call) {
     srcref <- attr(call, "srcref", exact = TRUE)
@@ -144,7 +154,7 @@ getCallStackDigest <- function(callStack, warn = FALSE) {
     )
   }
 
-  rlang::hash(getCallNames(callStack))
+  rlang::hash(getCallNamesForHash(callStack))
 }
 
 saveCallStackDigest <- function(callStack) {


### PR DESCRIPTION
Closes #4213.

Credit to @cpsievert for the suggestion.

This PR introduces a version of `getCallNames()` just for hashing that avoids the expensive formatting calls needed for nice output. We only need this function to create unique output to be hashed.

Notably the deep stack trace [tests](https://github.com/rstudio/shiny/blob/main/tests/testthat/test-stacks-deep.R) continue to pass.

I shouldn't think this would cause any issues, but would just like to draw your attention to this @jcheng5 in case you can think of a better solution.