### PR TITLE
Docs: clarify `varSelectInput()` purpose and fix typo

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,10 @@
 
 * `need()` now gives a clearer error when called without either a `message` or `label` argument, instead of the cryptic "argument \"label\" is missing, with no default". (thanks @chasemc and @sundrelingam, #2509)
 
+* Clarified `varSelectInput()` documentation to explain that the input
+  returns a symbol for use with tidy evaluation, and fixed a grammatical
+  typo. (#2334)
+
 # shiny 1.13.0
 
 ## New features

--- a/R/input-select.R
+++ b/R/input-select.R
@@ -299,9 +299,15 @@ selectizeScripts <- function() {
 #' Create a select list that can be used to choose a single or multiple items
 #' from the column names of a data frame.
 #'
+#' `varSelectInput()` is a convenience wrapper around [selectInput()] for use
+#' with tidy evaluation: it returns the selected column name as a symbol
+#' (see "Server value" below) so the value can be spliced directly into
+#' tidy-evaluation contexts without wrapping it in [rlang::sym()]. If you
+#' don't need a symbol, use [selectInput()] instead.
+#'
 #' By default, `varSelectInput()` and `selectizeInput()` use the
 #' JavaScript library \pkg{selectize.js}
-#' (<https://selectize.dev/>) to instead of the basic
+#' (<https://selectize.dev/>) instead of the basic
 #' select input element. To use the standard HTML select input element, use
 #' `selectInput()` with `selectize=FALSE`.
 #'

--- a/man/varSelectInput.Rd
+++ b/man/varSelectInput.Rd
@@ -55,9 +55,15 @@ Create a select list that can be used to choose a single or multiple items
 from the column names of a data frame.
 }
 \details{
+\code{varSelectInput()} is a convenience wrapper around \code{\link[=selectInput]{selectInput()}} for use
+with tidy evaluation: it returns the selected column name as a symbol
+(see "Server value" below) so the value can be spliced directly into
+tidy-evaluation contexts without wrapping it in \code{\link[rlang:sym]{rlang::sym()}}. If you
+don't need a symbol, use \code{\link[=selectInput]{selectInput()}} instead.
+
 By default, \code{varSelectInput()} and \code{selectizeInput()} use the
 JavaScript library \pkg{selectize.js}
-(\url{https://selectize.dev/}) to instead of the basic
+(\url{https://selectize.dev/}) instead of the basic
 select input element. To use the standard HTML select input element, use
 \code{selectInput()} with \code{selectize=FALSE}.
 }


### PR DESCRIPTION
Fixes #2334

## Summary

`varSelectInput()`'s documentation didn't explain *why* the input exists — only that it returns a symbol. Per @jcheng5 in the issue thread, its sole purpose is to make `selectInput()` ergonomic for tidy-evaluation contexts (e.g. `ggplot2::aes(!!input$var)`) by returning a symbol directly. This PR adds a short paragraph stating that purpose up front and pointing readers to the existing "Server value" section for the mechanics, and recommends plain `selectInput()` when a symbol is not needed.

It also fixes a grammatical typo ("to instead of" → "instead of") in the same docstring's description of `selectize.js`.

No behavior changes; documentation only.

## Verification

- `?varSelectInput` (or the pkgdown reference page) shows the new explanatory paragraph after the title block and before the existing `selectize.js` paragraph.
- The "to instead of the basic select input element" sentence now reads "instead of the basic select input element."
- `devtools::check()` passes.