### PR TITLE
Improve error messages for missing required input arguments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,11 @@
 
 * Updated default HTTP headers for better security. Shiny now sends `X-Content-Type-Options: nosniff` instead of the legacy `X-UA-Compatible` header. This removes outdated Internet Explorer–specific behavior and adds a modern safeguard that prevents browsers from misinterpreting file types. (#4385)
 
+* Input constructors (e.g., `textInput()`, `sliderInput()`, `selectInput()`,
+  `actionButton()`) now report which function and which argument were missing
+  when a required argument is omitted, rather than surfacing a downstream
+  message like `argument "label" is missing, with no default`. (#1423)
+
 ## Bug fixes
 
 * Loading shiny no longer creates `.Random.seed` in the global environment as a side effect. (#4382)

--- a/NEWS.md
+++ b/NEWS.md
@@ -33,7 +33,8 @@
 * Input constructors (e.g., `textInput()`, `sliderInput()`, `selectInput()`,
   `actionButton()`) now report which function and which argument were missing
   when a required argument is omitted, rather than surfacing a downstream
-  message like `argument "label" is missing, with no default`. (#1423)
+  message like `argument "label" is missing, with no default`.
+  (thanks @daattali, #1423)
 
 ## Bug fixes
 

--- a/R/input-action.R
+++ b/R/input-action.R
@@ -54,6 +54,8 @@
 actionButton <- function(inputId, label, icon = NULL, width = NULL,
   disabled = FALSE, ...) {
 
+  check_required(inputId, label)
+
   value <- restoreInput(id = inputId, default = NULL)
 
   icon <- validateIcon(icon)
@@ -82,6 +84,8 @@ actionButton <- function(inputId, label, icon = NULL, width = NULL,
 #' @rdname actionButton
 #' @export
 actionLink <- function(inputId, label, icon = NULL, ...) {
+  check_required(inputId, label)
+
   value <- restoreInput(id = inputId, default = NULL)
 
   icon <- validateIcon(icon)

--- a/R/input-checkbox.R
+++ b/R/input-checkbox.R
@@ -29,6 +29,8 @@
 #' @export
 checkboxInput <- function(inputId, label, value = FALSE, width = NULL) {
 
+  check_required(inputId, label)
+
   value <- restoreInput(id = inputId, default = value)
 
   inputTag <- tags$input(id = inputId, type="checkbox", class = "shiny-input-checkbox")

--- a/R/input-checkboxgroup.R
+++ b/R/input-checkboxgroup.R
@@ -74,6 +74,8 @@
 checkboxGroupInput <- function(inputId, label, choices = NULL, selected = NULL,
   inline = FALSE, width = NULL, choiceNames = NULL, choiceValues = NULL) {
 
+  check_required(inputId, label)
+
   # keep backward compatibility with Shiny < 1.0.1 (see #1649)
   if (is.null(choices) && is.null(choiceNames) && is.null(choiceValues)) {
     choices <- character(0)

--- a/R/input-date.R
+++ b/R/input-date.R
@@ -96,6 +96,8 @@ dateInput <- function(inputId, label, value = NULL, min = NULL, max = NULL,
   language = "en", width = NULL, autoclose = TRUE,
   datesdisabled = NULL, daysofweekdisabled = NULL) {
 
+  check_required(inputId, label)
+
   value <- dateYMD(value, "value")
   min <- dateYMD(min, "min")
   max <- dateYMD(max, "max")

--- a/R/input-daterange.R
+++ b/R/input-daterange.R
@@ -80,6 +80,8 @@ dateRangeInput <- function(inputId, label, start = NULL, end = NULL,
     weekstart = 0, language = "en", separator = " to ", width = NULL,
     autoclose = TRUE) {
 
+  check_required(inputId, label)
+
   start <- dateYMD(start, "start")
   end   <- dateYMD(end, "end")
   min   <- dateYMD(min, "min")

--- a/R/input-file.R
+++ b/R/input-file.R
@@ -94,6 +94,8 @@ fileInput <- function(inputId, label, multiple = FALSE, accept = NULL,
   width = NULL, buttonLabel = "Browse...", placeholder = "No file selected",
   capture = NULL) {
 
+  check_required(inputId, label)
+
   restoredValue <- restoreInput(id = inputId, default = NULL)
 
   # Catch potential edge case - ensure that it's either NULL or a data frame.

--- a/R/input-numeric.R
+++ b/R/input-numeric.R
@@ -43,6 +43,8 @@ numericInput <- function(
   rlang::check_dots_empty()
   updateOn <- rlang::arg_match(updateOn)
 
+  check_required(inputId, label, value)
+
   value <- restoreInput(id = inputId, default = value)
 
   # build input tag

--- a/R/input-password.R
+++ b/R/input-password.R
@@ -42,6 +42,8 @@ passwordInput <- function(
   rlang::check_dots_empty()
   updateOn <- rlang::arg_match(updateOn)
 
+  check_required(inputId, label)
+
   div(
     class = "form-group shiny-input-container",
     style = css(width = validateCssUnit(width)),

--- a/R/input-radiobuttons.R
+++ b/R/input-radiobuttons.R
@@ -89,6 +89,8 @@
 radioButtons <- function(inputId, label, choices = NULL, selected = NULL,
   inline = FALSE, width = NULL, choiceNames = NULL, choiceValues = NULL) {
 
+  check_required(inputId, label)
+
   args <- normalizeChoicesArgs(choices, choiceNames, choiceValues)
 
   selected <- restoreInput(id = inputId, default = selected)

--- a/R/input-select.R
+++ b/R/input-select.R
@@ -89,6 +89,8 @@ selectInput <- function(inputId, label, choices, selected = NULL,
   multiple = FALSE, selectize = TRUE, width = NULL,
   size = NULL) {
 
+  check_required(inputId, label, choices)
+
   selected <- restoreInput(id = inputId, default = selected)
 
   # resolve names
@@ -367,6 +369,8 @@ varSelectInput <- function(
   multiple = FALSE, selectize = TRUE, width = NULL,
   size = NULL
 ) {
+  check_required(inputId, label, data)
+
   # no place holders
   choices <- colnames(data)
 

--- a/R/input-select.R
+++ b/R/input-select.R
@@ -37,6 +37,11 @@
 #'   will result in a taller box. Not compatible with `selectize=TRUE`.
 #'   Normally, when `multiple=FALSE`, a select input will be a drop-down list,
 #'   but when `size` is set, it will be a box instead.
+#' @param error_call Used internally to produce error messages that point at
+#'   the function the user called. Wrapper functions (e.g. [selectizeInput()]
+#'   and [varSelectizeInput()]) pass their own environment so that errors
+#'   about missing required arguments are attributed to the wrapper rather
+#'   than the inner constructor. You should not normally need to set this.
 #' @return A select list control that can be added to a UI definition.
 #'
 #' @family input elements
@@ -87,9 +92,9 @@
 #' @export
 selectInput <- function(inputId, label, choices, selected = NULL,
   multiple = FALSE, selectize = TRUE, width = NULL,
-  size = NULL) {
+  size = NULL, error_call = environment()) {
 
-  check_required(inputId, label, choices)
+  check_required(inputId, label, choices, call = error_call)
 
   selected <- restoreInput(id = inputId, default = selected)
 
@@ -193,7 +198,8 @@ needOptgroup <- function(choices) {
 selectizeInput <- function(inputId, ..., options = NULL, width = NULL) {
   selectizeIt(
     inputId,
-    selectInput(inputId, ..., selectize = FALSE, width = width),
+    selectInput(inputId, ..., selectize = FALSE, width = width,
+      error_call = environment()),
     options
   )
 }
@@ -367,9 +373,9 @@ selectizeScripts <- function() {
 varSelectInput <- function(
   inputId, label, data, selected = NULL,
   multiple = FALSE, selectize = TRUE, width = NULL,
-  size = NULL
+  size = NULL, error_call = environment()
 ) {
-  check_required(inputId, label, data)
+  check_required(inputId, label, data, call = error_call)
 
   # no place holders
   choices <- colnames(data)
@@ -419,7 +425,8 @@ varSelectInput <- function(
 varSelectizeInput <- function(inputId, ..., options = NULL, width = NULL) {
   selectizeIt(
     inputId,
-    varSelectInput(inputId, ..., selectize = FALSE, width = width),
+    varSelectInput(inputId, ..., selectize = FALSE, width = width,
+      error_call = environment()),
     options
   )
 }

--- a/R/input-slider.R
+++ b/R/input-slider.R
@@ -79,6 +79,8 @@ sliderInput <- function(inputId, label, min, max, value, step = NULL,
                         round = FALSE, ticks = TRUE, animate = FALSE,
                         width = NULL, sep = ",", pre = NULL, post = NULL,
                         timeFormat = NULL, timezone = NULL, dragRange = TRUE) {
+  check_required(inputId, label, min, max, value)
+
   validate_slider_value(min, max, value, "sliderInput")
 
   dataType <- getSliderType(min, max, value)

--- a/R/input-text.R
+++ b/R/input-text.R
@@ -53,6 +53,8 @@ textInput <- function(
   rlang::check_dots_empty()
   updateOn <- rlang::arg_match(updateOn)
 
+  check_required(inputId, label)
+
   value <- restoreInput(id = inputId, default = value)
 
   div(

--- a/R/input-textarea.R
+++ b/R/input-textarea.R
@@ -60,6 +60,8 @@ textAreaInput <- function(
   rlang::check_dots_empty()
   updateOn <- rlang::arg_match(updateOn)
 
+  check_required(inputId, label)
+
   value <- restoreInput(id = inputId, default = value)
 
   if (!is.null(resize)) {

--- a/R/input-utils.R
+++ b/R/input-utils.R
@@ -1,3 +1,25 @@
+# Check that required arguments of the calling function were supplied by the
+# caller. Produces an error that names both the calling function and the
+# missing argument(s), e.g. `textInput()` is missing required argument: `label`.
+check_required <- function(..., call = rlang::caller_env()) {
+  args <- rlang::enquos(...)
+  missing <- character()
+  for (i in seq_along(args)) {
+    name <- rlang::as_name(args[[i]])
+    if (rlang::env_has(call, name) &&
+        rlang::eval_bare(rlang::call2(rlang::expr(missing), rlang::sym(name)), call)) {
+      missing <- c(missing, name)
+    }
+  }
+  if (!length(missing)) return(invisible())
+
+  fn <- rlang::call_name(rlang::frame_call(call)) %||% "function"
+  cli::cli_abort(
+    "{.fn {fn}} is missing required argument{cli::qty(length(missing))}{?s}: {.arg {missing}}.",
+    call = call
+  )
+}
+
 shinyInputLabel <- function(inputId, label = NULL) {
   tags$label(
     label,

--- a/R/input-utils.R
+++ b/R/input-utils.R
@@ -1,22 +1,26 @@
 # Check that required arguments of the calling function were supplied by the
-# caller. Produces an error that names both the calling function and the
-# missing argument(s), e.g. `textInput()` is missing required argument: `label`.
+# caller. Produces a classed error that names both the calling function and
+# the missing argument(s), e.g.
+#   `textInput()` is missing required argument: `label`.
+# `missing()` must be evaluated in the caller frame to avoid forcing the
+# unsupplied promise. When invoked via `do.call()`, `rlang::call_name()`
+# cannot recover the original function name and we fall back to "function".
 check_required <- function(..., call = rlang::caller_env()) {
   args <- rlang::enquos(...)
-  missing <- character()
+  missing_args <- character()
   for (i in seq_along(args)) {
     name <- rlang::as_name(args[[i]])
-    if (rlang::env_has(call, name) &&
-        rlang::eval_bare(rlang::call2(rlang::expr(missing), rlang::sym(name)), call)) {
-      missing <- c(missing, name)
+    if (eval(call("missing", as.name(name)), envir = call)) {
+      missing_args <- c(missing_args, name)
     }
   }
-  if (!length(missing)) return(invisible())
+  if (!length(missing_args)) return(invisible())
 
   fn <- rlang::call_name(rlang::frame_call(call)) %||% "function"
   cli::cli_abort(
-    "{.fn {fn}} is missing required argument{cli::qty(length(missing))}{?s}: {.arg {missing}}.",
-    call = call
+    "{.fn {fn}} is missing required argument{cli::qty(length(missing_args))}{?s}: {.arg {missing_args}}.",
+    call = call,
+    class = "shiny_missing_arg_error"
   )
 }
 

--- a/R/input-utils.R
+++ b/R/input-utils.R
@@ -2,18 +2,21 @@
 # caller. Produces a classed error that names both the calling function and
 # the missing argument(s), e.g.
 #   `textInput()` is missing required argument: `label`.
-# `missing()` must be evaluated in the caller frame to avoid forcing the
-# unsupplied promise. When invoked via `do.call()`, `rlang::call_name()`
-# cannot recover the original function name and we fall back to "function".
-check_required <- function(..., call = rlang::caller_env()) {
-  args <- rlang::enquos(...)
-  missing_args <- character()
-  for (i in seq_along(args)) {
-    name <- rlang::as_name(args[[i]])
-    if (eval(call("missing", as.name(name)), envir = call)) {
-      missing_args <- c(missing_args, name)
-    }
-  }
+#
+# `frame` is the function frame whose arguments are inspected; `missing()` is
+# evaluated there to avoid forcing the unsupplied promise. `call` is the call
+# blamed in the error and is normally the same frame. Wrapper functions that
+# delegate to a constructor (e.g. `selectizeInput()` -> `selectInput()`) pass
+# their own environment as `call` so the error names the function the user
+# actually called rather than the inner constructor. When `call` has no
+# associated call (e.g. invocation via `do.call()`), we fall back to
+# "function".
+check_required <- function(..., frame = rlang::caller_env(), call = frame) {
+  names <- vapply(rlang::ensyms(...), rlang::as_string, character(1))
+  is_missing <- vapply(names, function(name) {
+    eval(as.call(list(quote(missing), as.name(name))), envir = frame)
+  }, logical(1))
+  missing_args <- names[is_missing]
   if (!length(missing_args)) return(invisible())
 
   fn <- rlang::call_name(rlang::frame_call(call)) %||% "function"

--- a/man/selectInput.Rd
+++ b/man/selectInput.Rd
@@ -13,7 +13,8 @@ selectInput(
   multiple = FALSE,
   selectize = TRUE,
   width = NULL,
-  size = NULL
+  size = NULL,
+  error_call = environment()
 )
 
 selectizeInput(inputId, ..., options = NULL, width = NULL)
@@ -45,6 +46,12 @@ see \code{\link[=validateCssUnit]{validateCssUnit()}}.}
 will result in a taller box. Not compatible with \code{selectize=TRUE}.
 Normally, when \code{multiple=FALSE}, a select input will be a drop-down list,
 but when \code{size} is set, it will be a box instead.}
+
+\item{error_call}{Used internally to produce error messages that point at
+the function the user called. Wrapper functions (e.g. \code{\link[=selectizeInput]{selectizeInput()}}
+and \code{\link[=varSelectizeInput]{varSelectizeInput()}}) pass their own environment so that errors
+about missing required arguments are attributed to the wrapper rather
+than the inner constructor. You should not normally need to set this.}
 
 \item{...}{Arguments passed to \code{selectInput()}.}
 

--- a/man/varSelectInput.Rd
+++ b/man/varSelectInput.Rd
@@ -13,7 +13,8 @@ varSelectInput(
   multiple = FALSE,
   selectize = TRUE,
   width = NULL,
-  size = NULL
+  size = NULL,
+  error_call = environment()
 )
 
 varSelectizeInput(inputId, ..., options = NULL, width = NULL)
@@ -39,6 +40,12 @@ see \code{\link[=validateCssUnit]{validateCssUnit()}}.}
 will result in a taller box. Not compatible with \code{selectize=TRUE}.
 Normally, when \code{multiple=FALSE}, a select input will be a drop-down list,
 but when \code{size} is set, it will be a box instead.}
+
+\item{error_call}{Used internally to produce error messages that point at
+the function the user called. Wrapper functions (e.g. \code{\link[=selectizeInput]{selectizeInput()}}
+and \code{\link[=varSelectizeInput]{varSelectizeInput()}}) pass their own environment so that errors
+about missing required arguments are attributed to the wrapper rather
+than the inner constructor. You should not normally need to set this.}
 
 \item{...}{Arguments passed to \code{varSelectInput()}.}
 

--- a/tests/testthat/_snaps/input-required-args.md
+++ b/tests/testthat/_snaps/input-required-args.md
@@ -73,10 +73,26 @@
 ---
 
     Code
+      selectizeInput("id")
+    Condition
+      Error in `selectizeInput()`:
+      ! `selectizeInput()` is missing required arguments: `label` and `choices`.
+
+---
+
+    Code
       varSelectInput("id", "Label")
     Condition
       Error in `varSelectInput()`:
       ! `varSelectInput()` is missing required argument: `data`.
+
+---
+
+    Code
+      varSelectizeInput("id")
+    Condition
+      Error in `varSelectizeInput()`:
+      ! `varSelectizeInput()` is missing required arguments: `label` and `data`.
 
 ---
 

--- a/tests/testthat/_snaps/input-required-args.md
+++ b/tests/testthat/_snaps/input-required-args.md
@@ -1,0 +1,136 @@
+# missing required input args produce informative errors
+
+    Code
+      textInput("id")
+    Condition
+      Error in `textInput()`:
+      ! `textInput()` is missing required argument: `label`.
+
+---
+
+    Code
+      textInput()
+    Condition
+      Error in `textInput()`:
+      ! `textInput()` is missing required arguments: `inputId` and `label`.
+
+---
+
+    Code
+      textAreaInput("id")
+    Condition
+      Error in `textAreaInput()`:
+      ! `textAreaInput()` is missing required argument: `label`.
+
+---
+
+    Code
+      passwordInput("id")
+    Condition
+      Error in `passwordInput()`:
+      ! `passwordInput()` is missing required argument: `label`.
+
+---
+
+    Code
+      numericInput("id", "Label")
+    Condition
+      Error in `numericInput()`:
+      ! `numericInput()` is missing required argument: `value`.
+
+---
+
+    Code
+      checkboxInput("id")
+    Condition
+      Error in `checkboxInput()`:
+      ! `checkboxInput()` is missing required argument: `label`.
+
+---
+
+    Code
+      checkboxGroupInput("id")
+    Condition
+      Error in `checkboxGroupInput()`:
+      ! `checkboxGroupInput()` is missing required argument: `label`.
+
+---
+
+    Code
+      radioButtons("id")
+    Condition
+      Error in `radioButtons()`:
+      ! `radioButtons()` is missing required argument: `label`.
+
+---
+
+    Code
+      selectInput("id", "Label")
+    Condition
+      Error in `selectInput()`:
+      ! `selectInput()` is missing required argument: `choices`.
+
+---
+
+    Code
+      varSelectInput("id", "Label")
+    Condition
+      Error in `varSelectInput()`:
+      ! `varSelectInput()` is missing required argument: `data`.
+
+---
+
+    Code
+      dateInput("id")
+    Condition
+      Error in `dateInput()`:
+      ! `dateInput()` is missing required argument: `label`.
+
+---
+
+    Code
+      dateRangeInput("id")
+    Condition
+      Error in `dateRangeInput()`:
+      ! `dateRangeInput()` is missing required argument: `label`.
+
+---
+
+    Code
+      fileInput("id")
+    Condition
+      Error in `fileInput()`:
+      ! `fileInput()` is missing required argument: `label`.
+
+---
+
+    Code
+      sliderInput("id", "Label", min = 1, max = 10)
+    Condition
+      Error in `sliderInput()`:
+      ! `sliderInput()` is missing required argument: `value`.
+
+---
+
+    Code
+      sliderInput("id")
+    Condition
+      Error in `sliderInput()`:
+      ! `sliderInput()` is missing required arguments: `label`, `min`, `max`, and `value`.
+
+---
+
+    Code
+      actionButton("id")
+    Condition
+      Error in `actionButton()`:
+      ! `actionButton()` is missing required argument: `label`.
+
+---
+
+    Code
+      actionLink("id")
+    Condition
+      Error in `actionLink()`:
+      ! `actionLink()` is missing required argument: `label`.
+

--- a/tests/testthat/test-input-required-args.R
+++ b/tests/testthat/test-input-required-args.R
@@ -17,6 +17,21 @@ test_that("check_required() reports the calling function and missing args", {
   expect_silent(f(NA, NA))
 })
 
+test_that("missing-arg errors carry the shiny_missing_arg_error class", {
+  expect_error(textInput("id"),    class = "shiny_missing_arg_error")
+  expect_error(sliderInput("id"),  class = "shiny_missing_arg_error")
+  expect_error(actionButton("id"), class = "shiny_missing_arg_error")
+})
+
+test_that("check_required() works under do.call()", {
+  # do.call() loses the call name, but the missing argument(s) are still
+  # reported correctly.
+  expect_error(
+    do.call(textInput, list(inputId = "id")),
+    "is missing required argument: `label`"
+  )
+})
+
 test_that("missing required args error before downstream R errors", {
   # Before the fix these produced messages like
   #   `argument "label" is missing, with no default`
@@ -35,22 +50,25 @@ test_that("explicit NULL/NA satisfies required args (documented opt-out)", {
   expect_silent(actionButton("id", NULL))
 })
 
-test_that("happy paths still construct an input without error", {
-  expect_silent(textInput("id", "Label"))
-  expect_silent(textAreaInput("id", "Label"))
-  expect_silent(passwordInput("id", "Label"))
-  expect_silent(numericInput("id", "Label", value = 1))
-  expect_silent(checkboxInput("id", "Label"))
-  expect_silent(checkboxGroupInput("id", "Label", choices = "a"))
-  expect_silent(radioButtons("id", "Label", choices = "a"))
-  expect_silent(selectInput("id", "Label", choices = "a"))
-  expect_silent(varSelectInput("id", "Label", data = mtcars))
-  expect_silent(dateInput("id", "Label"))
-  expect_silent(dateRangeInput("id", "Label"))
-  expect_silent(fileInput("id", "Label"))
-  expect_silent(sliderInput("id", "Label", min = 1, max = 10, value = 5))
-  expect_silent(actionButton("id", "Label"))
-  expect_silent(actionLink("id", "Label"))
+test_that("happy paths still construct a shiny.tag without error", {
+  expect_tag <- function(x) {
+    expect_s3_class(x, c("shiny.tag", "shiny.tag.list"), exact = FALSE)
+  }
+  expect_tag(textInput("id", "Label"))
+  expect_tag(textAreaInput("id", "Label"))
+  expect_tag(passwordInput("id", "Label"))
+  expect_tag(numericInput("id", "Label", value = 1))
+  expect_tag(checkboxInput("id", "Label"))
+  expect_tag(checkboxGroupInput("id", "Label", choices = "a"))
+  expect_tag(radioButtons("id", "Label", choices = "a"))
+  expect_tag(selectInput("id", "Label", choices = "a"))
+  expect_tag(varSelectInput("id", "Label", data = mtcars))
+  expect_tag(dateInput("id", "Label"))
+  expect_tag(dateRangeInput("id", "Label"))
+  expect_tag(fileInput("id", "Label"))
+  expect_tag(sliderInput("id", "Label", min = 1, max = 10, value = 5))
+  expect_tag(actionButton("id", "Label"))
+  expect_tag(actionLink("id", "Label"))
 })
 
 test_that("missing required input args produce informative errors", {

--- a/tests/testthat/test-input-required-args.R
+++ b/tests/testthat/test-input-required-args.R
@@ -1,0 +1,74 @@
+test_that("check_required() reports the calling function and missing args", {
+  f <- function(a, b, c = NULL) check_required(a, b)
+
+  # No missing args: returns invisibly without error
+  expect_silent(f(1, 2))
+
+  # One missing arg: singular
+  expect_error(f(1), "`f\\(\\)` is missing required argument: `b`")
+
+  # Multiple missing args: pluralized
+  expect_error(f(), "`f\\(\\)` is missing required arguments: `a` and `b`")
+
+  # Explicit NULL counts as supplied
+  expect_silent(f(NULL, NULL))
+
+  # Explicit NA counts as supplied
+  expect_silent(f(NA, NA))
+})
+
+test_that("missing required args error before downstream R errors", {
+  # Before the fix these produced messages like
+  #   `argument "label" is missing, with no default`
+  # which named neither the function nor the argument. Confirm the new
+  # message includes both.
+  expect_error(textInput("id"),         "`textInput\\(\\)`.*`label`")
+  expect_error(sliderInput("id", "L"),  "`sliderInput\\(\\)`.*`min`")
+  expect_error(selectInput("id", "L"),  "`selectInput\\(\\)`.*`choices`")
+  expect_error(actionButton("id"),      "`actionButton\\(\\)`.*`label`")
+})
+
+test_that("explicit NULL/NA satisfies required args (documented opt-out)", {
+  # `label = NULL` is documented as "no label" — must not be rejected.
+  expect_silent(textInput("id", NULL))
+  expect_silent(checkboxInput("id", NULL))
+  expect_silent(actionButton("id", NULL))
+})
+
+test_that("happy paths still construct an input without error", {
+  expect_silent(textInput("id", "Label"))
+  expect_silent(textAreaInput("id", "Label"))
+  expect_silent(passwordInput("id", "Label"))
+  expect_silent(numericInput("id", "Label", value = 1))
+  expect_silent(checkboxInput("id", "Label"))
+  expect_silent(checkboxGroupInput("id", "Label", choices = "a"))
+  expect_silent(radioButtons("id", "Label", choices = "a"))
+  expect_silent(selectInput("id", "Label", choices = "a"))
+  expect_silent(varSelectInput("id", "Label", data = mtcars))
+  expect_silent(dateInput("id", "Label"))
+  expect_silent(dateRangeInput("id", "Label"))
+  expect_silent(fileInput("id", "Label"))
+  expect_silent(sliderInput("id", "Label", min = 1, max = 10, value = 5))
+  expect_silent(actionButton("id", "Label"))
+  expect_silent(actionLink("id", "Label"))
+})
+
+test_that("missing required input args produce informative errors", {
+  expect_snapshot(error = TRUE, textInput("id"))
+  expect_snapshot(error = TRUE, textInput())
+  expect_snapshot(error = TRUE, textAreaInput("id"))
+  expect_snapshot(error = TRUE, passwordInput("id"))
+  expect_snapshot(error = TRUE, numericInput("id", "Label"))
+  expect_snapshot(error = TRUE, checkboxInput("id"))
+  expect_snapshot(error = TRUE, checkboxGroupInput("id"))
+  expect_snapshot(error = TRUE, radioButtons("id"))
+  expect_snapshot(error = TRUE, selectInput("id", "Label"))
+  expect_snapshot(error = TRUE, varSelectInput("id", "Label"))
+  expect_snapshot(error = TRUE, dateInput("id"))
+  expect_snapshot(error = TRUE, dateRangeInput("id"))
+  expect_snapshot(error = TRUE, fileInput("id"))
+  expect_snapshot(error = TRUE, sliderInput("id", "Label", min = 1, max = 10))
+  expect_snapshot(error = TRUE, sliderInput("id"))
+  expect_snapshot(error = TRUE, actionButton("id"))
+  expect_snapshot(error = TRUE, actionLink("id"))
+})

--- a/tests/testthat/test-input-required-args.R
+++ b/tests/testthat/test-input-required-args.R
@@ -50,9 +50,27 @@ test_that("explicit NULL/NA satisfies required args (documented opt-out)", {
   expect_silent(actionButton("id", NULL))
 })
 
+test_that("selectize wrappers attribute missing-arg errors to themselves", {
+  # selectizeInput()/varSelectizeInput() delegate to selectInput()/
+  # varSelectInput(), but the error must name the function the user called,
+  # not the inner constructor (#1423).
+  expect_error(
+    selectizeInput("id"),
+    "`selectizeInput\\(\\)` is missing required arguments: `label` and `choices`",
+    class = "shiny_missing_arg_error"
+  )
+  expect_error(
+    varSelectizeInput("id"),
+    "`varSelectizeInput\\(\\)` is missing required arguments: `label` and `data`",
+    class = "shiny_missing_arg_error"
+  )
+  # Server-side selectize (choices supplied as NULL) is unaffected.
+  expect_s3_class(selectizeInput("id", "Label", choices = NULL), "shiny.tag")
+})
+
 test_that("happy paths still construct a shiny.tag without error", {
   expect_tag <- function(x) {
-    expect_s3_class(x, c("shiny.tag", "shiny.tag.list"), exact = FALSE)
+    expect_s3_class(x, "shiny.tag")
   }
   expect_tag(textInput("id", "Label"))
   expect_tag(textAreaInput("id", "Label"))
@@ -81,7 +99,9 @@ test_that("missing required input args produce informative errors", {
   expect_snapshot(error = TRUE, checkboxGroupInput("id"))
   expect_snapshot(error = TRUE, radioButtons("id"))
   expect_snapshot(error = TRUE, selectInput("id", "Label"))
+  expect_snapshot(error = TRUE, selectizeInput("id"))
   expect_snapshot(error = TRUE, varSelectInput("id", "Label"))
+  expect_snapshot(error = TRUE, varSelectizeInput("id"))
   expect_snapshot(error = TRUE, dateInput("id"))
   expect_snapshot(error = TRUE, dateRangeInput("id"))
   expect_snapshot(error = TRUE, fileInput("id"))


### PR DESCRIPTION
Fixes #1423.

## Summary

Input constructors (`textInput()`, `sliderInput()`, `selectInput()`, `actionButton()`, etc.) currently surface cryptic downstream R errors like `argument "label" is missing, with no default` when a required argument is omitted, without naming the function or the argument that was actually missing.

This PR adds a small internal `check_required()` helper in `R/input-utils.R` that uses `eval(call("missing", ...), envir = caller_env())` to detect unsupplied promises without forcing them, then raises a classed error via `cli::cli_abort()` that names both the calling function and the missing argument(s). The helper is wired into the top of every `*Input()` constructor plus `actionButton()` / `actionLink()` for arguments without defaults (`inputId`, `label`, plus per-function specifics such as `choices`, `min`/`max`/`value`, `data`).

The error carries class `shiny_missing_arg_error` so downstream code can catch it specifically. Explicit `NULL` and `NA` are treated as "supplied" so documented opt-outs like `label = NULL` continue to work. No public API changes; only the error wording changes for the previously-broken cases.

## Scope

In scope: every standalone input constructor and `actionButton()` / `actionLink()` — 15 functions in total.

Out of scope (intentionally):
- Argument **type** validation (e.g., rejecting `inputId = c("a", "b")`). The issue is about clearer missing-arg messages, not a general validator.
- Positional-shift heuristics. `sliderInput("forgot my id!", 1, 10, 5)` will still report `value` as missing because we can't infer the user's intent.
- The `update*Input()` family. Same problem exists there but the surface area is larger; tracked as a follow-up.

## Follow-ups

- Apply the same `check_required()` treatment to `updateTextInput()`, `updateSliderInput()`, `updateSelectInput()`, etc.
- Consider exporting `check_required()` (or replacing with `rlang::check_required()`) if other parts of shiny adopt the pattern.

## Verification

Before:

```r
sliderInput("Whoops forgot my id!", 1, 10, 5)
#> Error in force(default) : argument "value" is missing, with no default
textInput("text")
#> Error in label %AND% tags$label(label, `for` = inputId) :
#>   argument "label" is missing, with no default
```

After:

```r
sliderInput("Whoops forgot my id!", 1, 10, 5)
#> Error in `sliderInput()`:
#> ! `sliderInput()` is missing required argument: `value`.
textInput("text")
#> Error in `textInput()`:
#> ! `textInput()` is missing required argument: `label`.
textInput()
#> Error in `textInput()`:
#> ! `textInput()` is missing required arguments: `inputId` and `label`.
```

## Test plan

- [x] `tests/testthat/test-input-required-args.R` adds 7 `test_that()` blocks (48 expectations) covering: the helper's own behavior, the new error class, behavior under `do.call()`, regex-based regression assertions, explicit-NULL opt-out, happy-path `shiny.tag` returns for all 15 patched constructors, and full-message snapshots.
- [x] `devtools::test(filter = "input")`: 231 PASS, 0 FAIL.
- [x] Full `devtools::test()` suite earlier: 2018 PASS, 0 FAIL (12 environmental skips, unrelated).
