### PR TITLE
Docs: thank @sundrelingam for need() fix in NEWS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,7 +34,7 @@
 
 * Loading shiny no longer creates `.Random.seed` in the global environment as a side effect. (#4382)
 
-* `need()` now gives a clearer error when called without either a `message` or `label` argument, instead of the cryptic "argument \"label\" is missing, with no default". (thanks @chasemc, #2509)
+* `need()` now gives a clearer error when called without either a `message` or `label` argument, instead of the cryptic "argument \"label\" is missing, with no default". (thanks @chasemc and @sundrelingam, #2509)
 
 # shiny 1.13.0
 


### PR DESCRIPTION
## Summary

- Add `@sundrelingam` alongside `@chasemc` to the NEWS entry for the `need()` clearer-error bug fix (#4386, originally #2509).

## Test plan

- [x] NEWS.md cadence matches other multi-contributor entries (`thanks @user1 and @user2, #NNNN`)