### PR TITLE
fix(renderPlot): get interactive plotting working with ggplot2 v4.0

### DIFF
--- a/R/render-plot.R
+++ b/R/render-plot.R
@@ -266,6 +266,8 @@ drawPlot <- function(name, session, func, width, height, alt, pixelratio, res, .
               # addition to ggplot, and there's a print method for that class, that we
               # won't override that method. https://github.com/rstudio/shiny/issues/841
               print.ggplot <- custom_print.ggplot
+              # For compatibility with ggplot2 >v4.0.0
+              `print.ggplot2::ggplot` <- custom_print.ggplot
 
               # Use capture.output to squelch printing to the actual console; we
               # are only interested in plot output


### PR DESCRIPTION
This update gets `renderPlot()` interactive ggplot2 feature working with ggplot2's upcoming transition from S3 to S7 (https://github.com/tidyverse/ggplot2/pull/6364).

Note that https://github.com/rstudio/shiny/pull/4226 fixed a similar issue, but only for our unit tests. The same problem exists in `renderPlot()`'s interactive feature, which we don't have any automated tests for.

For a minimal example, with this app, no brushed points are returned when brushing the plot. 

```R
library(shiny)
library(ggplot2)
library(bslib)

ui <- page_fixed(
    card(
    card_header("Interactive Brushing Plot"),
    plotOutput("plot", brush = "plot_brush"),
    card_footer("Drag to select points on the plot")
  ),
  card(
    card_header("Selected Data Points"),
    tableOutput("brushed_data")
  )
)

server <- function(input, output, session) {
  
  output$plot <- renderPlot({
    ggplot(iris, aes(x = Sepal.Length, y = Sepal.Width, color = Species)) +
      geom_point(size = 3) +
      theme_minimal()
  })
  
  output$brushed_data <- renderTable({
    req(input$plot_brush)
    
    brushed_data <- brushedPoints(
      iris, input$plot_brush, 
      xvar = "Sepal.Length", yvar = "Sepal.Width"
    )
    
    if(nrow(brushed_data) == 0) {
      return(data.frame(Message = "No points selected"))
    }
    
    brushed_data
  })
}

shinyApp(ui = ui, server = server)
``` 

<img width="813" alt="Screenshot 2025-06-10 at 10 01 20 AM" src="https://github.com/user-attachments/assets/0856d2e2-ebec-4d60-aeab-acfda4c41e9e" />


With this change, you'll get the expected behavior:


<img width="817" alt="Screenshot 2025-06-10 at 10 04 23 AM" src="https://github.com/user-attachments/assets/529bbc8e-21ad-4b00-b38c-df61e2348168" />

## Testing notes

* First, verify the example above is broken by installing the new ggplot2 `remotes::install_github("tidyverse/ggplot2#6364")`
* Next, install this change, and verify the problem is fixed: `remotes::install_github("rstudio/shiny#4228")`

More generally, we should do more testing of shiny's interactive ggplot2 plot feature to make sure there isn't more changes that we're missing. We still have a handful of apps that we designed for manually testing, but never got automated tests:

093-plot-interaction-basic
094-image-interaction-basic
095-plot-interaction-advanced
096-plot-interaction-article-1
097-plot-interaction-article-2
098-plot-interaction-article-3
099-plot-interaction-article-4
100-plot-interaction-article-5
101-plot-interaction-article-6
102-plot-interaction-article-7
103-plot-interaction-article-8
104-plot-interaction-select
105-plot-interaction-zoom
106-plot-interaction-exclude

It'd also be great to verify that these apps are working as intended with the latest ggplot2 (plus this change). Testing across different environments isn't that important (we're just looking for changes in ggplot2's R code that we're not accounting for).
