### PR TITLE
Adding `full` as a valid parameter for the `size` arg in modalD…

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * The `icon` argument of `updateActionButton()`/`updateActionLink()` nows allows values other than `shiny::icon()` (e.g., `fontawesome::fa()`, `bsicons::bs_icon()`, etc). (#4249)
 
+* The `size` argument of `modalDialog` now supports `full` to create full-screen modals. (#4297)
+
 ## Bug fixes
 
 * `updateActionButton()`/`updateActionLink()` now correctly renders HTML content passed to the `label` argument. (#4249)
@@ -12,7 +14,7 @@
 
 ## Changes
 
-* The return value of `actionButton()`/`actionLink()` changed slightly: `label` and `icon` are wrapped in an additional HTML container element. This allows for: 1. `updateActionButton()`/`updateActionLink()` to distinguish between the `label` and `icon` when making updates and 2. spacing between `label` and `icon` to be more easily customized via CSS. 
+* The return value of `actionButton()`/`actionLink()` changed slightly: `label` and `icon` are wrapped in an additional HTML container element. This allows for: 1. `updateActionButton()`/`updateActionLink()` to distinguish between the `label` and `icon` when making updates and 2. spacing between `label` and `icon` to be more easily customized via CSS.
 
 # shiny 1.11.1
 

--- a/R/modal.R
+++ b/R/modal.R
@@ -43,9 +43,10 @@ removeModal <- function(session = getDefaultReactiveDomain()) {
 #' @param title An optional title for the dialog.
 #' @param footer UI for footer. Use `NULL` for no footer.
 #' @param size One of `"s"` for small, `"m"` (the default) for medium,
-#'   `"l"` for large, or `"xl"` for extra large. Note that `"xl"` only 
-#'    works with Bootstrap 4 and above (to opt-in to Bootstrap 4+, 
-#'    pass [bslib::bs_theme()] to the `theme` argument of a page container 
+#'   `"l"` for large, `"xl"` for extra large, or `"full"` for full screen.
+#'    Note that `"xl"` only works with Bootstrap >=4 and `"full"`
+#'    only works with Bootstrap >=5.(to opt-in to Bootstrap 4+ or Bootstrap 5+,
+#'    pass [bslib::bs_theme()] to the `theme` argument of a page container
 #'    like [fluidPage()]).
 #' @param easyClose If `TRUE`, the modal dialog can be dismissed by
 #'   clicking outside the dialog box, or be pressing the Escape key. If
@@ -154,7 +155,7 @@ removeModal <- function(session = getDefaultReactiveDomain()) {
 #' }
 #' @export
 modalDialog <- function(..., title = NULL, footer = modalButton("Dismiss"),
-  size = c("m", "s", "l", "xl"), easyClose = FALSE, fade = TRUE) {
+  size = c("m", "s", "l", "xl", "full"), easyClose = FALSE, fade = TRUE) {
 
   size <- match.arg(size)
 
@@ -172,7 +173,7 @@ modalDialog <- function(..., title = NULL, footer = modalButton("Dismiss"),
 
     div(
       class = "modal-dialog",
-      class = switch(size, s = "modal-sm", m = NULL, l = "modal-lg", xl = "modal-xl"),
+      class = switch(size, s = "modal-sm", m = NULL, l = "modal-lg", xl = "modal-xl", full = "modal-fullscreen"),
       div(class = "modal-content",
         if (!is.null(title)) div(class = "modal-header",
           tags$h4(class = "modal-title", title)

--- a/man/modalDialog.Rd
+++ b/man/modalDialog.Rd
@@ -9,7 +9,7 @@ modalDialog(
   ...,
   title = NULL,
   footer = modalButton("Dismiss"),
-  size = c("m", "s", "l", "xl"),
+  size = c("m", "s", "l", "xl", "full"),
   easyClose = FALSE,
   fade = TRUE
 )
@@ -24,8 +24,9 @@ modalButton(label, icon = NULL)
 \item{footer}{UI for footer. Use \code{NULL} for no footer.}
 
 \item{size}{One of \code{"s"} for small, \code{"m"} (the default) for medium,
-\code{"l"} for large, or \code{"xl"} for extra large. Note that \code{"xl"} only
-works with Bootstrap 4 and above (to opt-in to Bootstrap 4+,
+\code{"l"} for large, \code{"xl"} for extra large, or \code{"full"} for full screen.
+Note that \code{"xl"} only works with Bootstrap >=4 and \code{"full"}
+only works with Bootstrap >=5.(to opt-in to Bootstrap 4+ or Bootstrap 5+,
 pass \code{\link[bslib:bs_theme]{bslib::bs_theme()}} to the \code{theme} argument of a page container
 like \code{\link[=fluidPage]{fluidPage()}}).}
 


### PR DESCRIPTION
Closes #4297
Hey! thank you for this awesome package. Adding a small feature for modals here.

How to test
```R
library(shiny)
library(bslib)

shinyApp(
  ui = bslib::page_fillable(
    actionButton("open", "open modal")
  ),
  server = function(input, output, session) {
    observe(
      showModal(
        modalDialog("fullscreen!", size = "full")
      )
    ) |> 
      bindEvent(input$open)
  }
)
```