### PR TITLE
preempt jsonlite message about keep_vec_names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@
 
 * The return value of `actionButton()`/`actionLink()` changed slightly: `label` and `icon` are wrapped in an additional HTML container element. This allows for: 1. `updateActionButton()`/`updateActionLink()` to distinguish between the `label` and `icon` when making updates and 2. spacing between `label` and `icon` to be more easily customized via CSS. 
 
+* The internal (not `jsonlite::`) implementation of `toJSON` now converts named vectors to named lists in order to avoid jsonlite's message when `keep_vec_names=TRUE`.
+
 # shiny 1.11.1
 
 This is a patch release primarily for addressing the bugs introduced in v1.11.0.

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -38,7 +38,13 @@ toJSON <- function(x, ...,  dataframe = "columns", null = "null", na = "null",
   # https://github.com/jeroen/jsonlite/commit/728efa9
   digits = getOption("shiny.json.digits", I(16)), use_signif = is(digits, "AsIs"),
   force = TRUE, POSIXt = "ISO8601", UTC = TRUE,
-  rownames = FALSE, keep_vec_names = TRUE, strict_atomic = TRUE) {
+  rownames = FALSE, keep_vec_names = TRUE, strict_atomic = TRUE, fix_vec_names = TRUE) {
+
+  # jsonlite complains about named _vectors_, so we'll force all
+  # named-vectors to be named-lists
+  if (fix_vec_names) {
+    x <- lapply(x, function(L) if (is.null(names(L))) L else as.list(L))
+  }
 
   if (strict_atomic) {
     x <- I(x)


### PR DESCRIPTION
Prevent `jsonlite`'s message about `keep_vec_names=`:

```r
### without this patch
toJSON(list(a=5, b=quantile(1:5, 0.5)))
# Input to asJSON(keep_vec_names=TRUE) is a named vector. In a future version of jsonlite, this option will not be supported, and named vectors will be translated into arrays instead of objects. If you want JSON object output, please use a named list instead. See ?toJSON.
# {"a":5,"b":{"50%":3}} 

### with this patch
toJSON(list(a=5, b=quantile(1:5, 0.5)))
# {"a":5,"b":{"50%":3}} 
```

If there are specific places where this is not working (and the use does not otherwise trigger the message), setting `fix_vec_names=FALSE` will bypass the additional step.

I do find many calls to `jsonlite::toJSON(.)` in the package in addition to the (internal) `toJSON(.)`, I'm not sure if that's intentional or if there can be some dis-ambiguation here. I'm happy to participate in that if it is beneficial.
