### PR TITLE
Make `{watcher}` a required dependency for autoreload

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -97,6 +97,7 @@ Imports:
     sourcetools,
     tools,
     utils,
+    watcher (>= 0.2.0),
     withr,
     xtable
 Suggests:
@@ -119,7 +120,6 @@ Suggests:
     shinytest2,
     showtext,
     testthat (>= 3.2.1),
-    watcher,
     yaml
 Config/Needs/check: shinyjs
 Config/roxygen2/version: 8.0.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # shiny (development version)
 
-* `{watcher}` is now a required dependency and is always used for autoreload file watching, so it no longer needs to be installed separately. The legacy polling-based file watcher has been removed.
+* `{watcher}` is now a required dependency and is always used for autoreload file watching, so it no longer needs to be installed separately. The legacy polling-based file watcher has been removed. (#4403)
 
 # shiny 1.14.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # shiny (development version)
 
+* `{watcher}` is now a required dependency and is always used for autoreload file watching, so it no longer needs to be installed separately. The legacy polling-based file watcher has been removed.
+
 # shiny 1.14.0
 
 ## New features

--- a/R/shiny-options.R
+++ b/R/shiny-options.R
@@ -65,19 +65,18 @@ getShinyOption <- function(name, default = NULL) {
 #'   changes are detected, all connected Shiny sessions are reloaded. This
 #'   allows for fast feedback loops when tweaking Shiny UI.
 #'
-#'   Monitoring for changes is no longer expensive, thanks to the \pkg{watcher}
-#'   package, but this feature is still intended only for development.
+#'   Shiny uses the \pkg{watcher} package to efficiently monitor for changes,
+#'   but this feature is still intended only for development.
 #'
 #'   You can customize the file patterns Shiny will monitor by setting the
 #'   shiny.autoreload.pattern option. For example, to monitor only `ui.R`:
 #'   `options(shiny.autoreload.pattern = glob2rx("ui.R"))`.
 #'
-#'   As mentioned above, Shiny no longer polls watched files for changes.
-#'   Instead, using \pkg{watcher}, Shiny is notified of file changes as they
-#'   occur. These changes are batched together within a customizable latency
-#'   period. You can adjust this period by setting
+#'   Using \pkg{watcher}, Shiny is notified of file changes as they occur
+#'   rather than polling. These changes are batched together within a
+#'   customizable latency period. You can adjust this period by setting
 #'   `options(shiny.autoreload.interval = 2000)` (in milliseconds). This value
-#'   converted to seconds and passed to the `latency` argument of
+#'   is converted to seconds and passed to the `latency` argument of
 #'   [watcher::watcher()]. The default latency is 250ms.}
 #' \item{shiny.deprecation.messages (defaults to `TRUE`)}{This controls whether messages for
 #'   deprecated functions in Shiny will be printed. See

--- a/R/shinyapp.R
+++ b/R/shinyapp.R
@@ -289,14 +289,13 @@ shinyAppDir_serverR <- function(appDir, options=list()) {
   )
 }
 
-# Start a reactive observer that continually monitors dir for changes to files
-# that have the extensions: r, htm, html, js, css, png, jpg, jpeg, gif. Case is
-# ignored when checking extensions. If any changes are detected, all connected
-# Shiny sessions are reloaded.
+# Start a {watcher} file watcher that continually monitors dir for changes to
+# files that have the extensions: r, htm, html, js, css, png, jpg, jpeg, gif.
+# Case is ignored when checking extensions. If any changes are detected, all
+# connected Shiny sessions are reloaded.
 #
-# Use options(shiny.autoreload = TRUE) to enable this behavior. Since monitoring
-# for changes is expensive (we are polling for mtimes here, nothing fancy) this
-# feature is intended only for development.
+# Use options(shiny.autoreload = TRUE) to enable this behavior. This feature is
+# intended only for development.
 #
 # You can customize the file patterns Shiny will monitor by setting the
 # shiny.autoreload.pattern option. For example, to monitor only ui.R:
@@ -313,72 +312,30 @@ initAutoReloadMonitor <- function(dir) {
     ".*\\.(r|html?|js|css|png|jpe?g|gif)$"
   )
 
-  
-  if (is_installed("watcher")) {
-    check_for_update <- function(paths) {
-      paths <- grep(
-        filePattern,
-        paths,
-        ignore.case = TRUE,
-        value = TRUE
-      )
-      
-      if (length(paths) == 0) {
-        return()
-      }
-      
-      cachedAutoReloadLastChanged$set()
-      autoReloadCallbacks$invoke()
-    }
-    
-    # [garrick, 2025-02-20] Shiny <= v1.10.0 used `invalidateLater()` with an
-    # autoreload.interval in ms. {watcher} instead uses a latency parameter in
-    # seconds, which serves a similar purpose and that I'm keeping for backcompat.
-    latency <- getOption("shiny.autoreload.interval", 250) / 1000
-    watcher <- watcher::watcher(dir, check_for_update, latency = latency)
-    watcher$start()
-    onStop(watcher$stop)
-  } else {
-    # Fall back to legacy observer behavior
-    if (!is_false(getOption("shiny.autoreload.legacy_warning", TRUE))) {
-      cli::cli_warn(
-        c(
-          "Using legacy autoreload file watching. Please install {.pkg watcher} for a more performant autoreload file watcher.",
-          "i" = "Set {.run options(shiny.autoreload.legacy_warning = FALSE)} to suppress this warning."
-        ),
-        .frequency = "regularly",
-        .frequency_id = "shiny.autoreload.legacy_warning"
-      )
+  check_for_update <- function(paths) {
+    paths <- grep(
+      filePattern,
+      paths,
+      ignore.case = TRUE,
+      value = TRUE
+    )
+
+    if (length(paths) == 0) {
+      return()
     }
 
-    lastValue <- NULL
-    observeLabel <- paste0("File Auto-Reload - '", basename(dir), "'")
-    watcher <- observe(label = observeLabel, {
-      files <- sort_c(
-        list.files(dir, pattern = filePattern, recursive = TRUE, ignore.case = TRUE)
-      )
-      times <- file.info(files)$mtime
-      names(times) <- files
-  
-      if (is.null(lastValue)) {
-        # First run
-        lastValue <<- times
-      } else if (!identical(lastValue, times)) {
-        # We've changed!
-        lastValue <<- times
-        cachedAutoReloadLastChanged$set()
-        autoReloadCallbacks$invoke()
-      }
-  
-      invalidateLater(getOption("shiny.autoreload.interval", 500))
-    })
-  
-    onStop(watcher$destroy)
-  
-    watcher$destroy
+    cachedAutoReloadLastChanged$set()
+    autoReloadCallbacks$invoke()
   }
 
-  invisible(watcher)
+  # [garrick, 2025-02-20] Shiny <= v1.10.0 used `invalidateLater()` with an
+  # autoreload.interval in ms. {watcher} instead uses a latency parameter in
+  # seconds, which serves a similar purpose and that I'm keeping for backcompat.
+  latency <- getOption("shiny.autoreload.interval", 250) / 1000
+  watcher <- watcher::watcher(dir, check_for_update, latency = latency)
+  watcher$start()
+
+  invisible(watcher$stop)
 }
 
 #' Load an app's supporting R files

--- a/man/shinyOptions.Rd
+++ b/man/shinyOptions.Rd
@@ -44,19 +44,18 @@ have the extensions: r, htm, html, js, css, png, jpg, jpeg, gif. If any
 changes are detected, all connected Shiny sessions are reloaded. This
 allows for fast feedback loops when tweaking Shiny UI.
 
-Monitoring for changes is no longer expensive, thanks to the \pkg{watcher}
-package, but this feature is still intended only for development.
+Shiny uses the \pkg{watcher} package to efficiently monitor for changes,
+but this feature is still intended only for development.
 
 You can customize the file patterns Shiny will monitor by setting the
 shiny.autoreload.pattern option. For example, to monitor only \code{ui.R}:
 \code{options(shiny.autoreload.pattern = glob2rx("ui.R"))}.
 
-As mentioned above, Shiny no longer polls watched files for changes.
-Instead, using \pkg{watcher}, Shiny is notified of file changes as they
-occur. These changes are batched together within a customizable latency
-period. You can adjust this period by setting
+Using \pkg{watcher}, Shiny is notified of file changes as they occur
+rather than polling. These changes are batched together within a
+customizable latency period. You can adjust this period by setting
 \code{options(shiny.autoreload.interval = 2000)} (in milliseconds). This value
-converted to seconds and passed to the \code{latency} argument of
+is converted to seconds and passed to the \code{latency} argument of
 \code{\link[watcher:watcher]{watcher::watcher()}}. The default latency is 250ms.}
 \item{shiny.deprecation.messages (defaults to \code{TRUE})}{This controls whether messages for
 deprecated functions in Shiny will be printed. See


### PR DESCRIPTION
## Summary

Moves `{watcher}` from `Suggests` to `Imports` and uses it unconditionally for autoreload. Removes the legacy polling-based file watcher.

## Changes

- **`DESCRIPTION`**: `watcher` → `Imports`, with `(>= 0.2.0)`.
- **`R/shinyapp.R`** (`initAutoReloadMonitor()`): drop the `is_installed("watcher")` branch, the legacy `observe()`/`invalidateLater()` poller, and the `shiny.autoreload.legacy_warning` option. Return `invisible(watcher$stop)` so cleanup flows through the existing `onStop → monitorHandle()` path.
- **`R/shiny-options.R`** / **`man/shinyOptions.Rd`**: simplify the `shiny.autoreload` option docs now that watcher is the sole path (drop the historical "no longer polls"/"no longer expensive" hedging).
- **`NEWS.md`**: note the dependency change.

## Compatibility

- `shiny.autoreload.interval` / `.pattern` unchanged (interval still passed as `latency`, default 250ms).
- `shiny.autoreload.legacy_warning` removed; silently ignored if set.