### PR TITLE
Fix: don't create `.Random.seed` as side effect of loading shiny

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,10 @@
   This method was never called by Shiny's runtime, so any overrides were dead
   code. Use `unsubscribe()` for cleanup logic instead. (#4375)
 
+## Bug fixes
+
+* Loading shiny no longer creates `.Random.seed` in the global environment as a side effect. (#4382)
+
 # shiny 1.13.0
 
 ## New features

--- a/R/utils.R
+++ b/R/utils.R
@@ -76,12 +76,12 @@ withPrivateSeed <- function(expr) {
 
     if (hasOrigSeed) {
       .GlobalEnv$.Random.seed <- origSeed
+      # Need to call this to make sure that the value of .Random.seed gets put
+      # into R's internal RNG state. (Issue #1763)
+      httpuv::getRNGState()
     } else {
       rm(.Random.seed, envir = .GlobalEnv, inherits = FALSE)
     }
-    # Need to call this to make sure that the value of .Random.seed gets put
-    # into R's internal RNG state. (Issue #1763)
-    httpuv::getRNGState()
   })
 
   expr


### PR DESCRIPTION
Fixes #4382

## Summary

Loading shiny in a fresh R session (where `.Random.seed` doesn't yet exist) caused `.Random.seed` to be created as a side effect. This happened because `withPrivateSeed()` unconditionally called `httpuv::getRNGState()` on exit, which calls R's C-level `GetRNGstate()` — and that function initializes the RNG (creating `.Random.seed`) when it doesn't already exist.

The fix moves the `httpuv::getRNGState()` call inside the branch that restores a pre-existing seed. When there was no `.Random.seed` before the call, we simply remove it and skip the sync — leaving the RNG in the same "not yet initialized" state it was in before package load.

## Test plan

- [x] Existing `test-utils.R` tests pass (seed save/restore behavior unchanged)
- [x] Manually verify in a fresh R session:
  ```r
  exists(".Random.seed", envir = globalenv(), inherits = FALSE)
  #> FALSE
  loadNamespace("shiny")
  exists(".Random.seed", envir = globalenv(), inherits = FALSE)
  #> FALSE
  ```