### PR TITLE
fix: support `NULL` as the canonical root namespace for `session$destroy()`, etc

### DIFF
--- a/R/mock-session.R
+++ b/R/mock-session.R
@@ -323,11 +323,13 @@ MockShinySession <- R6Class(
     onDestroy = function(callback) {
       private$getOrCreateDestroyCallbacks(character(0))$register(callback)
     },
-    #' @description Destroys a module session scope. On the root session, a
-    #'   `namespace` is required: `session$destroy(namespace)` tears down the
-    #'   child module scope of that `namespace`. Calling `destroy()` with no
-    #'   `namespace` on the root session is an error.
-    #' @param namespace Optional module `namespace` whose scope should be destroyed.
+    #' @description Destroys a module session scope. `namespace` must be a
+    #'   non-empty, non-NA string naming a child module scope. The root scope is
+    #'   identified by `character(0)` (the default) and cannot be destroyed this
+    #'   way: calling `destroy()` with no `namespace` on the root session is an
+    #'   error.
+    #' @param namespace Module `namespace` (a non-empty, non-NA string) whose
+    #'   scope should be destroyed.
     destroy = function(namespace = character(0)) {
       if (length(namespace) == 0) {
         stop(
@@ -559,11 +561,11 @@ MockShinySession <- R6Class(
           call. = FALSE
         )
       }
-      # `character(0)` is the root; an empty string is not a valid namespace
-      # (it can't be used as a fastmap key, and `NS("")` yields a stray `-`).
-      if (length(namespace) == 1L && !nzchar(namespace)) {
+      # `character(0)` is the root; "" / NA are not valid namespaces (they
+      # can't be used as a fastmap key, and `NS("")` yields a stray `-`).
+      if (length(namespace) == 1L && (is.na(namespace) || !nzchar(namespace))) {
         stop(
-          "A module namespace must be a non-empty string; use `character(0)` for the root scope.",
+          "A module namespace must be a non-empty, non-NA string; use `character(0)` for the root scope.",
           call. = FALSE
         )
       }

--- a/R/mock-session.R
+++ b/R/mock-session.R
@@ -337,7 +337,7 @@ MockShinySession <- R6Class(
           call. = FALSE
         )
       }
-      validateDestroyNamespace(namespace)
+      validateNamespace(namespace)
       self$makeScope(namespace)$destroy()
     },
 
@@ -554,7 +554,7 @@ MockShinySession <- R6Class(
     #' @param namespace Character vector indicating a namespace.
     #' @return A new session proxy.
     makeScope = function(namespace) {
-      validateScopeNamespace(namespace)
+      validateNamespace(namespace, allow_root = TRUE)
       ns <- NS(namespace)
       # The scope's own namespace, captured because the proxy `destroy()` below
       # has a `namespace` parameter that would otherwise shadow it.
@@ -586,7 +586,7 @@ MockShinySession <- R6Class(
             private$invokeDestroyCallbacks(selfNamespace)
           } else {
             # Tear down a named child scope.
-            validateDestroyNamespace(namespace)
+            validateNamespace(namespace)
             self$makeScope(ns(namespace))$destroy()
           }
         }

--- a/R/mock-session.R
+++ b/R/mock-session.R
@@ -321,16 +321,16 @@ MockShinySession <- R6Class(
     #'   callback.
     #' @param callback The callback to invoke on destroy.
     onDestroy = function(callback) {
-      private$getOrCreateDestroyCallbacks(character(0))$register(callback)
+      private$getOrCreateDestroyCallbacks(NULL)$register(callback)
     },
     #' @description Destroys a module session scope. `namespace` must be a
     #'   non-empty, non-NA string naming a child module scope. The root scope is
-    #'   identified by `character(0)` (the default) and cannot be destroyed this
-    #'   way: calling `destroy()` with no `namespace` on the root session is an
-    #'   error.
+    #'   the absence of a namespace -- `NULL` (the default) or `character(0)` --
+    #'   and cannot be destroyed this way: calling `destroy()` with no
+    #'   `namespace` on the root session is an error.
     #' @param namespace Module `namespace` (a non-empty, non-NA string) whose
     #'   scope should be destroyed.
-    destroy = function(namespace = character(0)) {
+    destroy = function(namespace = NULL) {
       if (length(namespace) == 0) {
         stop(
           "`$destroy()` cannot be called on the root session without a `namespace`. Pass a module `namespace` to tear down that scope (e.g. `session$destroy(\"my_module\")`), or call `close()` to tear down the whole session.",
@@ -561,11 +561,11 @@ MockShinySession <- R6Class(
           call. = FALSE
         )
       }
-      # `character(0)` is the root; "" / NA are not valid namespaces (they
-      # can't be used as a fastmap key, and `NS("")` yields a stray `-`).
+      # A length-0 namespace (`NULL` or `character(0)`) is the root; "" / NA are
+      # not valid (they can't be a fastmap key, and `NS("")` yields a stray `-`).
       if (length(namespace) == 1L && (is.na(namespace) || !nzchar(namespace))) {
         stop(
-          "A module namespace must be a non-empty, non-NA string; use `character(0)` for the root scope.",
+          "A module namespace must be a non-empty, non-NA string; use `NULL` for the root scope.",
           call. = FALSE
         )
       }
@@ -594,7 +594,7 @@ MockShinySession <- R6Class(
         onDestroy = function(callback) {
           private$getOrCreateDestroyCallbacks(namespace)$register(callback)
         },
-        destroy = function(namespace = character(0)) {
+        destroy = function(namespace = NULL) {
           if (length(namespace) == 0) {
             # Tear down this scope itself.
             private$invokeDestroyCallbacks(selfNamespace)
@@ -777,8 +777,8 @@ MockShinySession <- R6Class(
     # @param ns The namespace key.
     # @return A Callbacks object.
     getOrCreateDestroyCallbacks = function(ns) {
-      # `character(0)` is the root; the sentinel keeps it out of fastmap, which
-      # disallows an empty-string key.
+      # The root scope (length 0: `NULL` or `character(0)`) maps to the sentinel
+      # key; fastmap can't use an empty-string key.
       if (length(ns) == 0) ns <- destroyNsRoot
       if (!private$destroyCallbacksByNs$containsKey(ns)) {
         private$destroyCallbacksByNs$set(ns, Callbacks$new())
@@ -787,11 +787,11 @@ MockShinySession <- R6Class(
     },
 
     # @description Invoke destroy callbacks for the given namespace
-    #   and all child namespaces, deepest-first. The root (`character(0)`)
-    #   may only be torn down with `allowRoot = TRUE` (via `close()`).
-    # @param namespace The namespace to match (`character(0)` is the root).
+    #   and all child namespaces, deepest-first. The root (length 0: `NULL` or
+    #   `character(0)`) may only be torn down with `allowRoot = TRUE` (via `close()`).
+    # @param namespace The namespace to match (length 0 is the root).
     # @param allowRoot Whether tearing down the root scope is permitted.
-    invokeDestroyCallbacks = function(namespace = character(0), allowRoot = FALSE) {
+    invokeDestroyCallbacks = function(namespace = NULL, allowRoot = FALSE) {
       isRoot <- length(namespace) == 0
       # The root scope can only be torn down via `close()` (allowRoot = TRUE).
       if (isRoot && !allowRoot) {

--- a/R/mock-session.R
+++ b/R/mock-session.R
@@ -328,16 +328,17 @@ MockShinySession <- R6Class(
       }
       private$destroyCallbacksByNs$get(ns)$register(callback)
     },
-    #' @description Destroys a module session scope. On the root session, an
-    #'   `id` is required: `session$destroy(id)` tears down the child module
-    #'   scope of that `id`. Calling `destroy()` with no `id` on the root
-    #'   session is an error.
-    #' @param id Optional module `id` whose scope should be destroyed.
-    destroy = function(id = NULL) {
-      if (is.null(id)) {
-        stop("`$destroy()` cannot be called on the root session without an `id`. Pass a module `id` to tear down that scope (e.g. `session$destroy(\"my_module\")`), or call `$destroy()` on a module session.")
+    #' @description Destroys a module session scope. On the root session, a
+    #'   `namespace` is required: `session$destroy(namespace)` tears down the
+    #'   child module scope of that `namespace`. Calling `destroy()` with no
+    #'   `namespace` on the root session is an error.
+    #' @param namespace Optional module `namespace` whose scope should be destroyed.
+    destroy = function(namespace = character(0)) {
+      if (length(namespace) == 0) {
+        stop("`$destroy()` cannot be called on the root session without a `namespace`. Pass a module `namespace` to tear down that scope (e.g. `session$destroy(\"my_module\")`), or call `$destroy()` on a module session.")
       }
-      self$makeScope(id)$destroy()
+      validateDestroyNamespace(namespace)
+      self$makeScope(namespace)$destroy()
     },
 
     #' @description Returns `FALSE` if the session has not yet been closed
@@ -352,7 +353,7 @@ MockShinySession <- R6Class(
       withReactiveDomain(self, {
         private$endedCBs$invoke(onError = printError, ..stacktraceon = TRUE)
       })
-      private$invokeDestroyCallbacks("")
+      private$invokeDestroyCallbacks(allowRoot = TRUE)
       private$was_closed <- TRUE
     },
 
@@ -560,6 +561,9 @@ MockShinySession <- R6Class(
         )
       }
       ns <- NS(namespace)
+      # The scope's own namespace, captured because the proxy `destroy()` below
+      # has a `namespace` parameter that would otherwise shadow it.
+      selfNamespace <- namespace
 
       bookmarkExclude <- character(0)
 
@@ -581,11 +585,14 @@ MockShinySession <- R6Class(
         onDestroy = function(callback) {
           private$getOrCreateDestroyCallbacks(namespace)$register(callback)
         },
-        destroy = function(id = NULL) {
-          if (is.null(id)) {
-            private$invokeDestroyCallbacks(namespace)
+        destroy = function(namespace = character(0)) {
+          if (length(namespace) == 0) {
+            # Tear down this scope itself.
+            private$invokeDestroyCallbacks(selfNamespace)
           } else {
-            self$makeScope(ns(id))$destroy()
+            # Tear down a named child scope.
+            validateDestroyNamespace(namespace)
+            self$makeScope(ns(namespace))$destroy()
           }
         }
       )
@@ -761,19 +768,32 @@ MockShinySession <- R6Class(
     # @param ns The namespace key.
     # @return A Callbacks object.
     getOrCreateDestroyCallbacks = function(ns) {
-      if (!nzchar(ns)) ns <- "..root"
+      # `character(0)` is the root; also fold in `""` since fastmap can't use
+      # an empty-string key.
+      if (length(ns) == 0 || !nzchar(ns)) ns <- "..root"
       if (!private$destroyCallbacksByNs$containsKey(ns)) {
         private$destroyCallbacksByNs$set(ns, Callbacks$new())
       }
       private$destroyCallbacksByNs$get(ns)
     },
 
-    # @description Invoke destroy callbacks for the given namespace prefix
-    #   and all child namespaces, deepest-first.
-    # @param nsPrefix The namespace prefix to match.
-    invokeDestroyCallbacks = function(nsPrefix = "") {
+    # @description Invoke destroy callbacks for the given namespace
+    #   and all child namespaces, deepest-first. The root (`character(0)`)
+    #   may only be torn down with `allowRoot = TRUE` (via `close()`).
+    # @param namespace The namespace to match (`character(0)` is the root).
+    # @param allowRoot Whether tearing down the root scope is permitted.
+    invokeDestroyCallbacks = function(namespace = character(0), allowRoot = FALSE) {
+      isRoot <- length(namespace) == 0
+      # The root scope can only be torn down via `close()` (allowRoot = TRUE).
+      if (isRoot && !allowRoot) {
+        stop(
+          "`$destroy()` cannot be called on the root session without a `namespace`. Pass a module `namespace` to tear down that scope (e.g. `session$destroy(\"my_module\")`), or call `$destroy()` on a module session.",
+          call. = FALSE
+        )
+      }
+
+      nsPrefix <- namespace
       allNs <- private$destroyCallbacksByNs$keys()
-      isRoot <- !nzchar(nsPrefix)
 
       if (!isRoot) {
         nsPrefixWithSep <- paste0(nsPrefix, ns.sep)

--- a/R/mock-session.R
+++ b/R/mock-session.R
@@ -321,8 +321,7 @@ MockShinySession <- R6Class(
     #'   callback.
     #' @param callback The callback to invoke on destroy.
     onDestroy = function(callback) {
-      # Use sentinel key since fastmap disallows empty string keys
-      ns <- "..root"
+      ns <- destroyNsRoot
       if (!private$destroyCallbacksByNs$containsKey(ns)) {
         private$destroyCallbacksByNs$set(ns, Callbacks$new())
       }
@@ -554,9 +553,10 @@ MockShinySession <- R6Class(
     #' @param namespace Character vector indicating a namespace.
     #' @return A new session proxy.
     makeScope = function(namespace) {
-      if (identical(namespace, "..root")) {
+      if (identical(namespace, destroyNsRoot)) {
         stop(
-          "The module namespace '..root' is reserved for internal use.",
+          "The module namespace '", destroyNsRoot,
+          "' is reserved for internal use.",
           call. = FALSE
         )
       }
@@ -770,7 +770,7 @@ MockShinySession <- R6Class(
     getOrCreateDestroyCallbacks = function(ns) {
       # `character(0)` is the root; also fold in `""` since fastmap can't use
       # an empty-string key.
-      if (length(ns) == 0 || !nzchar(ns)) ns <- "..root"
+      if (length(ns) == 0 || !nzchar(ns)) ns <- destroyNsRoot
       if (!private$destroyCallbacksByNs$containsKey(ns)) {
         private$destroyCallbacksByNs$set(ns, Callbacks$new())
       }
@@ -805,7 +805,7 @@ MockShinySession <- R6Class(
       if (length(matching) > 0L) {
         # Sort deepest-first (most separators first); root sentinel always last
         depths <- nchar(gsub(paste0("[^", ns.sep, "]"), "", matching))
-        isRootSentinel <- matching == "..root"
+        isRootSentinel <- matching == destroyNsRoot
         matching <- matching[order(-depths, isRootSentinel, matching)]
 
         for (ns in matching) {

--- a/R/mock-session.R
+++ b/R/mock-session.R
@@ -337,7 +337,6 @@ MockShinySession <- R6Class(
       if (is.null(id)) {
         stop("`$destroy()` cannot be called on the root session without an `id`. Pass a module `id` to tear down that scope (e.g. `session$destroy(\"my_module\")`), or call `$destroy()` on a module session.")
       }
-      validateDestroyId(id)
       self$makeScope(id)$destroy()
     },
 
@@ -586,7 +585,6 @@ MockShinySession <- R6Class(
           if (is.null(id)) {
             private$invokeDestroyCallbacks(namespace)
           } else {
-            validateDestroyId(id)
             self$makeScope(ns(id))$destroy()
           }
         }

--- a/R/mock-session.R
+++ b/R/mock-session.R
@@ -554,21 +554,7 @@ MockShinySession <- R6Class(
     #' @param namespace Character vector indicating a namespace.
     #' @return A new session proxy.
     makeScope = function(namespace) {
-      if (identical(namespace, destroyNsRoot)) {
-        stop(
-          "The module namespace '", destroyNsRoot,
-          "' is reserved for internal use.",
-          call. = FALSE
-        )
-      }
-      # A length-0 namespace (`NULL` or `character(0)`) is the root; "" / NA are
-      # not valid (they can't be a fastmap key, and `NS("")` yields a stray `-`).
-      if (length(namespace) == 1L && (is.na(namespace) || !nzchar(namespace))) {
-        stop(
-          "A module namespace must be a non-empty, non-NA string; use `NULL` for the root scope.",
-          call. = FALSE
-        )
-      }
+      validateScopeNamespace(namespace)
       ns <- NS(namespace)
       # The scope's own namespace, captured because the proxy `destroy()` below
       # has a `namespace` parameter that would otherwise shadow it.

--- a/R/mock-session.R
+++ b/R/mock-session.R
@@ -559,6 +559,14 @@ MockShinySession <- R6Class(
           call. = FALSE
         )
       }
+      # `character(0)` is the root; an empty string is not a valid namespace
+      # (it can't be used as a fastmap key, and `NS("")` yields a stray `-`).
+      if (length(namespace) == 1L && !nzchar(namespace)) {
+        stop(
+          "A module namespace must be a non-empty string; use `character(0)` for the root scope.",
+          call. = FALSE
+        )
+      }
       ns <- NS(namespace)
       # The scope's own namespace, captured because the proxy `destroy()` below
       # has a `namespace` parameter that would otherwise shadow it.

--- a/R/mock-session.R
+++ b/R/mock-session.R
@@ -767,9 +767,9 @@ MockShinySession <- R6Class(
     # @param ns The namespace key.
     # @return A Callbacks object.
     getOrCreateDestroyCallbacks = function(ns) {
-      # `character(0)` is the root; also fold in `""` since fastmap can't use
-      # an empty-string key.
-      if (length(ns) == 0 || !nzchar(ns)) ns <- destroyNsRoot
+      # `character(0)` is the root; the sentinel keeps it out of fastmap, which
+      # disallows an empty-string key.
+      if (length(ns) == 0) ns <- destroyNsRoot
       if (!private$destroyCallbacksByNs$containsKey(ns)) {
         private$destroyCallbacksByNs$set(ns, Callbacks$new())
       }

--- a/R/mock-session.R
+++ b/R/mock-session.R
@@ -321,11 +321,7 @@ MockShinySession <- R6Class(
     #'   callback.
     #' @param callback The callback to invoke on destroy.
     onDestroy = function(callback) {
-      ns <- destroyNsRoot
-      if (!private$destroyCallbacksByNs$containsKey(ns)) {
-        private$destroyCallbacksByNs$set(ns, Callbacks$new())
-      }
-      private$destroyCallbacksByNs$get(ns)$register(callback)
+      private$getOrCreateDestroyCallbacks(character(0))$register(callback)
     },
     #' @description Destroys a module session scope. On the root session, a
     #'   `namespace` is required: `session$destroy(namespace)` tears down the
@@ -334,7 +330,10 @@ MockShinySession <- R6Class(
     #' @param namespace Optional module `namespace` whose scope should be destroyed.
     destroy = function(namespace = character(0)) {
       if (length(namespace) == 0) {
-        stop("`$destroy()` cannot be called on the root session without a `namespace`. Pass a module `namespace` to tear down that scope (e.g. `session$destroy(\"my_module\")`), or call `$destroy()` on a module session.")
+        stop(
+          "`$destroy()` cannot be called on the root session without a `namespace`. Pass a module `namespace` to tear down that scope (e.g. `session$destroy(\"my_module\")`), or call `close()` to tear down the whole session.",
+          call. = FALSE
+        )
       }
       validateDestroyNamespace(namespace)
       self$makeScope(namespace)$destroy()
@@ -787,7 +786,7 @@ MockShinySession <- R6Class(
       # The root scope can only be torn down via `close()` (allowRoot = TRUE).
       if (isRoot && !allowRoot) {
         stop(
-          "`$destroy()` cannot be called on the root session without a `namespace`. Pass a module `namespace` to tear down that scope (e.g. `session$destroy(\"my_module\")`), or call `$destroy()` on a module session.",
+          "`$destroy()` cannot be called on the root session without a `namespace`. Pass a module `namespace` to tear down that scope (e.g. `session$destroy(\"my_module\")`), or call `close()` to tear down the whole session.",
           call. = FALSE
         )
       }

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -1031,6 +1031,14 @@ ShinySession <- R6Class(
           call. = FALSE
         )
       }
+      # `character(0)` is the root; an empty string is not a valid namespace
+      # (it can't be used as a fastmap key, and `NS(\"\")` yields a stray `-`).
+      if (length(namespace) == 1L && !nzchar(namespace)) {
+        stop(
+          "A module namespace must be a non-empty string; use `character(0)` for the root scope.",
+          call. = FALSE
+        )
+      }
       ns <- NS(namespace)
       # The scope's own namespace, captured because the proxy `destroy()` below
       # has a `namespace` parameter that would otherwise shadow it.

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -1031,11 +1031,11 @@ ShinySession <- R6Class(
           call. = FALSE
         )
       }
-      # `character(0)` is the root; an empty string is not a valid namespace
-      # (it can't be used as a fastmap key, and `NS(\"\")` yields a stray `-`).
-      if (length(namespace) == 1L && !nzchar(namespace)) {
+      # `character(0)` is the root; "" / NA are not valid namespaces (they
+      # can't be used as a fastmap key, and `NS("")` yields a stray `-`).
+      if (length(namespace) == 1L && (is.na(namespace) || !nzchar(namespace))) {
         stop(
-          "A module namespace must be a non-empty string; use `character(0)` for the root scope.",
+          "A module namespace must be a non-empty, non-NA string; use `character(0)` for the root scope.",
           call. = FALSE
         )
       }
@@ -1316,11 +1316,12 @@ ShinySession <- R6Class(
     },
     destroy = function(namespace = character(0)) {
       "Destroys a module session scope, cleaning up its reactive state and
-      invoking its `onDestroy()` callbacks. On the root session, an
-      `namespace` is required: `session$destroy(namespace)` tears down the
-      child module scope of that `namespace`. Calling `destroy()`
-      with no `namespace` on the root session is an error; the root session
-      is torn down via `close()`."
+      invoking its `onDestroy()` callbacks. `namespace` must be a non-empty,
+      non-NA string naming a child module scope; `session$destroy(namespace)`
+      tears that scope down. The root scope is identified by `character(0)`
+      (the default) and cannot be destroyed this way: calling `destroy()` with
+      no `namespace` on the root session is an error, since the root session is
+      torn down via `close()`."
       if (length(namespace) == 0) {
         stop(
           "`$destroy()` cannot be called on the root ShinySession without a `namespace`. Pass a module `namespace` to tear down that scope (e.g. `session$destroy(\"my_module\")`), or call `close()` to tear down the whole session.",

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -1125,18 +1125,21 @@ ShinySession <- R6Class(
       )
 
       # Given a char vector, return a logical vector indicating which of those
-      # strings are names of things in the namespace.
+      # strings are names of things in the namespace. For the root scope (a
+      # length-0 namespace) everything is in scope, since there is no prefix.
       filterNamespace <- function(x) {
+        if (length(namespace) == 0) return(rep_len(TRUE, length(x)))
         nsString <- paste0(namespace, ns.sep)
         substr(x, 1, nchar(nsString)) == nsString
       }
 
       # Given a char vector of namespaced names, return a char vector of corresponding
-      # names with namespace prefix removed.
+      # names with namespace prefix removed. The root scope has no prefix to strip.
       unNamespace <- function(x) {
         if (!all(filterNamespace(x))) {
           stop("x contains strings(s) that do not have namespace prefix ", namespace)
         }
+        if (length(namespace) == 0) return(x)
 
         nsString <- paste0(namespace, ns.sep)
         substring(x, nchar(nsString) + 1)
@@ -1164,7 +1167,9 @@ ShinySession <- R6Class(
           scopeState$values[[scopedName]] <- state$values[[origName]]
         })
 
-        if (!is.null(state$dir)) {
+        # The root scope shares the top-level bookmark dir; only a real
+        # (non-empty) namespace gets a subdir.
+        if (!is.null(state$dir) && length(namespace) > 0) {
           dir <- file.path(state$dir, namespace)
           if (dirExists(dir))
             scopeState$dir <- dir
@@ -1183,13 +1188,18 @@ ShinySession <- R6Class(
 
         scopeState <- ShinySaveState$new(scope$input, scope$getBookmarkExclude())
 
-        # Create subdir for this scope
+        # Create subdir for this scope. The root scope (length-0 namespace)
+        # shares the top-level dir rather than getting its own subdir.
         if (!is.null(state$dir)) {
-          scopeState$dir <- file.path(state$dir, namespace)
-          if (!dirExists(scopeState$dir)) {
-            res <- dir.create(scopeState$dir)
-            if (res == FALSE) {
-              stop("Error creating subdirectory for scope ", namespace)
+          if (length(namespace) == 0) {
+            scopeState$dir <- state$dir
+          } else {
+            scopeState$dir <- file.path(state$dir, namespace)
+            if (!dirExists(scopeState$dir)) {
+              res <- dir.create(scopeState$dir)
+              if (res == FALSE) {
+                stop("Error creating subdirectory for scope ", namespace)
+              }
             }
           }
         }

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -451,7 +451,8 @@ destroyNsRoot <- "..root"
 validateDestroyNamespace <- function(namespace) {
   if (!is.character(namespace) || length(namespace) != 1L || is.na(namespace) || !nzchar(namespace)) {
     stop(
-      "Invalid `namespace`: ", paste0(namespace, collapse = ", "),
+      "Invalid `namespace`: ",
+      encodeString(paste0(format(namespace), collapse = ", "), quote = '"'),
       ". `namespace` must be a non-empty length 1 character vector.",
       call. = FALSE
     )

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -820,8 +820,8 @@ ShinySession <- R6Class(
     },
 
     destroyNsKey = function(ns) {
-      # `character(0)` is the root; the sentinel keeps it out of fastmap, which
-      # disallows an empty-string key.
+      # The root scope (length 0: `NULL` or `character(0)`) maps to the sentinel
+      # key; fastmap can't use an empty-string key.
       if (length(ns) == 0) destroyNsRoot else ns
     },
 
@@ -832,7 +832,7 @@ ShinySession <- R6Class(
       }
       private$destroyCallbacksByNs$get(key)
     },
-    invokeDestroyCallbacks = function(namespace = character(0), allowRoot = FALSE) {
+    invokeDestroyCallbacks = function(namespace = NULL, allowRoot = FALSE) {
       isRoot <- length(namespace) == 0
       # The root scope can only be torn down via `close()` (allowRoot = TRUE).
       if (isRoot && !allowRoot) {
@@ -1031,11 +1031,11 @@ ShinySession <- R6Class(
           call. = FALSE
         )
       }
-      # `character(0)` is the root; "" / NA are not valid namespaces (they
-      # can't be used as a fastmap key, and `NS("")` yields a stray `-`).
+      # A length-0 namespace (`NULL` or `character(0)`) is the root; "" / NA are
+      # not valid (they can't be a fastmap key, and `NS("")` yields a stray `-`).
       if (length(namespace) == 1L && (is.na(namespace) || !nzchar(namespace))) {
         stop(
-          "A module namespace must be a non-empty, non-NA string; use `character(0)` for the root scope.",
+          "A module namespace must be a non-empty, non-NA string; use `NULL` for the root scope.",
           call. = FALSE
         )
       }
@@ -1114,7 +1114,7 @@ ShinySession <- R6Class(
         onDestroy = function(callback) {
           private$getOrCreateDestroyCallbacks(namespace)$register(callback)
         },
-        destroy = function(namespace = character(0)) {
+        destroy = function(namespace = NULL) {
           if (length(namespace) == 0) {
             # Tear down this scope itself.
             private$invokeDestroyCallbacks(selfNamespace)
@@ -1312,16 +1312,16 @@ ShinySession <- R6Class(
       unregister the callback. For module sessions, use this to register
       cleanup logic that runs when the module's UI is removed and
       `session$destroy()` is called."
-      private$getOrCreateDestroyCallbacks(character(0))$register(callback)
+      private$getOrCreateDestroyCallbacks(NULL)$register(callback)
     },
-    destroy = function(namespace = character(0)) {
+    destroy = function(namespace = NULL) {
       "Destroys a module session scope, cleaning up its reactive state and
       invoking its `onDestroy()` callbacks. `namespace` must be a non-empty,
       non-NA string naming a child module scope; `session$destroy(namespace)`
-      tears that scope down. The root scope is identified by `character(0)`
-      (the default) and cannot be destroyed this way: calling `destroy()` with
-      no `namespace` on the root session is an error, since the root session is
-      torn down via `close()`."
+      tears that scope down. The root scope is the absence of a namespace —
+      `NULL` (the default) or `character(0)` — and cannot be destroyed this
+      way: calling `destroy()` with no `namespace` on the root session is an
+      error, since the root session is torn down via `close()`."
       if (length(namespace) == 0) {
         stop(
           "`$destroy()` cannot be called on the root ShinySession without a `namespace`. Pass a module `namespace` to tear down that scope (e.g. `session$destroy(\"my_module\")`), or call `close()` to tear down the whole session.",

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -439,6 +439,20 @@ NS <- function(namespace, id = NULL) {
 ns.sep <- "-"
 
 
+# Validate the user-supplied `namespace` passed to `session$destroy(namespace)`.
+# Must be a single, non-empty, non-NA string. Checked at the public boundary,
+# before `makeScope()` runs (which would otherwise choke on bad input).
+validateDestroyNamespace <- function(namespace) {
+  if (!is.character(namespace) || length(namespace) != 1L || is.na(namespace) || !nzchar(namespace)) {
+    stop(
+      "Invalid `namespace`: ", paste0(namespace, collapse = ", "),
+      ". `namespace` must be a non-empty length 1 character vector.",
+      call. = FALSE
+    )
+  }
+  invisible(namespace)
+}
+
 #' @include utils.R
 ShinySession <- R6Class(
   'ShinySession',
@@ -802,7 +816,9 @@ ShinySession <- R6Class(
     destroyNsRoot = "..root",
 
     destroyNsKey = function(ns) {
-      if (length(ns) == 0) private$destroyNsRoot else ns
+      # `character(0)` is the root; also fold in `""` since fastmap can't use
+      # an empty-string key.
+      if (length(ns) == 0 || !nzchar(ns)) private$destroyNsRoot else ns
     },
 
     getOrCreateDestroyCallbacks = function(ns) {
@@ -814,21 +830,12 @@ ShinySession <- R6Class(
     },
     invokeDestroyCallbacks = function(namespace = character(0), allowRoot = FALSE) {
       isRoot <- length(namespace) == 0
-      if (!allowRoot) {
-        if (isRoot) {
-          stop(
-            "`$destroy()` cannot be called on the root ShinySession without a `namespace`. Pass a module `namespace` to tear down that scope (e.g. `session$destroy(\"my_module\")`), or call `$destroy()` on a module session.",
-            call. = FALSE
-          )
-        }
-        if (!is.character(namespace) || length(namespace) != 1L || is.na(namespace) || !nzchar(namespace)) {
-          stop(
-            "Invalid `namespace`:",
-            paste0(namespace, collapse = ", "),
-            ". `namespace` must be a non-empty length 1 character vector.",
-            call. = FALSE
-          )
-        }
+      # The root scope can only be torn down via `close()` (allowRoot = TRUE).
+      if (isRoot && !allowRoot) {
+        stop(
+          "`$destroy()` cannot be called on the root ShinySession without a `namespace`. Pass a module `namespace` to tear down that scope (e.g. `session$destroy(\"my_module\")`), or call `close()` to tear down the whole session.",
+          call. = FALSE
+        )
       }
 
       nsPrefix <- namespace
@@ -1013,7 +1020,17 @@ ShinySession <- R6Class(
       self
     },
     makeScope = function(namespace) {
+      if (identical(namespace, private$destroyNsRoot)) {
+        stop(
+          "The module namespace '", private$destroyNsRoot,
+          "' is reserved for internal use.",
+          call. = FALSE
+        )
+      }
       ns <- NS(namespace)
+      # The scope's own namespace, captured because the proxy `destroy()` below
+      # has a `namespace` parameter that would otherwise shadow it.
+      selfNamespace <- namespace
 
       # Private items for this scope. Can't be part of the scope object because
       # `$<-.session_proxy` doesn't allow assignment on overidden names.
@@ -1085,7 +1102,14 @@ ShinySession <- R6Class(
           private$getOrCreateDestroyCallbacks(namespace)$register(callback)
         },
         destroy = function(namespace = character(0)) {
-          self$makeScope(ns(namespace))$destroy()
+          if (length(namespace) == 0) {
+            # Tear down this scope itself.
+            private$invokeDestroyCallbacks(selfNamespace)
+          } else {
+            # Tear down a named child scope.
+            validateDestroyNamespace(namespace)
+            self$makeScope(ns(namespace))$destroy()
+          }
         }
       )
 
@@ -1284,6 +1308,13 @@ ShinySession <- R6Class(
       child module scope of that `namespace`. Calling `destroy()`
       with no `namespace` on the root session is an error; the root session
       is torn down via `close()`."
+      if (length(namespace) == 0) {
+        stop(
+          "`$destroy()` cannot be called on the root ShinySession without a `namespace`. Pass a module `namespace` to tear down that scope (e.g. `session$destroy(\"my_module\")`), or call `close()` to tear down the whole session.",
+          call. = FALSE
+        )
+      }
+      validateDestroyNamespace(namespace)
       self$makeScope(namespace)$destroy()
     },
     onInputReceived = function(callback) {

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -1090,7 +1090,8 @@ ShinySession <- R6Class(
             dots <- eval(substitute(alist(...)))
           }
 
-          if (any_unnamed(dots)) stop("exportTestValues: all arguments must be named.")
+          if (any_unnamed(dots)) 
+            stop("exportTestValues: all arguments must be named.")
 
           names(dots) <- ns(names(dots))
 

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -438,6 +438,12 @@ NS <- function(namespace, id = NULL) {
 #' @export
 ns.sep <- "-"
 
+# Sentinel key under which root-level (non-namespaced) destroy callbacks are
+# stored. It must be a non-zero-length character string because it is used as a
+# fastmap key, and fastmap disallows "" (and NA) keys. The leading dots also
+# keep it from colliding with a real module namespace (which `makeScope()`
+# additionally guards against).
+destroyNsRoot <- "..root"
 
 # Validate the user-supplied `namespace` passed to `session$destroy(namespace)`.
 # Must be a single, non-empty, non-NA string. Checked at the public boundary,
@@ -812,13 +818,10 @@ ShinySession <- R6Class(
       invisible()
     },
 
-    # Sentinel key for root-level destroy callbacks (fastmap disallows empty string keys)
-    destroyNsRoot = "..root",
-
     destroyNsKey = function(ns) {
       # `character(0)` is the root; also fold in `""` since fastmap can't use
       # an empty-string key.
-      if (length(ns) == 0 || !nzchar(ns)) private$destroyNsRoot else ns
+      if (length(ns) == 0 || !nzchar(ns)) destroyNsRoot else ns
     },
 
     getOrCreateDestroyCallbacks = function(ns) {
@@ -852,7 +855,7 @@ ShinySession <- R6Class(
       if (length(matching) > 0L) {
         # Sort deepest-first (most separators first); root sentinel always last
         depths <- nchar(gsub(paste0("[^", ns.sep, "]"), "", matching))
-        isRootSentinel <- matching == private$destroyNsRoot
+        isRootSentinel <- matching == destroyNsRoot
         matching <- matching[order(-depths, isRootSentinel, matching)]
 
         for (ns in matching) {
@@ -1020,9 +1023,9 @@ ShinySession <- R6Class(
       self
     },
     makeScope = function(namespace) {
-      if (identical(namespace, private$destroyNsRoot)) {
+      if (identical(namespace, destroyNsRoot)) {
         stop(
-          "The module namespace '", private$destroyNsRoot,
+          "The module namespace '", destroyNsRoot,
           "' is reserved for internal use.",
           call. = FALSE
         )

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -820,9 +820,9 @@ ShinySession <- R6Class(
     },
 
     destroyNsKey = function(ns) {
-      # `character(0)` is the root; also fold in `""` since fastmap can't use
-      # an empty-string key.
-      if (length(ns) == 0 || !nzchar(ns)) destroyNsRoot else ns
+      # `character(0)` is the root; the sentinel keeps it out of fastmap, which
+      # disallows an empty-string key.
+      if (length(ns) == 0) destroyNsRoot else ns
     },
 
     getOrCreateDestroyCallbacks = function(ns) {

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -1316,8 +1316,8 @@ ShinySession <- R6Class(
       "Destroys a module session scope, cleaning up its reactive state and
       invoking its `onDestroy()` callbacks. `namespace` must be a non-empty,
       non-NA string naming a child module scope; `session$destroy(namespace)`
-      tears that scope down. The root scope is the absence of a namespace —
-      `NULL` (the default) or `character(0)` — and cannot be destroyed this
+      tears that scope down. The root scope is the absence of a namespace --
+      `NULL` (the default) or `character(0)` -- and cannot be destroyed this
       way: calling `destroy()` with no `namespace` on the root session is an
       error, since the root session is torn down via `close()`."
       if (length(namespace) == 0) {

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -445,35 +445,27 @@ ns.sep <- "-"
 # additionally guards against).
 destroyNsRoot <- "..root"
 
-# Validate the user-supplied `namespace` passed to `session$destroy(namespace)`.
-# Must be a single, non-empty, non-NA string. Checked at the public boundary,
-# before `makeScope()` runs (which would otherwise choke on bad input).
-validateDestroyNamespace <- function(namespace) {
+# Validate a module `namespace`. A namespace must be a single, non-empty,
+# non-NA string and may not be the reserved sentinel. When `allow_root = TRUE`
+# (e.g. `makeScope()`), the root scope -- a length-0 `NULL` / `character(0)` --
+# is also accepted; the destroy entry points pass `allow_root = FALSE` because a
+# child scope must be named explicitly.
+validateNamespace <- function(namespace, allow_root = FALSE) {
+  if (allow_root && length(namespace) == 0) {
+    return(invisible(namespace))
+  }
   if (!is.character(namespace) || length(namespace) != 1L || is.na(namespace) || !nzchar(namespace)) {
     stop(
       "Invalid `namespace`: ",
       encodeString(paste0(format(namespace), collapse = ", "), quote = '"'),
-      ". `namespace` must be a non-empty length 1 character vector.",
+      ". A module namespace must be a non-empty, non-NA string; use `NULL` for the root scope.",
       call. = FALSE
     )
   }
-  invisible(namespace)
-}
-
-# Validate a namespace passed to `makeScope()`. The root (length 0: `NULL` or
-# `character(0)`) is allowed; "" / NA are rejected (they can't be a fastmap key,
-# and `NS("")` yields a stray `-`); the reserved sentinel is rejected too.
-validateScopeNamespace <- function(namespace) {
   if (identical(namespace, destroyNsRoot)) {
     stop(
       "The module namespace '", destroyNsRoot,
       "' is reserved for internal use.",
-      call. = FALSE
-    )
-  }
-  if (length(namespace) == 1L && (is.na(namespace) || !nzchar(namespace))) {
-    stop(
-      "A module namespace must be a non-empty, non-NA string; use `NULL` for the root scope.",
       call. = FALSE
     )
   }
@@ -1044,7 +1036,7 @@ ShinySession <- R6Class(
       self
     },
     makeScope = function(namespace) {
-      validateScopeNamespace(namespace)
+      validateNamespace(namespace, allow_root = TRUE)
       ns <- NS(namespace)
       # The scope's own namespace, captured because the proxy `destroy()` below
       # has a `namespace` parameter that would otherwise shadow it.
@@ -1126,7 +1118,7 @@ ShinySession <- R6Class(
             private$invokeDestroyCallbacks(selfNamespace)
           } else {
             # Tear down a named child scope.
-            validateDestroyNamespace(namespace)
+            validateNamespace(namespace)
             self$makeScope(ns(namespace))$destroy()
           }
         }
@@ -1334,7 +1326,7 @@ ShinySession <- R6Class(
           call. = FALSE
         )
       }
-      validateDestroyNamespace(namespace)
+      validateNamespace(namespace)
       self$makeScope(namespace)$destroy()
     },
     onInputReceived = function(callback) {

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -1090,7 +1090,7 @@ ShinySession <- R6Class(
             dots <- eval(substitute(alist(...)))
           }
 
-          if (any_unnamed(dots)) 
+          if (any_unnamed(dots))
             stop("exportTestValues: all arguments must be named.")
 
           names(dots) <- ns(names(dots))

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -439,16 +439,6 @@ NS <- function(namespace, id = NULL) {
 ns.sep <- "-"
 
 
-# Validate the `id` passed to `session$destroy(id)`. Must be a single,
-# non-empty, non-NA string. The reserved `..root` sentinel is additionally
-# rejected by `makeScope()`.
-validateDestroyId <- function(id) {
-  if (!is.character(id) || length(id) != 1L || is.na(id) || !nzchar(id)) {
-    stop("`id` must be a single, non-empty string.", call. = FALSE)
-  }
-  invisible(id)
-}
-
 #' @include utils.R
 ShinySession <- R6Class(
   'ShinySession',
@@ -812,7 +802,7 @@ ShinySession <- R6Class(
     destroyNsRoot = "..root",
 
     destroyNsKey = function(ns) {
-      if (!nzchar(ns)) private$destroyNsRoot else ns
+      if (length(ns) == 0) private$destroyNsRoot else ns
     },
 
     getOrCreateDestroyCallbacks = function(ns) {
@@ -822,9 +812,27 @@ ShinySession <- R6Class(
       }
       private$destroyCallbacksByNs$get(key)
     },
-    invokeDestroyCallbacks = function(nsPrefix = "") {
+    invokeDestroyCallbacks = function(namespace = character(0), allowRoot = FALSE) {
+      isRoot <- length(namespace) == 0
+      if (!allowRoot) {
+        if (isRoot) {
+          stop(
+            "`$destroy()` cannot be called on the root ShinySession without a `namespace`. Pass a module `namespace` to tear down that scope (e.g. `session$destroy(\"my_module\")`), or call `$destroy()` on a module session.",
+            call. = FALSE
+          )
+        }
+        if (!is.character(namespace) || length(namespace) != 1L || is.na(namespace) || !nzchar(namespace)) {
+          stop(
+            "Invalid `namespace`:",
+            paste0(namespace, collapse = ", "),
+            ". `namespace` must be a non-empty length 1 character vector.",
+            call. = FALSE
+          )
+        }
+      }
+
+      nsPrefix <- namespace
       allNs <- private$destroyCallbacksByNs$keys()
-      isRoot <- !nzchar(nsPrefix)
 
       if (!isRoot) {
         nsPrefixWithSep <- paste0(nsPrefix, ns.sep)
@@ -1005,13 +1013,6 @@ ShinySession <- R6Class(
       self
     },
     makeScope = function(namespace) {
-      if (identical(namespace, private$destroyNsRoot)) {
-        stop(
-          "The module namespace '", private$destroyNsRoot,
-          "' is reserved for internal use.",
-          call. = FALSE
-        )
-      }
       ns <- NS(namespace)
 
       # Private items for this scope. Can't be part of the scope object because
@@ -1069,8 +1070,7 @@ ShinySession <- R6Class(
             dots <- eval(substitute(alist(...)))
           }
 
-          if (any_unnamed(dots))
-            stop("exportTestValues: all arguments must be named.")
+          if (any_unnamed(dots)) stop("exportTestValues: all arguments must be named.")
 
           names(dots) <- ns(names(dots))
 
@@ -1084,13 +1084,8 @@ ShinySession <- R6Class(
         onDestroy = function(callback) {
           private$getOrCreateDestroyCallbacks(namespace)$register(callback)
         },
-        destroy = function(id = NULL) {
-          if (is.null(id)) {
-            private$invokeDestroyCallbacks(namespace)
-          } else {
-            validateDestroyId(id)
-            self$makeScope(ns(id))$destroy()
-          }
+        destroy = function(namespace = character(0)) {
+          self$makeScope(ns(namespace))$destroy()
         }
       )
 
@@ -1280,20 +1275,16 @@ ShinySession <- R6Class(
       unregister the callback. For module sessions, use this to register
       cleanup logic that runs when the module's UI is removed and
       `session$destroy()` is called."
-      private$getOrCreateDestroyCallbacks("")$register(callback)
+      private$getOrCreateDestroyCallbacks(character(0))$register(callback)
     },
-    destroy = function(id = NULL) {
+    destroy = function(namespace = character(0)) {
       "Destroys a module session scope, cleaning up its reactive state and
       invoking its `onDestroy()` callbacks. On the root session, an
-      `id` is required: `session$destroy(id)` tears down the
-      child module scope of that `id`. Calling `destroy()`
-      with no `id` on the root session is an error; the root session
+      `namespace` is required: `session$destroy(namespace)` tears down the
+      child module scope of that `namespace`. Calling `destroy()`
+      with no `namespace` on the root session is an error; the root session
       is torn down via `close()`."
-      if (is.null(id)) {
-        stop("`$destroy()` cannot be called on the root ShinySession without an `id`. Pass a module `id` to tear down that scope (e.g. `session$destroy(\"my_module\")`), or call `$destroy()` on a module session.")
-      }
-      validateDestroyId(id)
-      self$makeScope(id)$destroy()
+      self$makeScope(namespace)$destroy()
     },
     onInputReceived = function(callback) {
       "Registers the given callback to be invoked when the session receives
@@ -1345,7 +1336,7 @@ ShinySession <- R6Class(
           private$closedCallbacks$invoke(onError = printError, ..stacktraceon = TRUE)
         })
       })
-      private$invokeDestroyCallbacks("")
+      private$invokeDestroyCallbacks(allowRoot = TRUE)
     },
     isClosed = function() {
       return(self$closed)

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -460,6 +460,26 @@ validateDestroyNamespace <- function(namespace) {
   invisible(namespace)
 }
 
+# Validate a namespace passed to `makeScope()`. The root (length 0: `NULL` or
+# `character(0)`) is allowed; "" / NA are rejected (they can't be a fastmap key,
+# and `NS("")` yields a stray `-`); the reserved sentinel is rejected too.
+validateScopeNamespace <- function(namespace) {
+  if (identical(namespace, destroyNsRoot)) {
+    stop(
+      "The module namespace '", destroyNsRoot,
+      "' is reserved for internal use.",
+      call. = FALSE
+    )
+  }
+  if (length(namespace) == 1L && (is.na(namespace) || !nzchar(namespace))) {
+    stop(
+      "A module namespace must be a non-empty, non-NA string; use `NULL` for the root scope.",
+      call. = FALSE
+    )
+  }
+  invisible(namespace)
+}
+
 #' @include utils.R
 ShinySession <- R6Class(
   'ShinySession',
@@ -1024,21 +1044,7 @@ ShinySession <- R6Class(
       self
     },
     makeScope = function(namespace) {
-      if (identical(namespace, destroyNsRoot)) {
-        stop(
-          "The module namespace '", destroyNsRoot,
-          "' is reserved for internal use.",
-          call. = FALSE
-        )
-      }
-      # A length-0 namespace (`NULL` or `character(0)`) is the root; "" / NA are
-      # not valid (they can't be a fastmap key, and `NS("")` yields a stray `-`).
-      if (length(namespace) == 1L && (is.na(namespace) || !nzchar(namespace))) {
-        stop(
-          "A module namespace must be a non-empty, non-NA string; use `NULL` for the root scope.",
-          call. = FALSE
-        )
-      }
+      validateScopeNamespace(namespace)
       ns <- NS(namespace)
       # The scope's own namespace, captured because the proxy `destroy()` below
       # has a `namespace` parameter that would otherwise shadow it.

--- a/man/MockShinySession.Rd
+++ b/man/MockShinySession.Rd
@@ -217,19 +217,19 @@ callback.
 \if{html}{\out{<a id="method-MockShinySession-destroy"></a>}}
 \if{latex}{\out{\hypertarget{method-MockShinySession-destroy}{}}}
 \subsection{\code{MockShinySession$destroy()}}{
-  Destroys a module session scope. On the root session, an
-\code{id} is required: \code{session$destroy(id)} tears down the child module
-scope of that \code{id}. Calling \code{destroy()} with no \code{id} on the root
-session is an error.
+  Destroys a module session scope. On the root session, a
+\code{namespace} is required: \code{session$destroy(namespace)} tears down the
+child module scope of that \code{namespace}. Calling \code{destroy()} with no
+\code{namespace} on the root session is an error.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{MockShinySession$destroy(id = NULL)}
+    \preformatted{MockShinySession$destroy(namespace = character(0))}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{id}}{Optional module \code{id} whose scope should be destroyed.}
+      \item{\code{namespace}}{Optional module \code{namespace} whose scope should be destroyed.}
     }
     \if{html}{\out{</div>}}
   }

--- a/man/MockShinySession.Rd
+++ b/man/MockShinySession.Rd
@@ -217,10 +217,11 @@ callback.
 \if{html}{\out{<a id="method-MockShinySession-destroy"></a>}}
 \if{latex}{\out{\hypertarget{method-MockShinySession-destroy}{}}}
 \subsection{\code{MockShinySession$destroy()}}{
-  Destroys a module session scope. On the root session, a
-\code{namespace} is required: \code{session$destroy(namespace)} tears down the
-child module scope of that \code{namespace}. Calling \code{destroy()} with no
-\code{namespace} on the root session is an error.
+  Destroys a module session scope. \code{namespace} must be a
+non-empty, non-NA string naming a child module scope. The root scope is
+identified by \code{character(0)} (the default) and cannot be destroyed this
+way: calling \code{destroy()} with no \code{namespace} on the root session is an
+error.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{MockShinySession$destroy(namespace = character(0))}
@@ -229,7 +230,8 @@ child module scope of that \code{namespace}. Calling \code{destroy()} with no
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{namespace}}{Optional module \code{namespace} whose scope should be destroyed.}
+      \item{\code{namespace}}{Module \code{namespace} (a non-empty, non-NA string) whose
+scope should be destroyed.}
     }
     \if{html}{\out{</div>}}
   }

--- a/man/MockShinySession.Rd
+++ b/man/MockShinySession.Rd
@@ -219,12 +219,12 @@ callback.
 \subsection{\code{MockShinySession$destroy()}}{
   Destroys a module session scope. \code{namespace} must be a
 non-empty, non-NA string naming a child module scope. The root scope is
-identified by \code{character(0)} (the default) and cannot be destroyed this
-way: calling \code{destroy()} with no \code{namespace} on the root session is an
-error.
+the absence of a namespace -- \code{NULL} (the default) or \code{character(0)} --
+and cannot be destroyed this way: calling \code{destroy()} with no
+\code{namespace} on the root session is an error.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{MockShinySession$destroy(namespace = character(0))}
+    \preformatted{MockShinySession$destroy(namespace = NULL)}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{

--- a/tests/testthat/test-destroy.R
+++ b/tests/testthat/test-destroy.R
@@ -405,9 +405,9 @@ test_that("MockShinySession$onDestroy registers callback and returns unsubscribe
   expect_true(is.function(unsub))
 })
 
-test_that("MockShinySession$destroy() with no id throws an error", {
+test_that("MockShinySession$destroy() with no namespace throws an error", {
   session <- MockShinySession$new()
-  expect_error(session$destroy(), "without an `id`")
+  expect_error(session$destroy(), "without a `namespace`")
 })
 
 test_that("root session$destroy(id) tears down the named module scope", {
@@ -486,12 +486,46 @@ test_that("session$destroy(id) on an unknown id is a harmless no-op", {
   expect_no_error(session$destroy("never_created"))
 })
 
-test_that("session$destroy(id) validates the id argument", {
+test_that("session$destroy(namespace) validates the namespace argument", {
   session <- MockShinySession$new()
-  expect_error(session$destroy(1), "single, non-empty string")
-  expect_error(session$destroy(c("a", "b")), "single, non-empty string")
-  expect_error(session$destroy(""), "single, non-empty string")
-  expect_error(session$destroy(NA_character_), "single, non-empty string")
+  expect_error(session$destroy(1), "Invalid `namespace`")
+  expect_error(session$destroy(c("a", "b")), "Invalid `namespace`")
+  expect_error(session$destroy(""), "Invalid `namespace`")
+  expect_error(session$destroy(NA_character_), "Invalid `namespace`")
+})
+
+test_that("makeScope() accepts an empty (character(0)) namespace and leaves ids un-prefixed", {
+  session <- MockShinySession$new()
+  expect_no_error(scope <- session$makeScope(character(0)))
+  expect_identical(scope$ns("x"), "x")
+
+  called <- FALSE
+  scope$onDestroy(function() called <<- TRUE)
+  session$close()
+  expect_true(called)
+})
+
+test_that("callModule() with an empty namespace id does not error", {
+  session <- MockShinySession$new()
+  expect_no_error(
+    callModule(function(input, output, session) NULL, character(0), session = session)
+  )
+})
+
+test_that("session$destroy(namespace) tears down a module without recursing", {
+  session <- MockShinySession$new()
+  scope <- session$makeScope("mod1")
+
+  rv_destroyed <- FALSE
+  withReactiveDomain(scope, {
+    rv <- reactiveVal(1)
+    observe({ rv() })
+  })
+  flushReact()
+  scope$onDestroy(function() rv_destroyed <<- TRUE)
+
+  expect_no_error(session$destroy("mod1"))
+  expect_true(rv_destroyed)
 })
 
 test_that("session$destroy(id) does not leak bookmark-exclude callbacks", {

--- a/tests/testthat/test-destroy.R
+++ b/tests/testthat/test-destroy.R
@@ -494,15 +494,19 @@ test_that("session$destroy(namespace) validates the namespace argument", {
   expect_error(session$destroy(NA_character_), "Invalid `namespace`")
 })
 
-test_that("makeScope() accepts an empty (character(0)) namespace and leaves ids un-prefixed", {
-  session <- MockShinySession$new()
-  expect_no_error(scope <- session$makeScope(character(0)))
-  expect_identical(scope$ns("x"), "x")
+test_that("makeScope() accepts a NULL or character(0) root namespace and leaves ids un-prefixed", {
+  # `NULL` is the documented root spelling; `character(0)` is also accepted
+  # (both are length 0).
+  for (root in list(NULL, character(0))) {
+    session <- MockShinySession$new()
+    expect_no_error(scope <- session$makeScope(root))
+    expect_identical(scope$ns("x"), "x")
 
-  called <- FALSE
-  scope$onDestroy(function() called <<- TRUE)
-  session$close()
-  expect_true(called)
+    called <- FALSE
+    scope$onDestroy(function() called <<- TRUE)
+    session$close()
+    expect_true(called)
+  }
 })
 
 test_that("callModule() with an empty namespace id does not error", {
@@ -947,7 +951,8 @@ test_that("makeScope rejects empty-string and NA namespaces", {
     callModule(function(input, output, session) NULL, "", session = session),
     "non-empty, non-NA string"
   )
-  # `character(0)` (the root) is still accepted.
+  # Root scopes (length 0) are still accepted.
+  expect_no_error(session$makeScope(NULL))
   expect_no_error(session$makeScope(character(0)))
 })
 

--- a/tests/testthat/test-destroy.R
+++ b/tests/testthat/test-destroy.R
@@ -938,13 +938,14 @@ test_that("makeScope rejects reserved namespace '..root'", {
   expect_error(session$makeScope("..root"), "reserved")
 })
 
-test_that("makeScope rejects an empty-string namespace", {
+test_that("makeScope rejects empty-string and NA namespaces", {
   session <- MockShinySession$new()
-  expect_error(session$makeScope(""), "non-empty string")
+  expect_error(session$makeScope(""), "non-empty, non-NA string")
+  expect_error(session$makeScope(NA_character_), "non-empty, non-NA string")
   # `callModule()` doesn't validate `id`, so guard that entry point too.
   expect_error(
     callModule(function(input, output, session) NULL, "", session = session),
-    "non-empty string"
+    "non-empty, non-NA string"
   )
   # `character(0)` (the root) is still accepted.
   expect_no_error(session$makeScope(character(0)))

--- a/tests/testthat/test-destroy.R
+++ b/tests/testthat/test-destroy.R
@@ -938,6 +938,18 @@ test_that("makeScope rejects reserved namespace '..root'", {
   expect_error(session$makeScope("..root"), "reserved")
 })
 
+test_that("makeScope rejects an empty-string namespace", {
+  session <- MockShinySession$new()
+  expect_error(session$makeScope(""), "non-empty string")
+  # `callModule()` doesn't validate `id`, so guard that entry point too.
+  expect_error(
+    callModule(function(input, output, session) NULL, "", session = session),
+    "non-empty string"
+  )
+  # `character(0)` (the root) is still accepted.
+  expect_no_error(session$makeScope(character(0)))
+})
+
 test_that("createMockDomain supports onDestroy and destroy", {
   domain <- createMockDomain()
 


### PR DESCRIPTION
This refines the unreleased `session$destroy()` work (#4372) so that an empty module id — `callModule(server, character(0))`, the documented `NS()` length-0 idiom that packages like **teal** use to run a module server in the parent namespace — is treated as the root scope throughout the destroy machinery.

The first commit records a pairing-session refactor (making `character(0)` the canonical root value instead of `""`, renaming the destroy `id` argument to `namespace`). The second commit fixes several issues found while reviewing it:

- **Real `ShinySession$destroy()` no longer recurses infinitely.** The renamed `namespace` parameter shadowed the scope’s own captured namespace and the self-destroy branch had been replaced by a recursive `makeScope()` call that never reached `invokeDestroyCallbacks()`. The self-vs-child branch is restored, with the scope’s namespace captured as `selfNamespace`.

- **`MockShinySession` now matches the real session.** It had been left on the old `nzchar()`/`""` logic, so it still errored with "argument is of length zero" on `callModule(server, character(0))` (the teal failure path via `testServer()`). The `character(0)` handling is mirrored so mock and real behave identically.

- **Destroy `namespace` is validated at the public boundary**, before `makeScope()` runs, via a small `validateDestroyNamespace()` helper.

- **Restored safeguards:** the reserved `"..root"` namespace guard in `makeScope()`, and mapping `""` to root in the destroy-key logic (fastmap can’t key on an empty string).

## Tests
Full suite passes (0 failures). New coverage: empty-namespace `makeScope()`/`callModule()` acceptance, un-prefixed ids (`scope$ns("x") == "x"`), and non-recursive teardown.

Caveat for reviewers: the recursion fix is verified through `MockShinySession` (now line-for-line equivalent to the real session) plus static reasoning — the test harness can’t instantiate a live `ShinySession`.

Caught by reverse-dependency checks against teal. Supersedes the minimal-guard approach in #4394 (one of the two should be chosen).