### PR TITLE
fix: Provide context around SHINY_PORT triggering Shiny Server warning

### DIFF
--- a/R/runapp.R
+++ b/R/runapp.R
@@ -221,7 +221,7 @@ runApp <- function(
           "Shiny Server v%s or later is required; please upgrade.",
           .shinyServerMinVersion
         ),
-        "i" = "If you are not using Shiny Server you are likely seeing this message because the `SHINY_PORT` environment variable is set in your environment.",
+        "i" = "If you are not using Shiny Server, you are likely seeing this message because the `SHINY_PORT` environment variable is set in your environment.",
         "i" = "Avoid using `SHINY_PORT` to prevent this warning."
       ))
     }


### PR DESCRIPTION
Fixes #4182

When the `SHINY_PORT` environment variable is set and apps are run locally or not in a hosted environment, Shiny emits a warning about using an incompatible version of Shiny Server.

This PR adds additional context to the warning message to recommend either using another environment variable or making it clear that you can ignore the message. 