### PR TITLE
fix: support running a module in the parent namespace via an empty id

### DIFF
--- a/R/mock-session.R
+++ b/R/mock-session.R
@@ -763,7 +763,8 @@ MockShinySession <- R6Class(
     # @param ns The namespace key.
     # @return A Callbacks object.
     getOrCreateDestroyCallbacks = function(ns) {
-      if (!nzchar(ns)) ns <- "..root"
+      # length-0 namespace is the root scope; nzchar(character(0)) is logical(0)
+      if (length(ns) == 0L || !nzchar(ns)) ns <- "..root"
       if (!private$destroyCallbacksByNs$containsKey(ns)) {
         private$destroyCallbacksByNs$set(ns, Callbacks$new())
       }
@@ -775,7 +776,7 @@ MockShinySession <- R6Class(
     # @param nsPrefix The namespace prefix to match.
     invokeDestroyCallbacks = function(nsPrefix = "") {
       allNs <- private$destroyCallbacksByNs$keys()
-      isRoot <- !nzchar(nsPrefix)
+      isRoot <- length(nsPrefix) == 0L || !nzchar(nsPrefix)
 
       if (!isRoot) {
         nsPrefixWithSep <- paste0(nsPrefix, ns.sep)

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -812,7 +812,8 @@ ShinySession <- R6Class(
     destroyNsRoot = "..root",
 
     destroyNsKey = function(ns) {
-      if (!nzchar(ns)) private$destroyNsRoot else ns
+      # length-0 namespace is the root scope; nzchar(character(0)) is logical(0)
+      if (length(ns) == 0L || !nzchar(ns)) private$destroyNsRoot else ns
     },
 
     getOrCreateDestroyCallbacks = function(ns) {
@@ -824,7 +825,7 @@ ShinySession <- R6Class(
     },
     invokeDestroyCallbacks = function(nsPrefix = "") {
       allNs <- private$destroyCallbacksByNs$keys()
-      isRoot <- !nzchar(nsPrefix)
+      isRoot <- length(nsPrefix) == 0L || !nzchar(nsPrefix)
 
       if (!isRoot) {
         nsPrefixWithSep <- paste0(nsPrefix, ns.sep)

--- a/tests/testthat/test-destroy.R
+++ b/tests/testthat/test-destroy.R
@@ -904,6 +904,29 @@ test_that("makeScope rejects reserved namespace '..root'", {
   expect_error(session$makeScope("..root"), "reserved")
 })
 
+test_that("makeScope() accepts an empty (character(0)) namespace", {
+  session <- MockShinySession$new()
+  expect_no_error(scope <- session$makeScope(character(0)))
+
+  called <- FALSE
+  scope$onDestroy(function() called <<- TRUE)
+  session$close()
+  expect_true(called)
+})
+
+test_that("empty namespace scope leaves ids un-prefixed (NS length-0 semantics)", {
+  session <- MockShinySession$new()
+  scope <- session$makeScope(character(0))
+  expect_identical(scope$ns("x"), "x")
+})
+
+test_that("callModule() with an empty namespace id does not error", {
+  session <- MockShinySession$new()
+  expect_no_error(
+    callModule(function(input, output, session) NULL, character(0), session = session)
+  )
+})
+
 test_that("createMockDomain supports onDestroy and destroy", {
   domain <- createMockDomain()
 


### PR DESCRIPTION
After the new `session$destroy()` work (#4372), the root-scope detection (`if (!nzchar(namespace))`) errors with "argument is of length zero" when a module is run with an empty id, e.g. `callModule(server, character(0))`.

That empty-id idiom is how packages such as **teal** run a module server in the parent namespace, and it is the documented behavior of `NS()`:

> Length 0 will cause the `id` to be returned without a namespace

This makes the new destroy machinery handle that case. A length-0 namespace is treated as the root scope in the destroy-callback bookkeeping only; the namespace itself is left untouched so `NS(character(0))` keeps returning ids unchanged (normalizing to `""` would instead prepend a stray `-` separator).

Caught by reverse-dependency checks against teal.