### PR TITLE
Docs: Remove obsolete browser references and update stale documentation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,8 @@
   This method was never called by Shiny's runtime, so any overrides were dead
   code. Use `unsubscribe()` for cleanup logic instead. (#4375)
 
+* Updated default HTTP headers for better security. Shiny now sends `X-Content-Type-Options: nosniff` instead of the legacy `X-UA-Compatible` header. This removes outdated Internet Explorer–specific behavior and adds a modern safeguard that prevents browsers from misinterpreting file types. (#4385)
+
 ## Bug fixes
 
 * Loading shiny no longer creates `.Random.seed` in the global environment as a side effect. (#4382)

--- a/NEWS.md
+++ b/NEWS.md
@@ -946,7 +946,7 @@ This is a significant release for Shiny, with a major new feature that was nearl
 
 * Fixed #1600: URL-encoded bookmarking did not work with sliders that had dates or date-times. (#1961)
 
-* Fixed #1962: [File dragging and dropping](https://posit.co/blog/shiny-1-0-4/) broke in the presence of jQuery version 3.0 as introduced by the [rhandsontable](https://jrowen.github.io/rhandsontable/) [htmlwidget](https://www.htmlwidgets.org/). (#2005)
+* Fixed #1962: [File dragging and dropping](https://posit.co/blog/shiny-1-0-4) broke in the presence of jQuery version 3.0 as introduced by the [rhandsontable](https://jrowen.github.io/rhandsontable/) [htmlwidget](https://www.htmlwidgets.org/). (#2005)
 
 * Improved the error handling inside the `addResourcePath()` function, to give end users more informative error messages when the `directoryPath` argument cannot be normalized. This is especially useful for `runtime: shiny_prerendered` Rmd documents, like `learnr` tutorials. (#1968)
 

--- a/R/bookmark-state.R
+++ b/R/bookmark-state.R
@@ -529,8 +529,8 @@ restoreInput <- function(id, default) {
 #' Update URL in browser's location bar
 #'
 #' This function updates the client browser's query string in the location bar.
-#' It typically is called from an observer. Note that this will not work in
-#' Internet Explorer 9 and below.
+#' It typically is called from an observer. Note that this requires a browser
+#' with History API support (`history.pushState` / `history.replaceState`).
 #'
 #' For `mode = "push"`, only three updates are currently allowed:
 #' \enumerate{

--- a/R/bookmark-state.R
+++ b/R/bookmark-state.R
@@ -543,8 +543,8 @@ restoreInput <- function(id, default) {
 #' In other words, if `mode = "push"`, the `queryString` must start
 #' with either `?` or with `#`.
 #'
-#' A technical curiosity: under the hood, this function is calling the HTML5
-#' history API (which is where the names for the `mode` argument come from).
+#' A technical curiosity: under the hood, this function is calling the History
+#' API (which is where the names for the `mode` argument come from).
 #' When `mode = "replace"`, the function called is
 #' `window.history.replaceState(null, null, queryString)`.
 #' When `mode = "push"`, the function called is

--- a/R/bootstrap-layout.R
+++ b/R/bootstrap-layout.R
@@ -21,7 +21,7 @@
 #'   higher-level layout functions like [sidebarLayout()].
 #'
 #' @note See the [
-#'   Shiny-Application-Layout-Guide](https://shiny.rstudio.com/articles/layout-guide.html) for additional details on laying out fluid
+#'   Shiny-Application-Layout-Guide](https://shiny.posit.co/articles/layout-guide.html) for additional details on laying out fluid
 #'   pages.
 #'
 #' @family layout functions
@@ -120,7 +120,7 @@ fluidRow <- function(...) {
 #'   with `fixedRow` and `column`.
 #'
 #' @note See the [
-#'   Shiny Application Layout Guide](https://shiny.rstudio.com/articles/layout-guide.html) for additional details on laying out fixed
+#'   Shiny Application Layout Guide](https://shiny.posit.co/articles/layout-guide.html) for additional details on laying out fixed
 #'   pages.
 #'
 #' @family layout functions

--- a/R/bootstrap-layout.R
+++ b/R/bootstrap-layout.R
@@ -538,9 +538,8 @@ splitLayout <- function(..., cellWidths = NULL, cellArgs = list()) {
 #'
 #' Creates row and column layouts with proportionally-sized cells, using the
 #' Flex Box layout model of CSS3. These can be nested to create arbitrary
-#' proportional-grid layouts. **Warning:** Flex Box is not well supported
-#' by Internet Explorer, so these functions should only be used where modern
-#' browsers can be assumed.
+#' proportional-grid layouts. **Note:** These functions require a browser with
+#' flexbox support.
 #'
 #' @details If you try to use `fillRow` and `fillCol` inside of other
 #'   Shiny containers, such as [sidebarLayout()],

--- a/R/fileupload.R
+++ b/R/fileupload.R
@@ -1,4 +1,4 @@
-# For HTML5-capable browsers, file uploads happen through a series of requests.
+# File uploads happen through a series of requests.
 #
 # 1. Client tells server that one or more files are about to be uploaded; the
 #    server responds with a "job ID" that the client should use for the rest of
@@ -16,7 +16,7 @@
 #    input ID that this data should be associated with.
 #
 # Unfortunately this approach will not work for browsers that don't support
-# HTML5 File API, but the fallback approach we would like to use (multipart
+# the File API, but the fallback approach we would like to use (multipart
 # form upload, i.e. traditional HTTP POST-based file upload) doesn't work with
 # the websockets package's HTTP server at the moment.
 

--- a/R/input-file.R
+++ b/R/input-file.R
@@ -14,8 +14,8 @@
 #'
 #' @inheritParams textInput
 #' @param multiple Whether the user should be allowed to select and upload
-#'   multiple files at once. **Does not work on older browsers, including
-#'   Internet Explorer 9 and earlier.**
+#'   multiple files at once. Support for selecting multiple files depends on
+#'   the browser's support for the HTML `multiple` attribute on file inputs.
 #' @param accept A character vector of "unique file type specifiers" which gives
 #'   the browser a hint as to the type of file the server expects. Many browsers
 #'   use this prevent the user from selecting an invalid file.

--- a/R/input-select.R
+++ b/R/input-select.R
@@ -13,9 +13,9 @@
 #' `selectInput("letter", "Letter", c("Choose one" = "", LETTERS))`
 #'
 #' **Performance note:** `selectInput()` and `selectizeInput()` can slow down
-#' significantly when thousands of choices are used; with legacy browsers like
-#' Internet Explorer, the user interface may hang for many seconds. For large
-#' numbers of choices, Shiny offers a "server-side selectize" option that
+#' significantly when thousands of choices are used, and the user interface may
+#' hang for many seconds. For large numbers of choices, Shiny offers a
+#' "server-side selectize" option that
 #' massively improves performance and efficiency; see
 #' [this selectize article](https://shiny.rstudio.com/articles/selectize.html)
 #' on the Shiny Dev Center for details.

--- a/R/input-select.R
+++ b/R/input-select.R
@@ -17,7 +17,7 @@
 #' hang for many seconds. For large numbers of choices, Shiny offers a
 #' "server-side selectize" option that
 #' massively improves performance and efficiency; see
-#' [this selectize article](https://shiny.rstudio.com/articles/selectize.html)
+#' [this selectize article](https://shiny.posit.co/articles/selectize.html)
 #' on the Shiny Dev Center for details.
 #'
 #' @inheritParams textInput

--- a/R/input-submit.R
+++ b/R/input-submit.R
@@ -10,7 +10,7 @@
 #' [actionButton()] instead of `submitButton` when you
 #' want to delay a reaction.
 #' See [this
-#' article](https://shiny.rstudio.com/articles/action-buttons.html) for more information (including a demo of how to "translate"
+#' article](https://shiny.posit.co/articles/action-buttons.html) for more information (including a demo of how to "translate"
 #' code using a `submitButton` to code using an `actionButton`).
 #'
 #' In essence, the presence of a submit button stops all inputs from

--- a/R/input-text.R
+++ b/R/input-text.R
@@ -8,8 +8,7 @@
 #' @param width The width of the input, e.g. `'400px'`, or `'100%'`;
 #'   see [validateCssUnit()].
 #' @param placeholder A character string giving the user a hint as to what can
-#'   be entered into the control. Internet Explorer 8 and 9 do not support this
-#'   option.
+#'   be entered into the control.
 #' @param ... Ignored, included to require named arguments and for future
 #'   feature expansion.
 #' @param updateOn A character vector specifying when the input should be

--- a/R/middleware.R
+++ b/R/middleware.R
@@ -39,8 +39,8 @@ httpResponse <- function(status = 200L,
                          headers = list()) {
   # Make sure it's a list, not a vector
   headers <- as.list(headers)
-  if (is.null(headers$`X-UA-Compatible`))
-    headers$`X-UA-Compatible` <- "IE=edge,chrome=1"
+  if (is.null(headers$`X-Content-Type-Options`))
+    headers$`X-Content-Type-Options` <- "nosniff"
   resp <- list(status = status, content_type = content_type, content = content,
                headers = headers)
   class(resp) <- 'httpResponse'

--- a/R/modules.R
+++ b/R/modules.R
@@ -66,7 +66,7 @@ find_ancestor_session <- function(x, depth = 20) {
 #' Shiny's module feature lets you break complicated UI and server logic into
 #' smaller, self-contained pieces. Compared to large monolithic Shiny apps,
 #' modules are easier to reuse and easier to reason about. See the article at
-#' <https://shiny.rstudio.com/articles/modules.html> to learn more.
+#' <https://shiny.posit.co/articles/modules.html> to learn more.
 #'
 #' Starting in Shiny 1.5.0, we recommend using `moduleServer` instead of
 #' [`callModule()`], because the syntax is a little easier
@@ -80,7 +80,7 @@ find_ancestor_session <- function(x, depth = 20) {
 #'   almost always be used).
 #'
 #' @return The return value, if any, from executing the module server function
-#' @seealso <https://shiny.rstudio.com/articles/modules.html>
+#' @seealso <https://shiny.posit.co/articles/modules.html>
 #'
 #' @examples
 #' # Define the UI for a module

--- a/R/reactives.R
+++ b/R/reactives.R
@@ -1061,7 +1061,7 @@ Observable <- R6Class(
 #' marked as invalidated. In this way, invalidations ripple through the
 #' expressions that depend on each other.
 #'
-#' See the [Shiny tutorial](https://shiny.rstudio.com/tutorial/) for
+#' See the [Shiny tutorial](https://shiny.posit.co/tutorial/) for
 #' more information about reactive expressions.
 #'
 #' @param x For `is.reactive()`, an object to test. For `reactive()`, an

--- a/R/server.R
+++ b/R/server.R
@@ -54,7 +54,7 @@ registerClient <- function(client) {
 #' optional `session` parameter, which is used when greater control is
 #' needed.
 #'
-#' See the [tutorial](https://shiny.rstudio.com/tutorial/) for more
+#' See the [tutorial](https://shiny.posit.co/tutorial/) for more
 #' on how to write a server function.
 #'
 #' @param func The server function for this application. See the details section

--- a/R/server.R
+++ b/R/server.R
@@ -39,10 +39,9 @@ registerClient <- function(client) {
 #' @description Defines the server-side logic of the Shiny application. This generally
 #' involves creating functions that map user inputs to various kinds of output.
 #' In older versions of Shiny, it was necessary to call `shinyServer()` in
-#' the `server.R` file, but this is no longer required as of Shiny 0.10.
-#' Now the `server.R` file may simply return the appropriate server
-#' function (as the last expression in the code), without calling
-#' `shinyServer()`.
+#' the `server.R` file, but this is no longer required. The `server.R` file
+#' may simply return the appropriate server function as the last expression
+#' in the code, without calling `shinyServer()`.
 #'
 #' Call `shinyServer` from your application's `server.R`
 #' file, passing in a "server function" that provides the server-side logic of

--- a/R/server.R
+++ b/R/server.R
@@ -446,7 +446,7 @@ startHttpuvApp <- function(appObj, port, host, quiet) {
 
   httpuvApp$staticPathOptions <- httpuv::staticPathOptions(
     html_charset = "utf-8",
-    headers = list("X-UA-Compatible" = "IE=edge,chrome=1"),
+    headers = list("X-Content-Type-Options" = "nosniff"),
     validation =
       if (!is.null(getOption("shiny.sharedSecret"))) {
         sprintf('"Shiny-Shared-Secret" == "%s"', getOption("shiny.sharedSecret"))

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -8,7 +8,7 @@ NULL
 #' prebuilt widgets make it possible to build beautiful, responsive, and
 #' powerful applications with minimal effort.
 #'
-#' The Shiny tutorial at <https://shiny.rstudio.com/tutorial/> explains
+#' The Shiny tutorial at <https://shiny.posit.co/tutorial/> explains
 #' the framework in depth, walks you through building a simple application, and
 #' includes extensive annotated examples.
 #'
@@ -293,7 +293,7 @@ NULL
 #'
 #' The `NS` function creates namespaced IDs out of bare IDs, by joining
 #' them using `ns.sep` as the delimiter. It is intended for use in Shiny
-#' modules. See <https://shiny.rstudio.com/articles/modules.html>.
+#' modules. See <https://shiny.posit.co/articles/modules.html>.
 #'
 #' Shiny applications use IDs to identify inputs and outputs. These IDs must be
 #' unique within an application, as accidentally using the same input/output ID
@@ -310,7 +310,7 @@ NULL
 #' @param id The id string to be namespaced (optional).
 #' @return If `id` is missing, returns a function that expects an id string
 #'   as its only argument and returns that id with the namespace prepended.
-#' @seealso <https://shiny.rstudio.com/articles/modules.html>
+#' @seealso <https://shiny.posit.co/articles/modules.html>
 #' @export
 NS <- function(namespace, id = NULL) {
   if (length(namespace) == 0)

--- a/R/shinyui.R
+++ b/R/shinyui.R
@@ -173,8 +173,8 @@ shinyDependencyCSS <- function(theme) {
 #' @description `r lifecycle::badge("superseded")`
 #'
 #' @description Historically this function was used in ui.R files to register a user
-#' interface with Shiny. It is no longer required as of Shiny 0.10; simply
-#' ensure that the last expression to be returned from ui.R is a user interface.
+#' interface with Shiny. It is no longer required; simply ensure that the last
+#' expression returned from ui.R is a user interface.
 #' This function is kept for backwards compatibility with older applications. It
 #' returns the value that is passed to it.
 #'

--- a/R/utils.R
+++ b/R/utils.R
@@ -1340,7 +1340,7 @@ checkEncoding <- function(file) {
   if (identical(charToRaw(readChar(file, 3L, TRUE)), charToRaw('\UFEFF'))) {
     warning('You should not include the Byte Order Mark (BOM) in ', file, '. ',
             'Please re-save it in UTF-8 without BOM. See ',
-            'https://shiny.rstudio.com/articles/unicode.html for more info.')
+            'https://shiny.posit.co/articles/unicode.html for more info.')
     return('UTF-8-BOM')
   }
   x <- readChar(file, size, useBytes = TRUE)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Easily build rich and productive interactive web apps in R &mdash; no HTML/CSS/J
 * A prebuilt set of highly sophisticated, customizable, and easy-to-use widgets (e.g., plots, tables, sliders, dropdowns, date pickers, and more).
 * An attractive default look based on [Bootstrap](https://getbootstrap.com/) which can also be easily customized with the [bslib](https://github.com/rstudio/bslib) package or avoided entirely with more direct R bindings to HTML/CSS/JavaScript.
 * Seamless integration with [R Markdown](https://shiny.rstudio.com/articles/interactive-docs.html), making it easy to embed numerous applications natively within a larger dynamic document.
-* Tools for improving and monitoring performance, including native support for [async programming](https://posit.co/blog/shiny-1-1-0/), [caching](https://talks.cpsievert.me/20201117), [load testing](https://rstudio.github.io/shinyloadtest/), and more.
+* Tools for improving and monitoring performance, including native support for [async programming](https://posit.co/blog/shiny-1-1-0), [caching](https://talks.cpsievert.me/20201117), [load testing](https://rstudio.github.io/shinyloadtest/), and more.
 * [Modules](https://shiny.rstudio.com/articles/modules.html): a framework for reducing code duplication and complexity.
 * An ability to [bookmark application state](https://shiny.rstudio.com/articles/bookmarking-state.html) and/or [generate code to reproduce output(s)](https://github.com/rstudio/shinymeta).
 * A rich ecosystem of extension packages for more [custom widgets](http://www.htmlwidgets.org/), [input validation](https://github.com/rstudio/shinyvalidate), [unit testing](https://github.com/rstudio/shinytest), and more.

--- a/man/NS.Rd
+++ b/man/NS.Rd
@@ -25,7 +25,7 @@ as its only argument and returns that id with the namespace prepended.
 \description{
 The \code{NS} function creates namespaced IDs out of bare IDs, by joining
 them using \code{ns.sep} as the delimiter. It is intended for use in Shiny
-modules. See \url{https://shiny.rstudio.com/articles/modules.html}.
+modules. See \url{https://shiny.posit.co/articles/modules.html}.
 }
 \details{
 Shiny applications use IDs to identify inputs and outputs. These IDs must be
@@ -36,5 +36,5 @@ as a directory is to a file. Use the \code{NS} function to turn a bare ID
 into a namespaced one, by combining them with \code{ns.sep} in between.
 }
 \seealso{
-\url{https://shiny.rstudio.com/articles/modules.html}
+\url{https://shiny.posit.co/articles/modules.html}
 }

--- a/man/fileInput.Rd
+++ b/man/fileInput.Rd
@@ -21,8 +21,8 @@ fileInput(
 \item{label}{Display label for the control, or \code{NULL} for no label.}
 
 \item{multiple}{Whether the user should be allowed to select and upload
-multiple files at once. \strong{Does not work on older browsers, including
-Internet Explorer 9 and earlier.}}
+multiple files at once. Support for selecting multiple files depends on
+the browser's support for the HTML \code{multiple} attribute on file inputs.}
 
 \item{accept}{A character vector of "unique file type specifiers" which gives
 the browser a hint as to the type of file the server expects. Many browsers

--- a/man/fillRow.Rd
+++ b/man/fillRow.Rd
@@ -32,9 +32,8 @@ not determined by the height of its contents.}
 \description{
 Creates row and column layouts with proportionally-sized cells, using the
 Flex Box layout model of CSS3. These can be nested to create arbitrary
-proportional-grid layouts. \strong{Warning:} Flex Box is not well supported
-by Internet Explorer, so these functions should only be used where modern
-browsers can be assumed.
+proportional-grid layouts. \strong{Note:} These functions require a browser with
+flexbox support.
 }
 \details{
 If you try to use \code{fillRow} and \code{fillCol} inside of other

--- a/man/fixedPage.Rd
+++ b/man/fixedPage.Rd
@@ -47,7 +47,7 @@ layout functions like \code{sidebarLayout}, rather, all layout must be done
 with \code{fixedRow} and \code{column}.
 }
 \note{
-See the \href{https://shiny.rstudio.com/articles/layout-guide.html}{ Shiny Application Layout Guide} for additional details on laying out fixed
+See the \href{https://shiny.posit.co/articles/layout-guide.html}{ Shiny Application Layout Guide} for additional details on laying out fixed
 pages.
 }
 \examples{

--- a/man/fluidPage.Rd
+++ b/man/fluidPage.Rd
@@ -46,7 +46,7 @@ alternative to low-level row and column functions you can also use
 higher-level layout functions like \code{\link[=sidebarLayout]{sidebarLayout()}}.
 }
 \note{
-See the \href{https://shiny.rstudio.com/articles/layout-guide.html}{ Shiny-Application-Layout-Guide} for additional details on laying out fluid
+See the \href{https://shiny.posit.co/articles/layout-guide.html}{ Shiny-Application-Layout-Guide} for additional details on laying out fluid
 pages.
 }
 \examples{

--- a/man/moduleServer.Rd
+++ b/man/moduleServer.Rd
@@ -22,7 +22,7 @@ The return value, if any, from executing the module server function
 Shiny's module feature lets you break complicated UI and server logic into
 smaller, self-contained pieces. Compared to large monolithic Shiny apps,
 modules are easier to reuse and easier to reason about. See the article at
-\url{https://shiny.rstudio.com/articles/modules.html} to learn more.
+\url{https://shiny.posit.co/articles/modules.html} to learn more.
 }
 \details{
 Starting in Shiny 1.5.0, we recommend using \code{moduleServer} instead of
@@ -103,5 +103,5 @@ if (interactive()) {
 
 }
 \seealso{
-\url{https://shiny.rstudio.com/articles/modules.html}
+\url{https://shiny.posit.co/articles/modules.html}
 }

--- a/man/passwordInput.Rd
+++ b/man/passwordInput.Rd
@@ -25,8 +25,7 @@ passwordInput(
 see \code{\link[=validateCssUnit]{validateCssUnit()}}.}
 
 \item{placeholder}{A character string giving the user a hint as to what can
-be entered into the control. Internet Explorer 8 and 9 do not support this
-option.}
+be entered into the control.}
 
 \item{...}{Ignored, included to require named arguments and for future
 feature expansion.}

--- a/man/reactive.Rd
+++ b/man/reactive.Rd
@@ -58,7 +58,7 @@ invalidated, any other reactive expressions that recently called it are also
 marked as invalidated. In this way, invalidations ripple through the
 expressions that depend on each other.
 
-See the \href{https://shiny.rstudio.com/tutorial/}{Shiny tutorial} for
+See the \href{https://shiny.posit.co/tutorial/}{Shiny tutorial} for
 more information about reactive expressions.
 }
 \examples{

--- a/man/selectInput.Rd
+++ b/man/selectInput.Rd
@@ -71,9 +71,9 @@ name will be treated as a placeholder prompt. For example:
 \code{selectInput("letter", "Letter", c("Choose one" = "", LETTERS))}
 
 \strong{Performance note:} \code{selectInput()} and \code{selectizeInput()} can slow down
-significantly when thousands of choices are used; with legacy browsers like
-Internet Explorer, the user interface may hang for many seconds. For large
-numbers of choices, Shiny offers a "server-side selectize" option that
+significantly when thousands of choices are used, and the user interface may
+hang for many seconds. For large numbers of choices, Shiny offers a
+"server-side selectize" option that
 massively improves performance and efficiency; see
 \href{https://shiny.rstudio.com/articles/selectize.html}{this selectize article}
 on the Shiny Dev Center for details.

--- a/man/selectInput.Rd
+++ b/man/selectInput.Rd
@@ -75,7 +75,7 @@ significantly when thousands of choices are used, and the user interface may
 hang for many seconds. For large numbers of choices, Shiny offers a
 "server-side selectize" option that
 massively improves performance and efficiency; see
-\href{https://shiny.rstudio.com/articles/selectize.html}{this selectize article}
+\href{https://shiny.posit.co/articles/selectize.html}{this selectize article}
 on the Shiny Dev Center for details.
 }
 \note{

--- a/man/shiny-package.Rd
+++ b/man/shiny-package.Rd
@@ -12,7 +12,7 @@ prebuilt widgets make it possible to build beautiful, responsive, and
 powerful applications with minimal effort.
 }
 \details{
-The Shiny tutorial at \url{https://shiny.rstudio.com/tutorial/} explains
+The Shiny tutorial at \url{https://shiny.posit.co/tutorial/} explains
 the framework in depth, walks you through building a simple application, and
 includes extensive annotated examples.
 }

--- a/man/shinyServer.Rd
+++ b/man/shinyServer.Rd
@@ -16,10 +16,9 @@ for more information.}
 Defines the server-side logic of the Shiny application. This generally
 involves creating functions that map user inputs to various kinds of output.
 In older versions of Shiny, it was necessary to call \code{shinyServer()} in
-the \code{server.R} file, but this is no longer required as of Shiny 0.10.
-Now the \code{server.R} file may simply return the appropriate server
-function (as the last expression in the code), without calling
-\code{shinyServer()}.
+the \code{server.R} file, but this is no longer required. The \code{server.R} file
+may simply return the appropriate server function as the last expression
+in the code, without calling \code{shinyServer()}.
 
 Call \code{shinyServer} from your application's \code{server.R}
 file, passing in a "server function" that provides the server-side logic of
@@ -31,7 +30,7 @@ the Shiny application's page. It must take an \code{input} and an
 optional \code{session} parameter, which is used when greater control is
 needed.
 
-See the \href{https://shiny.rstudio.com/tutorial/}{tutorial} for more
+See the \href{https://shiny.posit.co/tutorial/}{tutorial} for more
 on how to write a server function.
 }
 \examples{

--- a/man/shinyUI.Rd
+++ b/man/shinyUI.Rd
@@ -16,8 +16,8 @@ The user interface definition, without modifications or side effects.
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#superseded}{\figure{lifecycle-superseded.svg}{options: alt='[Superseded]'}}}{\strong{[Superseded]}}
 
 Historically this function was used in ui.R files to register a user
-interface with Shiny. It is no longer required as of Shiny 0.10; simply
-ensure that the last expression to be returned from ui.R is a user interface.
+interface with Shiny. It is no longer required; simply ensure that the last
+expression returned from ui.R is a user interface.
 This function is kept for backwards compatibility with older applications. It
 returns the value that is passed to it.
 }

--- a/man/submitButton.Rd
+++ b/man/submitButton.Rd
@@ -28,7 +28,7 @@ the more versatile \code{\link[=actionButton]{actionButton()}} (see details belo
 Submit buttons are unusual Shiny inputs, and we recommend using
 \code{\link[=actionButton]{actionButton()}} instead of \code{submitButton} when you
 want to delay a reaction.
-See \href{https://shiny.rstudio.com/articles/action-buttons.html}{this article} for more information (including a demo of how to "translate"
+See \href{https://shiny.posit.co/articles/action-buttons.html}{this article} for more information (including a demo of how to "translate"
 code using a \code{submitButton} to code using an \code{actionButton}).
 
 In essence, the presence of a submit button stops all inputs from

--- a/man/textAreaInput.Rd
+++ b/man/textAreaInput.Rd
@@ -43,8 +43,7 @@ If the \code{height} argument is specified, \code{height} will take precedence i
 browser's rendering.}
 
 \item{placeholder}{A character string giving the user a hint as to what can
-be entered into the control. Internet Explorer 8 and 9 do not support this
-option.}
+be entered into the control.}
 
 \item{resize}{Which directions the textarea box can be resized. Can be one of
 \code{"both"}, \code{"none"}, \code{"vertical"}, and \code{"horizontal"}. The default, \code{NULL},

--- a/man/textInput.Rd
+++ b/man/textInput.Rd
@@ -25,8 +25,7 @@ textInput(
 see \code{\link[=validateCssUnit]{validateCssUnit()}}.}
 
 \item{placeholder}{A character string giving the user a hint as to what can
-be entered into the control. Internet Explorer 8 and 9 do not support this
-option.}
+be entered into the control.}
 
 \item{...}{Ignored, included to require named arguments and for future
 feature expansion.}

--- a/man/updateQueryString.Rd
+++ b/man/updateQueryString.Rd
@@ -38,8 +38,8 @@ For \code{mode = "push"}, only three updates are currently allowed:
 In other words, if \code{mode = "push"}, the \code{queryString} must start
 with either \verb{?} or with \verb{#}.
 
-A technical curiosity: under the hood, this function is calling the HTML5
-history API (which is where the names for the \code{mode} argument come from).
+A technical curiosity: under the hood, this function is calling the History
+API (which is where the names for the \code{mode} argument come from).
 When \code{mode = "replace"}, the function called is
 \code{window.history.replaceState(null, null, queryString)}.
 When \code{mode = "push"}, the function called is

--- a/man/updateQueryString.Rd
+++ b/man/updateQueryString.Rd
@@ -23,8 +23,8 @@ the browser's back and forward buttons. See Examples.}
 }
 \description{
 This function updates the client browser's query string in the location bar.
-It typically is called from an observer. Note that this will not work in
-Internet Explorer 9 and below.
+It typically is called from an observer. Note that this requires a browser
+with History API support (\code{history.pushState} / \code{history.replaceState}).
 }
 \details{
 For \code{mode = "push"}, only three updates are currently allowed:

--- a/man/updateTextAreaInput.Rd
+++ b/man/updateTextAreaInput.Rd
@@ -23,8 +23,7 @@ updateTextAreaInput(
 \item{value}{Initial value.}
 
 \item{placeholder}{A character string giving the user a hint as to what can
-be entered into the control. Internet Explorer 8 and 9 do not support this
-option.}
+be entered into the control.}
 }
 \description{
 Change the value of a textarea input on the client

--- a/man/updateTextInput.Rd
+++ b/man/updateTextInput.Rd
@@ -23,8 +23,7 @@ updateTextInput(
 \item{value}{Initial value.}
 
 \item{placeholder}{A character string giving the user a hint as to what can
-be entered into the control. Internet Explorer 8 and 9 do not support this
-option.}
+be entered into the control.}
 }
 \description{
 Change the value of a text input on the client


### PR DESCRIPTION
Fixes #4384

## Summary

- Removes all IE 8/9-specific caveats from roxygen comments, replacing them with browser-agnostic or standards-based language across five source files (`R/input-text.R`, `R/input-file.R`, `R/bookmark-state.R`, `R/bootstrap-layout.R`, `R/input-select.R`). The `placeholder` IE note was shared across five `.Rd` files via a single roxygen param in `R/input-text.R`.
- Updates 12 `shiny.rstudio.com` article and tutorial URLs to `shiny.posit.co` across eight source files.
- Removes the stale "as of Shiny 0.10" phrasing from the `shinyUI()` and `shinyServer()` deprecation notes.
- Replaces the obsolete `X-UA-Compatible: IE=edge,chrome=1` HTTP response header with `X-Content-Type-Options: nosniff` in `R/middleware.R` and `R/server.R`. The old header targeted IE's rendering engine and the defunct Chrome Frame plugin; the new header prevents MIME-type sniffing and is a current security best practice.
- Modernizes "HTML5 File API" and "HTML5 history API" terminology to "File API" and "History API", matching the WHATWG living standard naming convention.
- Removes trailing slashes from two blog post URLs in `NEWS.md` and `README.md` (via `urlchecker::url_update()`).
- Regenerates all affected `.Rd` files.