### PR TITLE
Fix: helpful error from `need()` when `message` and `label` are missing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,8 @@
 
 * Loading shiny no longer creates `.Random.seed` in the global environment as a side effect. (#4382)
 
+* `need()` now gives a clearer error when called without either a `message` or `label` argument, instead of the cryptic "argument \"label\" is missing, with no default". (thanks @chasemc, #2509)
+
 # shiny 1.13.0
 
 ## New features

--- a/R/utils.R
+++ b/R/utils.R
@@ -1064,7 +1064,9 @@ validate <- function(..., errorClass = character(0)) {
 need <- function(expr, message = paste(label, "must be provided"), label) {
 
   if (missing(message) && missing(label)) {
-    stop("`need()` requires either a `message` or `label` argument.", call. = FALSE)
+    cli::cli_abort(
+      "{.fn need} requires either a {.arg message} or {.arg label} argument."
+    )
   }
   force(message) # Fail fast in case `label` is missing but referenced via `message`
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1063,7 +1063,10 @@ validate <- function(..., errorClass = character(0)) {
 #' @rdname validate
 need <- function(expr, message = paste(label, "must be provided"), label) {
 
-  force(message) # Fail fast on message/label both being missing
+  if (missing(message) && missing(label)) {
+    stop("`need()` requires either a `message` or `label` argument.", call. = FALSE)
+  }
+  force(message) # Fail fast in case `label` is missing but referenced via `message`
 
   if (!isTruthy(expr))
     return(message)

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -106,7 +106,6 @@ test_that("need() works as expected", {
   expect_null(need(TRUE, FALSE))
   expect_null(need(c(NA, NA, TRUE), FALSE))
   expect_null(need(c(FALSE, FALSE, TRUE), FALSE))
-
 })
 
 test_that("need() message/label handling (#2509)", {
@@ -114,11 +113,13 @@ test_that("need() message/label handling (#2509)", {
   # whether `expr` is truthy or falsy (the message default is evaluated eagerly).
   expect_error(
     need(1 + 1),
-    "`need\\(\\)` requires either a `message` or `label` argument"
+    "`need()` requires either a `message` or `label` argument",
+    fixed = TRUE
   )
   expect_error(
     need(NULL),
-    "`need\\(\\)` requires either a `message` or `label` argument"
+    "`need()` requires either a `message` or `label` argument",
+    fixed = TRUE
   )
 
   # `label` alone: default message is built from `label`

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -106,6 +106,38 @@ test_that("need() works as expected", {
   expect_null(need(TRUE, FALSE))
   expect_null(need(c(NA, NA, TRUE), FALSE))
   expect_null(need(c(FALSE, FALSE, TRUE), FALSE))
+
+})
+
+test_that("need() message/label handling (#2509)", {
+  # Errors clearly when both `message` and `label` are missing, regardless of
+  # whether `expr` is truthy or falsy (the message default is evaluated eagerly).
+  expect_error(
+    need(1 + 1),
+    "`need\\(\\)` requires either a `message` or `label` argument"
+  )
+  expect_error(
+    need(NULL),
+    "`need\\(\\)` requires either a `message` or `label` argument"
+  )
+
+  # `label` alone: default message is built from `label`
+  expect_identical(need(NULL, label = "input$x"), "input$x must be provided")
+  expect_null(need(1, label = "input$x"))
+
+  # `message` alone: used verbatim, no `label` needed
+  expect_identical(need(NULL, message = "custom message"), "custom message")
+  expect_null(need(1, message = "custom message"))
+
+  # `message = FALSE` is a documented "fail with no message" mode, and must
+  # work without a `label`
+  expect_false(need(NULL, FALSE))
+
+  # When both are provided, `message` wins (no reference to `label`)
+  expect_identical(
+    need(NULL, message = "explicit", label = "ignored"),
+    "explicit"
+  )
 })
 
 test_that("req works", {


### PR DESCRIPTION
Closes #2509

## Summary

`shiny::need(expr)` called without either a `message` or `label` argument previously failed with the cryptic `argument "label" is missing, with no default`, raised from inside the default-argument expression `paste(label, "must be provided")`. This PR adds an explicit `missing(message) && missing(label)` check at the top of `need()` so the failure now says `` `need()` requires either a `message` or `label` argument. ``

## Verification

```r
shiny::need(1 + 1)
#> Error: `need()` requires either a `message` or `label` argument.

shiny::need(NULL, label = "input$x")
#> [1] "input$x must be provided"

shiny::need(NULL, "custom message")
#> [1] "custom message"
```

Tests in `tests/testthat/test-utils.R` exercise the new error path alongside the existing `label`-only, `message`-only, `message = FALSE`, and both-provided cases.