### PR TITLE
docs: update srcts/readme.md to shiny 1.11.1

### DIFF
--- a/srcts/README.md
+++ b/srcts/README.md
@@ -3,12 +3,12 @@
 When developing TypeScript projects that use `window.Shiny`, we recommend installing the Shiny TypeScript definitions to your package. To install the latest stable definitions, run one of the following (depending on if you're using `npm` or `yarn`):
 
 ```bash
-npm install https://github.com/rstudio/shiny\#v1.10.0 --save-dev
+npm install https://github.com/rstudio/shiny\#v1.11.1 --save-dev
 # or
-yarn add https://github.com/rstudio/shiny\#v1.10.0 --dev
+yarn add https://github.com/rstudio/shiny\#v1.11.1 --dev
 ```
 
-, matching the GitHub tag to your current the Shiny CRAN release (ex: `v1.10.0`).  If you are asked to select a version of `@types/jquery`, please select the closest matching version.
+, matching the GitHub tag to your current the Shiny CRAN release (ex: `v1.11.1`).  If you are asked to select a version of `@types/jquery`, please select the closest matching version.
 
 This will provide a global type definition of `window.Shiny`. In your code, you can access the Shiny object via `window.Shiny` or just `Shiny`. However, note that if you are using TypeScript, it will be OK with `window.Shiny` but it will flag uses of `Shiny` (without the `window.` prefix), because TypeScript won't know that it's a global variable. We consider it better practice to use `window.Shiny` instead of `Shiny`, but if you want TypeScript to know that `Shiny` is available as a global variable, you can add the following to a TypeScript file in your code base.
 


### PR DESCRIPTION
In the process of updating dev docs. Thought I'd put in this batch doc fix first.