### PR TITLE
Docs: clarify `selectInput()` NULL handling with `multiple = TRUE`

### DIFF
--- a/R/input-select.R
+++ b/R/input-select.R
@@ -187,6 +187,11 @@ needOptgroup <- function(choices) {
 #'   value when it is a single choice input and the empty string is not in the
 #'   `choices` argument. This is to keep compatibility with
 #'   `selectInput(..., selectize = FALSE)`.
+#'
+#'   When `multiple = TRUE`, deleting all selected options yields an input
+#'   value of `NULL`. Because [observeEvent()] and [eventReactive()] ignore
+#'   `NULL` by default, this transition will not trigger them unless you set
+#'   `ignoreNULL = FALSE`.
 #' @export
 selectizeInput <- function(inputId, ..., options = NULL, width = NULL) {
   selectizeIt(
@@ -411,6 +416,11 @@ varSelectInput <- function(
 #'   value when it is a single choice input and the empty string is not in the
 #'   `choices` argument. This is to keep compatibility with
 #'   `selectInput(..., selectize = FALSE)`.
+#'
+#'   When `multiple = TRUE`, deleting all selected options yields an input
+#'   value of `NULL`. Because [observeEvent()] and [eventReactive()] ignore
+#'   `NULL` by default, this transition will not trigger them unless you set
+#'   `ignoreNULL = FALSE`.
 #' @export
 varSelectizeInput <- function(inputId, ..., options = NULL, width = NULL) {
   selectizeIt(

--- a/man/selectInput.Rd
+++ b/man/selectInput.Rd
@@ -87,6 +87,11 @@ return an empty string as its value. This is the default behavior of
 value when it is a single choice input and the empty string is not in the
 \code{choices} argument. This is to keep compatibility with
 \code{selectInput(..., selectize = FALSE)}.
+
+When \code{multiple = TRUE}, deleting all selected options yields an input
+value of \code{NULL}. Because \code{\link[=observeEvent]{observeEvent()}} and \code{\link[=eventReactive]{eventReactive()}} ignore
+\code{NULL} by default, this transition will not trigger them unless you set
+\code{ignoreNULL = FALSE}.
 }
 \section{Server value}{
  A vector of character strings, usually of length

--- a/man/varSelectInput.Rd
+++ b/man/varSelectInput.Rd
@@ -70,6 +70,11 @@ return an empty string as its value. This is the default behavior of
 value when it is a single choice input and the empty string is not in the
 \code{choices} argument. This is to keep compatibility with
 \code{selectInput(..., selectize = FALSE)}.
+
+When \code{multiple = TRUE}, deleting all selected options yields an input
+value of \code{NULL}. Because \code{\link[=observeEvent]{observeEvent()}} and \code{\link[=eventReactive]{eventReactive()}} ignore
+\code{NULL} by default, this transition will not trigger them unless you set
+\code{ignoreNULL = FALSE}.
 }
 \section{Server value}{
 


### PR DESCRIPTION
Fixes #3844

## Summary

Extends the `@note` block in `selectizeInput()` and `varSelectizeInput()` (which `@rdname` into `selectInput.Rd` and `varSelectInput.Rd`, respectively) to call out a behavior that has surprised users: when `multiple = TRUE`, deleting all selected options yields an input value of `NULL`, and `observeEvent()` / `eventReactive()` ignore `NULL` by default — so the transition to "no selection" silently fails to trigger downstream reactives. The new note points users to `ignoreNULL = FALSE` as the knob to use when that behavior is undesirable.

This is a docs-only change. It follows the approach @gadenbuie outlined in #3844 and revives the work @BajczA475 started in the closed #3846, with corrected wording (`ignoreNULL = FALSE`, since the default is already `TRUE`).

No `NEWS.md` entry was added — recent precedent in this repo (e.g. f55c26af4, 4361f2cb5, 5b6c187bc) is that pure roxygen clarifications don't get a NEWS bullet; NEWS is reserved for observable behavior changes. Happy to add one if preferred.

## Verification

- `devtools::document()` regenerated `man/selectInput.Rd` and `man/varSelectInput.Rd` cleanly.
- Render `?selectInput` and `?varSelectInput`; the new paragraph appears under "Note" with working cross-references to `observeEvent()` and `eventReactive()` (the latter resolves via the alias in `observeEvent.Rd`).
- No code paths were touched, so no test changes were needed.