### PR TITLE
Fix 404 in example 08_html (shiny.min.css)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,8 @@
 
 ## Bug fixes
 
+* examples-shiny/08_html/index.html now points to 'shiny.min.css' instead of the removed 'shiny.css', eliminating a 404 in DevTools. (#4220)
+
 * Fixed a bug with modals where calling `removeModal()` too quickly after `showModal()` would fail to remove the modal if the remove modal message was received while the modal was in the process of being revealed. (#4173)
 
 * The Shiny Client Console (enabled with `shiny::devmode()`) no longer displays duplicate warning or error message. (#4177)

--- a/inst/examples-shiny/08_html/www/index.html
+++ b/inst/examples-shiny/08_html/www/index.html
@@ -3,7 +3,7 @@
 <head>
   <script src="shared/jquery.js" type="text/javascript"></script>
   <script src="shared/shiny.js" type="text/javascript"></script>
-  <link rel="stylesheet" type="text/css" href="shared/shiny.css"/>
+  <link rel="stylesheet" type="text/css" href="shared/shiny.min.css"/>
 </head>
 
 <body>


### PR DESCRIPTION
The HTML example requested **shared/shiny.css**, which was renamed to **shiny.min.css**. This fix relinks the correct file and resolves the 404 in issue #4220