### PR TITLE
docs(mcp): correct mcpConfigure(arguments) init-restore claim

### DIFF
--- a/R/mcp-config.R
+++ b/R/mcp-config.R
@@ -25,8 +25,12 @@ MCP_DISPLAY_MODES <- c("inline", "fullscreen", "pip")
 #' @param arguments Optional named list of \pkg{ellmer} type objects (e.g.
 #'   [ellmer::type_integer()]) declaring the arguments the model may pass when
 #'   opening the app. Published as the tool's input schema and used as an
-#'   allow-list. Read within the app with [mcpUpdates()] (post-init) or via
-#'   input/bookmark restoration (init).
+#'   allow-list. Read within the app with [mcpUpdates()] and apply them from a
+#'   single `observe()` with the usual `updateXxxInput()` functions; the host
+#'   renders a fresh instance per tool call, so the same observer handles both
+#'   the initial open and any later re-open. There is no input/bookmark
+#'   auto-restore of init args (a brief flash from the widget default to the
+#'   model's value on open is unavoidable); see [mcp-session].
 #' @param direct Whether to advertise the direct-connect fast path (default
 #'   `TRUE`).
 #' @param displayModes Display modes the app supports; a subset of

--- a/man/mcpConfigure.Rd
+++ b/man/mcpConfigure.Rd
@@ -27,8 +27,12 @@ the model reads it to decide whether to open the app.}
 \item{arguments}{Optional named list of \pkg{ellmer} type objects (e.g.
 \code{\link[ellmer:type_integer]{ellmer::type_integer()}}) declaring the arguments the model may pass when
 opening the app. Published as the tool's input schema and used as an
-allow-list. Read within the app with \code{\link[=mcpUpdates]{mcpUpdates()}} (post-init) or via
-input/bookmark restoration (init).}
+allow-list. Read within the app with \code{\link[=mcpUpdates]{mcpUpdates()}} and apply them from a
+single \code{observe()} with the usual \code{updateXxxInput()} functions; the host
+renders a fresh instance per tool call, so the same observer handles both
+the initial open and any later re-open. There is no input/bookmark
+auto-restore of init args (a brief flash from the widget default to the
+model's value on open is unavoidable); see \link{mcp-session}.}
 
 \item{direct}{Whether to advertise the direct-connect fast path (default
 \code{TRUE}).}


### PR DESCRIPTION
Handles a documentation correction deferred as a non-goal from the [#4415](https://github.com/rstudio/shiny/issues/4415) design spec (the "widget auto-restore doc corrections from #4414" item).

## Problem
The `@param arguments` roxygen for `mcpConfigure()` still claimed init args could be read *"via input/bookmark restoration (init)."* That auto-restore path was proven unworkable for MCP Apps — the UI renders at `resources/read` before the tool-call arguments exist — and was removed in #4414. The stale claim was the only leftover; the other locations (`mcp/design-mcpConfigure.md`, `mcp/limitations.md`, `mcp/demo-app/app.R`, and the `R/mcp-session.R` roxygen) were already corrected during #4414.

The companion out-of-scope item (the `resourceUri`-args init-path spike) is already fully documented in `mcp/limitations.md` §1 and its summary table, so no change was needed there.

## Change
- `R/mcp-config.R`: describe the real mechanism — a single `mcpUpdates()` observer applying `updateXxxInput()`, fresh instance per tool call, no input/bookmark auto-restore, brief open flash unavoidable — matching the wording already in `R/mcp-session.R`.
- `man/mcpConfigure.Rd`: regenerated.

Docs-only. No NEWS entry (`mcpConfigure()` is still on the unreleased `mcp` feature branch).