### PR TITLE
Adds mirai to documentation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -107,6 +107,7 @@ Suggests:
     reactlog (>= 1.0.0),
     magrittr,
     yaml,
+    mirai,
     future,
     dygraphs,
     ragg,

--- a/R/bind-cache.R
+++ b/R/bind-cache.R
@@ -231,8 +231,8 @@ utils::globalVariables(".GenericCallEnv", add = TRUE)
 #'   promises, but rather objects provided by the
 #'   \href{https://rstudio.github.io/promises/}{\pkg{promises}}  package, which
 #'   are similar to promises in JavaScript. (See [promises::promise()] for more
-#'   information.) You can also use [future::future()] objects to run code in a
-#'   separate process or even on a remote machine.
+#'   information.) You can also use [mirai::mirai()] or [future::future()]
+#'   objects to run code in a separate process or even on a remote machine.
 #'
 #'   If the value returns a promise, then anything that consumes the cached
 #'   reactive must expect it to return a promise.

--- a/R/extended-task.R
+++ b/R/extended-task.R
@@ -41,12 +41,15 @@
 #'   is, a function that quickly returns a promise) and allows even that very
 #'   session to immediately unblock and carry on with other user interactions.
 #'
-#' @examplesIf rlang::is_interactive() && rlang::is_installed("future")
-#'
+#' @examplesIf rlang::is_interactive() && rlang::is_installed("mirai")
 #' library(shiny)
 #' library(bslib)
-#' library(future)
-#' plan(multisession)
+#' library(mirai)
+#'
+#' # Set background processes for running tasks
+#' daemons(1)
+#' # Reset when the app is stopped
+#' onStop(function() daemons(0))
 #'
 #' ui <- page_fluid(
 #'   titlePanel("Extended Task Demo"),
@@ -60,13 +63,12 @@
 #'
 #' server <- function(input, output) {
 #'   rand_task <- ExtendedTask$new(function() {
-#'     future(
+#'     mirai(
 #'       {
 #'         # Slow operation goes here
 #'         Sys.sleep(2)
 #'         sample(1:100, 1)
-#'       },
-#'       seed = TRUE
+#'       }
 #'     )
 #'   })
 #'

--- a/R/extended-task.R
+++ b/R/extended-task.R
@@ -100,11 +100,12 @@ ExtendedTask <- R6Class("ExtendedTask", portable = TRUE, cloneable = FALSE,
     #' @param func The long-running operation to execute. This should be an
     #'   asynchronous function, meaning, it should use the
     #'   [\{promises\}](https://rstudio.github.io/promises/) package, most
-    #'   likely in conjuction with the
+    #'   likely in conjunction with the
+    #'   [\{mirai\}](https://mirai.r-lib.org) or
     #'   [\{future\}](https://rstudio.github.io/promises/articles/promises_04_futures.html)
     #'   package. (In short, the return value of `func` should be a
-    #'   [`Future`][future::future()] object, or a `promise`, or something else
-    #'   that [promises::as.promise()] understands.)
+    #'   [`mirai`][mirai::mirai()], [`Future`][future::future()], `promise`,
+    #'   or something else that [promises::as.promise()] understands.)
     #'
     #'   It's also important that this logic does not read from any
     #'   reactive inputs/sources, as inputs may change after the function is

--- a/man/ExtendedTask.Rd
+++ b/man/ExtendedTask.Rd
@@ -121,11 +121,12 @@ server function.
 \item{\code{func}}{The long-running operation to execute. This should be an
 asynchronous function, meaning, it should use the
 \href{https://rstudio.github.io/promises/}{\{promises\}} package, most
-likely in conjuction with the
+likely in conjunction with the
+\href{https://mirai.r-lib.org}{\{mirai\}} or
 \href{https://rstudio.github.io/promises/articles/promises_04_futures.html}{\{future\}}
 package. (In short, the return value of \code{func} should be a
-\code{\link[future:future]{Future}} object, or a \code{promise}, or something else
-that \code{\link[promises:is.promise]{promises::as.promise()}} understands.)
+\code{\link[mirai:mirai]{mirai}}, \code{\link[future:future]{Future}}, \code{promise},
+or something else that \code{\link[promises:is.promise]{promises::as.promise()}} understands.)
 
 It's also important that this logic does not read from any
 reactive inputs/sources, as inputs may change after the function is

--- a/man/ExtendedTask.Rd
+++ b/man/ExtendedTask.Rd
@@ -46,12 +46,15 @@ session to immediately unblock and carry on with other user interactions.
 }
 
 \examples{
-\dontshow{if (rlang::is_interactive() && rlang::is_installed("future")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
-
+\dontshow{if (rlang::is_interactive() && rlang::is_installed("mirai")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(shiny)
 library(bslib)
-library(future)
-plan(multisession)
+library(mirai)
+
+# Set background processes for running tasks
+daemons(1)
+# Reset when the app is stopped
+onStop(function() daemons(0))
 
 ui <- page_fluid(
   titlePanel("Extended Task Demo"),
@@ -65,13 +68,12 @@ ui <- page_fluid(
 
 server <- function(input, output) {
   rand_task <- ExtendedTask$new(function() {
-    future(
+    mirai(
       {
         # Slow operation goes here
         Sys.sleep(2)
         sample(1:100, 1)
-      },
-      seed = TRUE
+      }
     )
   })
 

--- a/man/bindCache.Rd
+++ b/man/bindCache.Rd
@@ -234,8 +234,8 @@ With a cached reactive expression, the key and/or value expression can be
 promises, but rather objects provided by the
 \href{https://rstudio.github.io/promises/}{\pkg{promises}}  package, which
 are similar to promises in JavaScript. (See \code{\link[promises:promise]{promises::promise()}} for more
-information.) You can also use \code{\link[future:future]{future::future()}} objects to run code in a
-separate process or even on a remote machine.
+information.) You can also use \code{\link[mirai:mirai]{mirai::mirai()}} or \code{\link[future:future]{future::future()}}
+objects to run code in a separate process or even on a remote machine.
 
 If the value returns a promise, then anything that consumes the cached
 reactive must expect it to return a promise.

--- a/man/shiny-package.Rd
+++ b/man/shiny-package.Rd
@@ -61,7 +61,7 @@ Other contributors:
   \item John Fraser (showdown.js library) [contributor, copyright holder]
   \item John Gruber (showdown.js library) [contributor, copyright holder]
   \item Ivan Sagalaev (highlight.js library) [contributor, copyright holder]
-  \item  R Core Team (tar implementation from R) [contributor, copyright holder]
+  \item R Core Team (tar implementation from R) [contributor, copyright holder]
 }
 
 }


### PR DESCRIPTION
Closes #4229.

The edits in Shiny here are really light. The bulk of the updates belong in the promises package and the articles there.

1. Adds 'mirai or future' in the couple of cases 'future' is mentioned (package ordering was as @schloerke preferred).
2. Amends the simple ExtendedTask example to use mirai.
    I don't think there's particular value in adding another future-based example, given the pretty exhaustive examples in the promises package (and also lets us sidestep the `future()` vs `future_promise()` question here).

Thanks!

FYI @jcheng5 