### PR TITLE
fix: Wrap extended task invocation in `promise_resolve()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,8 @@
 
 * Shiny's Typescript assets are now compiled to ES2021 instead of ES5. (#4066)
 
+* `ExtendedTask` now catches synchronous values and errors and returns them via `$result()`. Previously, the extended task function was required to always return a promise. This change makes it easier to use `ExtendedTask` with a function that may return early or do some synchronous work before returning a promise. (#4225)
+
 ## Bug fixes
 
 * Fixed a bug with modals where calling `removeModal()` too quickly after `showModal()` would fail to remove the modal if the remove modal message was received while the modal was in the process of being revealed. (#4173)
@@ -30,6 +32,8 @@
 * The Shiny Client Console (enabled with `shiny::devmode()`) no longer displays duplicate warning or error message. (#4177)
 
 * Updated the JavaScript used when inserting a tab to avoid rendering dynamic UI elements twice when adding the new tab via `insertTab()` or `bslib::nav_insert()`. (#4179)
+
+* Fixed an issue with `ExtendedTask` where synchronous errors would cause an error that would stop the current session. (#4225)
 
 # shiny 1.10.0
 

--- a/R/extended-task.R
+++ b/R/extended-task.R
@@ -130,14 +130,15 @@ ExtendedTask <- R6Class("ExtendedTask", portable = TRUE, cloneable = FALSE,
     #'   arguments.
     invoke = function(...) {
       args <- rlang::dots_list(..., .ignore_empty = "none")
+      call <- rlang::caller_call(n = 0)
 
       if (
         isolate(private$rv_status()) == "running" ||
           private$invocation_queue$size() > 0
       ) {
-        private$invocation_queue$add(args)
+        private$invocation_queue$add(list(args = args, call = call))
       } else {
-        private$do_invoke(args)
+        private$do_invoke(args, call = call)
       }
       invisible(NULL)
     },
@@ -204,22 +205,23 @@ ExtendedTask <- R6Class("ExtendedTask", portable = TRUE, cloneable = FALSE,
     rv_error = NULL,
     invocation_queue = NULL,
 
-    do_invoke = function(args) {
+    do_invoke = function(args, call = NULL) {
       private$rv_status("running")
       private$rv_value(NULL)
       private$rv_error(NULL)
 
       p <- NULL
-      tryCatch({
-        maskReactiveContext({
-          # TODO: Bounce the do.call off of a promise_resolve(), so that the
-          # call to invoke() always returns immediately?
-          result <- do.call(private$func, args)
-          p <- promises::as.promise(result)
-        })
-      }, error = function(e) {
-        private$on_error(e)
-      })
+      tryCatch(
+        {
+          maskReactiveContext({
+
+            p <- promises::promise_resolve(do.call(private$func, args))
+          })
+        },
+        error = function(e) {
+          private$on_error(e, call = call)
+        }
+      )
 
       promises::finally(
         promises::then(p,
@@ -227,12 +229,13 @@ ExtendedTask <- R6Class("ExtendedTask", portable = TRUE, cloneable = FALSE,
             private$on_success(list(value=value, visible=.visible))
           },
           onRejected = function(error) {
-            private$on_error(error)
+            private$on_error(error, call = call)
           }
         ),
         onFinally = function() {
           if (private$invocation_queue$size() > 0) {
-            private$do_invoke(private$invocation_queue$remove())
+            next_call <- private$invocation_queue$remove()
+            private$do_invoke(next_call$args, next_call$call)
           }
         }
       )
@@ -241,7 +244,12 @@ ExtendedTask <- R6Class("ExtendedTask", portable = TRUE, cloneable = FALSE,
       invisible(NULL)
     },
 
-    on_error = function(err) {
+    on_error = function(err, call = NULL) {
+      cli::cli_warn(
+        "ERROR: An error occurred when invoking the ExtendedTask.",
+        parent = err,
+        call = call
+      )
       private$rv_status("error")
       private$rv_error(err)
     },


### PR DESCRIPTION
Fixes #4223

This PR updates `ExtendedTask$invoke()` to wrap calling the task function in `promise_resolve()`. The primary goal is to consolidate all error handling through the `$status()` and `$result()` methods and to avoid having errors from `$invoke()` stop the current app session.

I also updated the `$on_error()` method to emit a warning with errors thrown during the task, since it's posible to invoke an etended task without actually inspecting `$result()` to see the error, in which case there would be no indication that an error occurred.

Here's an example app that you can run locally to see the impact of the behavior of this PR. There's a simple task that does both sync and async work and possibly errors or returns either sync or asynchronously.

Currently (on main), the task only succeeds if it follows the happy path of doing and returning an async value or returning a rejected promise. If the task throws or returns a value synchronously, the app session crashes. If the task throws an async error, note that the user needs to inspect `$result()` to know that an error happened.

With this PR, synchronous values and errors are returned without crashing the app session and all errors (sync or async) are logged as a warning.

```r
library(shiny)
library(bslib)

ui <- page_fluid(
  layout_columns(
    card(
      input_switch("will_error", "Throw a synchronous error?"),
      input_switch("will_nothing", "Do nothing?"),
      input_switch("will_error_async", "Throw an asynchronous error?"),
      input_task_button("start", "Start Task"),
    ),
    card(
      markdown(
        "The extended task does four things:

1. A bit of synchronous work
2. Maybe throws a synchronous error
3. Maybe returns early (does nothing)
4. A bit of asynchronous work
5. Maybe throws an asynchronous error
6. Returns an async value
    "
      )
    )
  ),
  verbatimTextOutput("task_status"),
)

server <- function(input, output, session) {
  cli::cli_h1("Start {.stamp {Sys.time()}}")

  long_task <- ExtendedTask$new(coro::async(function(
    do_throw_sync = FALSE,
    do_throw_async = FALSE,
    do_nothing = FALSE
  ) {
    Sys.sleep(1)
    if (do_throw_sync) rlang::abort("boom!")
    if (do_nothing) return()
    coro::await(coro::async_sleep(1))
    if (do_throw_async) rlang::abort("boom!")
    1L
  }))

  bind_task_button(long_task, "start")

  observeEvent(input$start, {
    long_task$invoke(
      input$will_error,
      input$will_error_async,
      input$will_nothing
    )
  })

  output$task_status <- renderPrint({
    list(
      status = long_task$status(),
      result = tryCatch(long_task$result(), error = identity)
    )
  })
}

shinyApp(ui, server)
```