### PR TITLE
Update modal.R

### DIFF
--- a/R/modal.R
+++ b/R/modal.R
@@ -41,8 +41,6 @@ removeModal <- function(session = getDefaultReactiveDomain()) {
 #' @inheritParams actionButton
 #' @param ... UI elements for the body of the modal dialog box.
 #' @param title An optional title for the dialog.
-#` @param title_level An optional header level (between 1 and 6) for the title. 
-#'   Defaults to 4 (h4 element).
 #' @param footer UI for footer. Use `NULL` for no footer.
 #' @param size One of `"s"` for small, `"m"` (the default) for medium,
 #'   `"l"` for large, or `"xl"` for extra large. Note that `"xl"` only 
@@ -155,22 +153,12 @@ removeModal <- function(session = getDefaultReactiveDomain()) {
 #' )
 #' }
 #' @export
-modalDialog <- function(..., title = NULL, title_level = 4, footer = modalButton("Dismiss"),
+modalDialog <- function(..., title = NULL, footer = modalButton("Dismiss"),
   size = c("m", "s", "l", "xl"), easyClose = FALSE, fade = TRUE) {
 
-if (!is.numeric(title_level) || length(title_level) != 1 || is.na(title_level)) {
-  stop("`title_level` must be a single numeric value between 1 and 6.")
-}
-
-if (title_level %% 1 != 0) {
-  stop("`title_level` must be an integer between 1 and 6.")
-}
-
-if (title_level < 1 || title_level > 6) {
-  stop("`title_level` must be a value 1 through 6.")
-}
-
   size <- match.arg(size)
+
+  has_title <- !is.null(title)
 
   backdrop <- if (!easyClose) "static"
   keyboard <- if (!easyClose) "false"
@@ -183,14 +171,16 @@ if (title_level < 1 || title_level > 6) {
     `data-bs-backdrop` = backdrop,
     `data-keyboard` = keyboard,
     `data-bs-keyboard` = keyboard,
+    if (has_title) `aria-labelledby` = "shiny-modal-title",
 
     div(
       class = "modal-dialog",
       class = switch(size, s = "modal-sm", m = NULL, l = "modal-lg", xl = "modal-xl"),
       div(class = "modal-content",
         if (!is.null(title)) div(class = "modal-header",
-          tag_fun = htmltools::tags[[paste0("h", title_level)]] #NOW, GRAB HEADER LEVEL ACCORDING TO USER SPEC
-          tag_fun(class = "modal-title", title)
+          div(class = "modal-title",
+              id = "shiny-modal-title", 
+              title)
         ),
         div(class = "modal-body", ...),
         if (!is.null(footer)) div(class = "modal-footer", footer)


### PR DESCRIPTION
Currently, the modal title is hard-coded to be an h4 element. This makes sense as a default, but ideally, it would be toggleable to respect a user's heading hierarchy for a11y. This creates an input that allows toggling to whatever level is desired.