### PR TITLE
family->given for R Core authorship

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -60,7 +60,7 @@ Authors@R: c(
     comment = "showdown.js library"),
     person("Ivan", "Sagalaev", role = c("ctb", "cph"),
     comment = "highlight.js library"),
-    person(family = "R Core Team", role = c("ctb", "cph"),
+    person(given = "R Core Team", role = c("ctb", "cph"),
     comment = "tar implementation from R")
     )
 Description: Makes it incredibly easy to build interactive web


### PR DESCRIPTION
This is the more typical and correct way to cite this contributor.

c.f.

```r
a = tools::CRAN_authors_db()
sum(grepl("(?i)r core team", a$family))
# [1] 8
sum(grepl("(?i)r core team", a$given))
# [1] 61
```

From `?person`:

> For persons which are not natural persons (e.g., institutions, companies, etc.) it is appropriate to use `given` (but not `family`) for the name, e.g., `person("R Core Team", role = "aut")`.