### PR TITLE
Docs: Clarify update*Input() selected behavior with NULL (#2144)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,8 @@
 
 * Updated default HTTP headers for better security. Shiny now sends `X-Content-Type-Options: nosniff` instead of the legacy `X-UA-Compatible` header. This removes outdated Internet Explorer–specific behavior and adds a modern safeguard that prevents browsers from misinterpreting file types. (#4385)
 
+* Clarified the `selected` argument docs for `updateSelectInput()`, `updateSelectizeInput()`, `updateVarSelectInput()`, `updateCheckboxGroupInput()`, and `updateRadioButtons()`: when `choices` is also being updated, `selected = NULL` resets the selection (or, for `updateRadioButtons()`, picks the first choice) rather than preserving it. (#2144)
+
 ## Bug fixes
 
 * Loading shiny no longer creates `.Random.seed` in the global environment as a side effect. (#4382)

--- a/R/update-input.R
+++ b/R/update-input.R
@@ -522,6 +522,12 @@ updateInputOptions <- function(session, inputId, label = NULL, choices = NULL,
 #'
 #' @template update-input
 #' @inheritParams checkboxGroupInput
+#' @param selected The values that should be checked. The default of `NULL`
+#'   does not preserve the current selection when `choices` (or `choiceValues`)
+#'   is also being updated: the new checkboxes are rendered with none checked.
+#'   To preserve the current selection across a `choices` update, pass
+#'   `selected = input$id` explicitly. To clear the selection, pass
+#'   `selected = character(0)`.
 #'
 #' @seealso [checkboxGroupInput()]
 #'
@@ -572,6 +578,12 @@ updateCheckboxGroupInput <- function(session = getDefaultReactiveDomain(), input
 #'
 #' @template update-input
 #' @inheritParams radioButtons
+#' @param selected The value that should be selected. The default of `NULL`
+#'   does not preserve the current selection when `choices` (or `choiceValues`)
+#'   is also being updated: as with [radioButtons()] itself, it defaults to the
+#'   first choice. To preserve the current selection across a `choices` update,
+#'   pass `selected = input$id` explicitly. To start with no item selected,
+#'   pass `selected = character(0)`.
 #'
 #' @seealso [radioButtons()]
 #'
@@ -623,6 +635,14 @@ updateRadioButtons <- function(session = getDefaultReactiveDomain(), inputId, la
 #'
 #' @template update-input
 #' @inheritParams selectInput
+#' @param selected The values that should be selected. The default of `NULL`
+#'   does not preserve the current selection when the set of options is also
+#'   being updated (via `choices`, or `data` for the `varSelect` variants): the
+#'   options are re-rendered with none selected, except for server-side
+#'   single-select `updateSelectizeInput()`, which selects the first option. To
+#'   preserve the current selection across such an update, pass
+#'   `selected = input$id` explicitly. To clear the selection, pass
+#'   `selected = character(0)`.
 #'
 #' @seealso [selectInput()] [varSelectInput()]
 #'

--- a/man-roxygen/update-input.R
+++ b/man-roxygen/update-input.R
@@ -8,8 +8,9 @@
 #' inputs in the first place. For example, \code{\link{numericInput}()} and
 #' \code{updateNumericInput()} take a similar set of arguments.
 #'
-#' Any arguments with NULL values will be ignored; they will not result in any
-#' changes to the input object on the client.
+#' Arguments with \code{NULL} values are generally ignored: they will not
+#' result in any changes to the input object on the client. See the
+#' per-argument documentation for any exceptions.
 #'
 #' For \code{\link{radioButtons}()}, \code{\link{checkboxGroupInput}()} and
 #' \code{\link{selectInput}()}, the set of choices can be cleared by using

--- a/man/updateActionButton.Rd
+++ b/man/updateActionButton.Rd
@@ -45,8 +45,9 @@ The syntax of these functions is similar to the functions that created the
 inputs in the first place. For example, \code{\link{numericInput}()} and
 \code{updateNumericInput()} take a similar set of arguments.
 
-Any arguments with NULL values will be ignored; they will not result in any
-changes to the input object on the client.
+Arguments with \code{NULL} values are generally ignored: they will not
+result in any changes to the input object on the client. See the
+per-argument documentation for any exceptions.
 
 For \code{\link{radioButtons}()}, \code{\link{checkboxGroupInput}()} and
 \code{\link{selectInput}()}, the set of choices can be cleared by using

--- a/man/updateCheckboxGroupInput.Rd
+++ b/man/updateCheckboxGroupInput.Rd
@@ -29,7 +29,12 @@ this argument is provided, then \code{choiceNames} and \code{choiceValues}
 must not be provided, and vice-versa. The values should be strings; other
 types (such as logicals and numbers) will be coerced to strings.}
 
-\item{selected}{The values that should be initially selected, if any.}
+\item{selected}{The values that should be checked. The default of \code{NULL}
+does not preserve the current selection when \code{choices} (or \code{choiceValues})
+is also being updated: the new checkboxes are rendered with none checked.
+To preserve the current selection across a \code{choices} update, pass
+\code{selected = input$id} explicitly. To clear the selection, pass
+\code{selected = character(0)}.}
 
 \item{inline}{If \code{TRUE}, render the choices inline (i.e. horizontally)}
 
@@ -55,8 +60,9 @@ The syntax of these functions is similar to the functions that created the
 inputs in the first place. For example, \code{\link{numericInput}()} and
 \code{updateNumericInput()} take a similar set of arguments.
 
-Any arguments with NULL values will be ignored; they will not result in any
-changes to the input object on the client.
+Arguments with \code{NULL} values are generally ignored: they will not
+result in any changes to the input object on the client. See the
+per-argument documentation for any exceptions.
 
 For \code{\link{radioButtons}()}, \code{\link{checkboxGroupInput}()} and
 \code{\link{selectInput}()}, the set of choices can be cleared by using

--- a/man/updateCheckboxInput.Rd
+++ b/man/updateCheckboxInput.Rd
@@ -33,8 +33,9 @@ The syntax of these functions is similar to the functions that created the
 inputs in the first place. For example, \code{\link{numericInput}()} and
 \code{updateNumericInput()} take a similar set of arguments.
 
-Any arguments with NULL values will be ignored; they will not result in any
-changes to the input object on the client.
+Arguments with \code{NULL} values are generally ignored: they will not
+result in any changes to the input object on the client. See the
+per-argument documentation for any exceptions.
 
 For \code{\link{radioButtons}()}, \code{\link{checkboxGroupInput}()} and
 \code{\link{selectInput}()}, the set of choices can be cleared by using

--- a/man/updateDateInput.Rd
+++ b/man/updateDateInput.Rd
@@ -43,8 +43,9 @@ The syntax of these functions is similar to the functions that created the
 inputs in the first place. For example, \code{\link{numericInput}()} and
 \code{updateNumericInput()} take a similar set of arguments.
 
-Any arguments with NULL values will be ignored; they will not result in any
-changes to the input object on the client.
+Arguments with \code{NULL} values are generally ignored: they will not
+result in any changes to the input object on the client. See the
+per-argument documentation for any exceptions.
 
 For \code{\link{radioButtons}()}, \code{\link{checkboxGroupInput}()} and
 \code{\link{selectInput}()}, the set of choices can be cleared by using

--- a/man/updateDateRangeInput.Rd
+++ b/man/updateDateRangeInput.Rd
@@ -48,8 +48,9 @@ The syntax of these functions is similar to the functions that created the
 inputs in the first place. For example, \code{\link{numericInput}()} and
 \code{updateNumericInput()} take a similar set of arguments.
 
-Any arguments with NULL values will be ignored; they will not result in any
-changes to the input object on the client.
+Arguments with \code{NULL} values are generally ignored: they will not
+result in any changes to the input object on the client. See the
+per-argument documentation for any exceptions.
 
 For \code{\link{radioButtons}()}, \code{\link{checkboxGroupInput}()} and
 \code{\link{selectInput}()}, the set of choices can be cleared by using

--- a/man/updateNumericInput.Rd
+++ b/man/updateNumericInput.Rd
@@ -42,8 +42,9 @@ The syntax of these functions is similar to the functions that created the
 inputs in the first place. For example, \code{\link{numericInput}()} and
 \code{updateNumericInput()} take a similar set of arguments.
 
-Any arguments with NULL values will be ignored; they will not result in any
-changes to the input object on the client.
+Arguments with \code{NULL} values are generally ignored: they will not
+result in any changes to the input object on the client. See the
+per-argument documentation for any exceptions.
 
 For \code{\link{radioButtons}()}, \code{\link{checkboxGroupInput}()} and
 \code{\link{selectInput}()}, the set of choices can be cleared by using

--- a/man/updateRadioButtons.Rd
+++ b/man/updateRadioButtons.Rd
@@ -29,9 +29,12 @@ this argument is provided, then \code{choiceNames} and \code{choiceValues} must 
 be provided, and vice-versa. The values should be strings; other types
 (such as logicals and numbers) will be coerced to strings.}
 
-\item{selected}{The initially selected value. If not specified, then it
-defaults to the first item in \code{choices}. To start with no items selected,
-use \code{character(0)}.}
+\item{selected}{The value that should be selected. The default of \code{NULL}
+does not preserve the current selection when \code{choices} (or \code{choiceValues})
+is also being updated: as with \code{\link[=radioButtons]{radioButtons()}} itself, it defaults to the
+first choice. To preserve the current selection across a \code{choices} update,
+pass \code{selected = input$id} explicitly. To start with no item selected,
+pass \code{selected = character(0)}.}
 
 \item{inline}{If \code{TRUE}, render the choices inline (i.e. horizontally)}
 
@@ -56,8 +59,9 @@ The syntax of these functions is similar to the functions that created the
 inputs in the first place. For example, \code{\link{numericInput}()} and
 \code{updateNumericInput()} take a similar set of arguments.
 
-Any arguments with NULL values will be ignored; they will not result in any
-changes to the input object on the client.
+Arguments with \code{NULL} values are generally ignored: they will not
+result in any changes to the input object on the client. See the
+per-argument documentation for any exceptions.
 
 For \code{\link{radioButtons}()}, \code{\link{checkboxGroupInput}()} and
 \code{\link{selectInput}()}, the set of choices can be cleared by using

--- a/man/updateSelectInput.Rd
+++ b/man/updateSelectInput.Rd
@@ -59,8 +59,14 @@ this case, the outermost names will be used as the group labels (leveraging
 the \verb{<optgroup>} HTML tag) for the elements in the respective sublist. See
 the example section for a small demo of this feature.}
 
-\item{selected}{The initially selected value (or multiple values if \code{multiple = TRUE}). If not specified then defaults to the first value for
-single-select lists and no values for multiple select lists.}
+\item{selected}{The values that should be selected. The default of \code{NULL}
+does not preserve the current selection when the set of options is also
+being updated (via \code{choices}, or \code{data} for the \code{varSelect} variants): the
+options are re-rendered with none selected, except for server-side
+single-select \code{updateSelectizeInput()}, which selects the first option. To
+preserve the current selection across such an update, pass
+\code{selected = input$id} explicitly. To clear the selection, pass
+\code{selected = character(0)}.}
 
 \item{options}{A list of options. See the documentation of \pkg{selectize.js}(\url{https://selectize.dev/docs/usage})
 for possible options (character option values inside \code{\link[base:I]{base::I()}} will
@@ -86,8 +92,9 @@ The syntax of these functions is similar to the functions that created the
 inputs in the first place. For example, \code{\link{numericInput}()} and
 \code{updateNumericInput()} take a similar set of arguments.
 
-Any arguments with NULL values will be ignored; they will not result in any
-changes to the input object on the client.
+Arguments with \code{NULL} values are generally ignored: they will not
+result in any changes to the input object on the client. See the
+per-argument documentation for any exceptions.
 
 For \code{\link{radioButtons}()}, \code{\link{checkboxGroupInput}()} and
 \code{\link{selectInput}()}, the set of choices can be cleared by using

--- a/man/updateSliderInput.Rd
+++ b/man/updateSliderInput.Rd
@@ -63,8 +63,9 @@ The syntax of these functions is similar to the functions that created the
 inputs in the first place. For example, \code{\link{numericInput}()} and
 \code{updateNumericInput()} take a similar set of arguments.
 
-Any arguments with NULL values will be ignored; they will not result in any
-changes to the input object on the client.
+Arguments with \code{NULL} values are generally ignored: they will not
+result in any changes to the input object on the client. See the
+per-argument documentation for any exceptions.
 
 For \code{\link{radioButtons}()}, \code{\link{checkboxGroupInput}()} and
 \code{\link{selectInput}()}, the set of choices can be cleared by using

--- a/man/updateTextAreaInput.Rd
+++ b/man/updateTextAreaInput.Rd
@@ -37,8 +37,9 @@ The syntax of these functions is similar to the functions that created the
 inputs in the first place. For example, \code{\link{numericInput}()} and
 \code{updateNumericInput()} take a similar set of arguments.
 
-Any arguments with NULL values will be ignored; they will not result in any
-changes to the input object on the client.
+Arguments with \code{NULL} values are generally ignored: they will not
+result in any changes to the input object on the client. See the
+per-argument documentation for any exceptions.
 
 For \code{\link{radioButtons}()}, \code{\link{checkboxGroupInput}()} and
 \code{\link{selectInput}()}, the set of choices can be cleared by using

--- a/man/updateTextInput.Rd
+++ b/man/updateTextInput.Rd
@@ -37,8 +37,9 @@ The syntax of these functions is similar to the functions that created the
 inputs in the first place. For example, \code{\link{numericInput}()} and
 \code{updateNumericInput()} take a similar set of arguments.
 
-Any arguments with NULL values will be ignored; they will not result in any
-changes to the input object on the client.
+Arguments with \code{NULL} values are generally ignored: they will not
+result in any changes to the input object on the client. See the
+per-argument documentation for any exceptions.
 
 For \code{\link{radioButtons}()}, \code{\link{checkboxGroupInput}()} and
 \code{\link{selectInput}()}, the set of choices can be cleared by using


### PR DESCRIPTION
Closes #2144

## Summary

`updateSelectInput()`'s documentation was self-contradicting. The shared `man-roxygen/update-input.R` template stated that "Any arguments with NULL values will be ignored; they will not result in any changes to the input object on the client", but for choice-based inputs `selected = NULL` (the default) does *not* preserve the current selection — when `choices` is also being updated, the options are re-rendered with nothing selected. The inherited `selected` param doc also carried `selectInput()`'s constructor wording ("defaults to the first value..."), which is misleading for an updater.

This is a docs-only change with no behavior change. It generalizes the shared template so its first paragraph is accurate for all `update*Input()` functions ("Arguments with `NULL` values are generally ignored... See the per-argument documentation for any exceptions."). The previous wording named `selected`/choice-inputs in the *shared* template, which leaked an irrelevant sentence onto unrelated functions (`updateSliderInput()`, `updateTextInput()`, etc.) that have no `selected` argument. It then adds per-argument `selected` documentation to `updateSelectInput()` (shared via `@rdname` with the selectize/varSelect variants), `updateCheckboxGroupInput()`, and `updateRadioButtons()`, describing how `NULL` (no-op unless options are also updated), `character(0)` (clears the selection), and an explicit value behave, plus the server-side single-select selectize and radio "first choice" caveats.

All behavioral claims were verified against the actual `sendInputMessage()` payloads using a mock session.

## Verification

The documented contract, confirmed by inspecting the message sent to the client via a mock session:

- `selected = NULL`, no `choices` update -> empty message (no-op, selection preserved)
- `selected = NULL`, with `choices` -> options re-rendered, none selected
- `selected = character(0)`, no `choices` -> `value = character(0)` (selection cleared)
- `updateRadioButtons(selected = NULL, choices = ...)` -> first choice selected

Rendered help pages: `?updateSelectInput` now describes updater semantics for `selected`; `?updateSliderInput` (and other non-choice updaters) show only the clean generic paragraph with no stray `selected` reference.