### PR TITLE
feat: `reactive()` and `bindCache()` default `label=` are now namespaced

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,9 @@
 
 ## Changes
 
-* The return value of `actionButton()`/`actionLink()` changed slightly: `label` and `icon` are wrapped in an additional HTML container element. This allows for: 1. `updateActionButton()`/`updateActionLink()` to distinguish between the `label` and `icon` when making updates and 2. spacing between `label` and `icon` to be more easily customized via CSS. 
+* `reactive()` and `bindCache()` default `label=` values are now namespaced when used within Shiny modules. This ensures that reactive labels are unique within their module context, preventing potential conflicts in debugging and profiling tools. (#4279)
+
+* The return value of `actionButton()`/`actionLink()` changed slightly: `label` and `icon` are wrapped in an additional HTML container element. This allows for: 1. `updateActionButton()`/`updateActionLink()` to distinguish between the `label` and `icon` when making updates and 2. spacing between `label` and `icon` to be more easily customized via CSS.
 
 # shiny 1.11.1
 

--- a/R/utils-lang.R
+++ b/R/utils-lang.R
@@ -213,7 +213,9 @@ exprToLabel <- function(expr, function_name, label = NULL) {
   }
   if (length(srcref) >= 2) attr(label, "srcref") <- srcref[[2]]
   attr(label, "srcfile") <- srcFileOfRef(srcref[[1]])
-  label
+
+  domain <- getDefaultReactiveDomain()
+  domain$ns(label)
 }
 simpleExprToFunction <- function(expr, function_name) {
   sprintf('%s(%s)', function_name, paste(deparse(expr), collapse='\n'))


### PR DESCRIPTION
For example, if the reactive `r <- reactive({force(1 + 1)})` is created within the module, `mymod`. Then the default name will be `"mymod-r"`.

If the reactive is created at the top level domain, then it will remain as `"r"`.