### PR TITLE
feat(mcp): update a running Shiny MCP App in place via update_<appId>_app (#4415)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # shiny (development version)
 
+* Shiny MCP Apps configured with `mcpConfigure(arguments = ...)` now
+  auto-register a companion `update_<appId>_app` tool. A model can call it to
+  update an already-open app instance in place (via `mcpUpdates()`) instead of
+  re-opening the app, targeting a specific instance by the `session` id the app
+  announces on connect. (#4415)
+
 * Experimental support for serving a Shiny app as an MCP App (the Model
   Context Protocol Apps extension, SEP-1865). Calling `mcpConfigure()`
   before the app starts mounts an MCP endpoint at `/mcp` on the app's

--- a/R/mcp-config.R
+++ b/R/mcp-config.R
@@ -132,6 +132,14 @@ mcpToolName <- function() {
   if (is.null(id)) "open_shiny_app" else paste0("open_", id, "_app")
 }
 
+# update_shiny_app, or update_<appId>_app when an appId is configured. The
+# companion to mcpToolName(): the model calls this to change a running
+# instance in place instead of re-opening the app.
+mcpUpdateToolName <- function() {
+  id <- .globals$mcp$appId
+  if (is.null(id)) "update_shiny_app" else paste0("update_", id, "_app")
+}
+
 # Convert the configured `arguments` (named list of ellmer types) into the
 # JSON Schema published as the tool's inputSchema. Mirrors
 # mcpToolInputSchema() (R/mcp-server.R) so the two conversions stay aligned.

--- a/R/mcp-server.R
+++ b/R/mcp-server.R
@@ -495,7 +495,8 @@ mcpUpdateAppCall <- function(params, id) {
   }
   pushed <- mcpFilterArguments(args[setdiff(names(args), "session")])
   withReactiveDomain(session, {
-    mcpServerUpdatesFor(session)(pushed)
+    rv <- mcpServerUpdatesFor(session)
+    rv(utils::modifyList(isolate(rv()) %||% list(), pushed))
   })
   session$requestFlush()
   mcpResult(id, list(content = list(list(

--- a/R/mcp-server.R
+++ b/R/mcp-server.R
@@ -207,6 +207,34 @@ mcpToolInfo <- function() {
   )
 }
 
+# inputSchema for update_<appId>_app: the declared arguments allow-list plus a
+# required `session` string identifying the running instance to update.
+mcpUpdateToolInfo <- function() {
+  schema <- mcpArgumentsSchema(.globals$mcp$arguments)
+  schema$properties$session <- list(
+    type = "string",
+    description = paste(
+      "Id of the running app instance to update, as reported by the app when",
+      "it opened. Required."
+    )
+  )
+  schema$required <- as.list(unique(c(unlist(schema$required), "session")))
+  list(
+    name = mcpUpdateToolName(),
+    description = paste(
+      "Change parameters of the already-open app in place. Do NOT re-open the",
+      "app; use this to update the running instance identified by `session`."
+    ),
+    inputSchema = schema
+  )
+}
+
+# TRUE when a companion update_* tool should be published (author declared
+# arguments the model may push into a running session).
+mcpHasUpdateTool <- function() {
+  length(.globals$mcp$arguments) > 0
+}
+
 mcpCorsHeaders <- function() {
   list(
     "Access-Control-Allow-Origin" = "*",
@@ -334,6 +362,16 @@ mcpInitializeResult <- function(body) {
 
 mcpToolsList <- function() {
   info <- mcpToolInfo()
+  update_entry <- if (mcpHasUpdateTool()) {
+    upd <- mcpUpdateToolInfo()
+    list(list(
+      name = upd$name,
+      description = upd$description,
+      inputSchema = upd$inputSchema
+    ))
+  } else {
+    list()
+  }
   # unname: a partially named list would serialize as a JSON object rather
   # than the array that tools/list requires.
   unname(c(
@@ -343,6 +381,7 @@ mcpToolsList <- function() {
       inputSchema = info$inputSchema,
       `_meta` = list(ui = list(resourceUri = mcpResourceUri()))
     )),
+    update_entry,
     mcpTunnelToolsList(),
     lapply(mcpAuthorTools(), function(tool) {
       dropNulls(list(
@@ -358,6 +397,7 @@ mcpToolsList <- function() {
 mcpReservedToolNames <- function() {
   c(
     mcpToolInfo()$name,
+    if (mcpHasUpdateTool()) mcpUpdateToolName(),
     vapply(mcpTunnelToolsList(), function(t) t$name, character(1))
   )
 }

--- a/R/mcp-server.R
+++ b/R/mcp-server.R
@@ -471,6 +471,39 @@ mcpAuthorToolCall <- function(tool, params, id) {
   )
 }
 
+# Handle a model call to update_<appId>_app: push the (allow-list-filtered)
+# arguments into the running session named by `session`, inside that session's
+# reactive domain so its mcpUpdates() observer re-fires.
+mcpUpdateAppCall <- function(params, id) {
+  args <- params$arguments %||% list()
+  token <- args$session
+  if (!is.character(token) || length(token) != 1 || !nzchar(token)) {
+    return(mcpToolErrorResult(
+      id,
+      "update requires a `session` id identifying the running app instance."
+    ))
+  }
+  session <- appsByToken$get(token)
+  if (is.null(session) || !isMcpSession(session)) {
+    return(mcpToolErrorResult(id, sprintf(
+      paste(
+        "No running app session with id '%s'. Open the app first, or use the",
+        "id the app reported for the instance you want to change."
+      ),
+      token
+    )))
+  }
+  pushed <- mcpFilterArguments(args[setdiff(names(args), "session")])
+  withReactiveDomain(session, {
+    mcpServerUpdatesFor(session)(pushed)
+  })
+  session$requestFlush()
+  mcpResult(id, list(content = list(list(
+    type = "text",
+    text = "Updated the running app in place."
+  ))))
+}
+
 mcpToolCall <- function(body, uiHandler, wsHandler) {
   name <- body$params$name %||% ""
   info <- mcpToolInfo()
@@ -481,6 +514,9 @@ mcpToolCall <- function(body, uiHandler, wsHandler) {
         text = "The Shiny app is now displayed in the conversation."
       ))
     )))
+  }
+  if (mcpHasUpdateTool() && identical(name, mcpUpdateToolName())) {
+    return(mcpUpdateAppCall(body$params, body$id))
   }
   localName <- mcpTunnelLocalName(name)
   if (startsWith(localName, "_shiny_")) {

--- a/R/mcp-session.R
+++ b/R/mcp-session.R
@@ -15,12 +15,18 @@
 #'   `mcpConfigure(arguments = list(...))`. Apply them from a single
 #'   `observe()` with the usual `updateXxxInput()` functions. Hosts render a
 #'   fresh instance for each tool call, so the same observer handles both the
-#'   initial open and any later re-open.
+#'   initial open and any later re-open. When `arguments` are declared,
+#'   an `update_<appId>_app` tool is auto-registered; the model can call it
+#'   to push new argument values to a running instance (server-side), which
+#'   also arrive through this same `mcpUpdates()` channel.
 #' * `mcpHostContext()` returns the host's context (theme, locale, display
 #'   mode, ...) as a named list (reactive read).
 #' * `mcpUpdateModelContext()` updates the model's context for future
 #'   conversation turns. Each call overwrites the previous update; the host
-#'   typically delivers it with the user's next message.
+#'   typically delivers it with the user's next message. On connect, the
+#'   framework automatically announces the app instance's `session` id to
+#'   the model (via `mcpAnnounceSession()`), so the model can target the
+#'   running instance with `update_<appId>_app(session = "<id>", ...)`.
 #' * `mcpSendMessage()` sends a user-role message to the host's chat
 #'   interface, which may trigger a model response.
 #'

--- a/R/mcp-session.R
+++ b/R/mcp-session.R
@@ -186,11 +186,15 @@ mcpUpdateModelContext <- function(
   if (!isMcpSession(session)) {
     return(invisible(FALSE))
   }
+  structured <- dropNulls(list(
+    session = session$token,
+    data = data
+  ))
   params <- dropNulls(list(
     content = if (!is.null(text)) {
       list(list(type = "text", text = text))
     },
-    structuredContent = data
+    structuredContent = structured
   ))
   session$sendCustomMessage("shiny.mcp.updateModelContext", params)
   invisible(TRUE)

--- a/R/mcp-session.R
+++ b/R/mcp-session.R
@@ -232,6 +232,12 @@ mcpSendMessage <- function(
 # model knows to echo the id; the structured {session, state} carries it
 # machine-readably. Only meaningful when an update_* tool exists (arguments
 # declared) and this is an MCP session.
+#
+# NOTE: this builds its own shiny.mcp.updateModelContext payload rather than
+# calling mcpUpdateModelContext() because the announcement needs the reserved
+# `state` key in structuredContent (not the author-facing `data` key). If the
+# envelope shape of mcpUpdateModelContext() changes, this must be updated
+# independently.
 mcpAnnounceSession <- function(session) {
   session$onFlushed(
     function() {

--- a/R/mcp-session.R
+++ b/R/mcp-session.R
@@ -92,6 +92,27 @@
 #' @name mcp-session
 NULL
 
+# Server-pushed MCP updates, keyed by session token. Shared between
+# mcpUpdates() (a reactive read) and the update_<appId>_app tool handler (a
+# server-side write): both fetch the *same* reactiveVal for a given session so
+# a push invalidates the app's mcpUpdates() observer. Created lazily; removed
+# when the session ends.
+mcpSessionUpdates <- NULL
+on_load({
+  mcpSessionUpdates <- Map$new()
+})
+
+mcpServerUpdatesFor <- function(session) {
+  token <- session$token
+  rv <- mcpSessionUpdates$get(token)
+  if (is.null(rv)) {
+    rv <- reactiveVal(NULL, label = "mcpServerUpdates")
+    mcpSessionUpdates$set(token, rv)
+    session$onSessionEnded(function() mcpSessionUpdates$remove(token))
+  }
+  rv
+}
+
 #' @rdname mcp-session
 #' @export
 isMcpSession <- function(session = getDefaultReactiveDomain()) {
@@ -121,7 +142,16 @@ mcpUpdates <- function(session = getDefaultReactiveDomain()) {
   if (is.null(session)) {
     stop("mcpUpdates() must be called from within a Shiny session")
   }
-  mcpFilterArguments(mcpParseClientData(session$clientData$mcp_tool_input))
+  clientArgs <- mcpParseClientData(session$clientData$mcp_tool_input)
+  # Server-side pushes from update_<appId>_app overlay the client-delivered
+  # init args, per key (latest wins). Reading the reactiveVal registers the
+  # dependency so a push re-fires this observer.
+  serverArgs <- mcpServerUpdatesFor(session)()
+  if (is.null(clientArgs) && is.null(serverArgs)) {
+    return(NULL)
+  }
+  merged <- utils::modifyList(clientArgs %||% list(), serverArgs %||% list())
+  mcpFilterArguments(merged)
 }
 
 #' @rdname mcp-session

--- a/R/mcp-session.R
+++ b/R/mcp-session.R
@@ -219,6 +219,34 @@ mcpSendMessage <- function(
   invisible(TRUE)
 }
 
+# Tell the model, once per MCP session, the id it must pass to
+# update_<appId>_app to change THIS running instance in place. Sent after the
+# first flush (the client bridge is initialized by then) via the same
+# updateModelContext bridge channel. The token instruction is text so the
+# model knows to echo the id; the structured {session, state} carries it
+# machine-readably. Only meaningful when an update_* tool exists (arguments
+# declared) and this is an MCP session.
+mcpAnnounceSession <- function(session) {
+  session$onFlushed(
+    function() {
+      token <- session$token
+      instruction <- sprintf(
+        paste(
+          "This app instance's id is \"%s\". To change THIS instance in",
+          "place, call %s with session = \"%s\". Do not re-open the app to",
+          "change it."
+        ),
+        token, mcpUpdateToolName(), token
+      )
+      session$sendCustomMessage("shiny.mcp.updateModelContext", list(
+        content = list(list(type = "text", text = instruction)),
+        structuredContent = list(session = token, state = "connected")
+      ))
+    },
+    once = TRUE
+  )
+}
+
 #' @param mode The display mode to request: `"inline"`, `"fullscreen"`, or
 #'   `"pip"`. The host may decline; observe `mcpHostContext()$displayMode`
 #'   for the mode actually in effect. Declare the modes the app supports

--- a/R/server.R
+++ b/R/server.R
@@ -174,6 +174,9 @@ createAppHandlers <- function(httpHandlers, serverFuncSource) {
 
     shinysession <- ShinySession$new(ws)
     appsByToken$set(shinysession$token, shinysession)
+    if (mcpEnabled() && mcpHasUpdateTool() && isMcpSession(shinysession)) {
+      mcpAnnounceSession(shinysession)
+    }
     shinysession$setShowcase(.globals$showcaseDefault)
 
     messageHandler <- function(binary, msg) {

--- a/man/mcp-session.Rd
+++ b/man/mcp-session.Rd
@@ -67,12 +67,18 @@ the app (a reactive read), filtered to the arguments declared with
 \code{mcpConfigure(arguments = list(...))}. Apply them from a single
 \code{observe()} with the usual \code{updateXxxInput()} functions. Hosts render a
 fresh instance for each tool call, so the same observer handles both the
-initial open and any later re-open.
+initial open and any later re-open. When \code{arguments} are declared,
+an \verb{update_<appId>_app} tool is auto-registered; the model can call it
+to push new argument values to a running instance (server-side), which
+also arrive through this same \code{mcpUpdates()} channel.
 \item \code{mcpHostContext()} returns the host's context (theme, locale, display
 mode, ...) as a named list (reactive read).
 \item \code{mcpUpdateModelContext()} updates the model's context for future
 conversation turns. Each call overwrites the previous update; the host
-typically delivers it with the user's next message.
+typically delivers it with the user's next message. On connect, the
+framework automatically announces the app instance's \code{session} id to
+the model (via \code{mcpAnnounceSession()}), so the model can target the
+running instance with \verb{update_<appId>_app(session = "<id>", ...)}.
 \item \code{mcpSendMessage()} sends a user-role message to the host's chat
 interface, which may trigger a model response.
 }

--- a/mcp/demo-app/app.R
+++ b/mcp/demo-app/app.R
@@ -59,9 +59,8 @@ shinyApp(
   server = function(input, output, session) {
     initNote <- reactiveVal("")
 
-    # Apply the model's arguments in one observer. The host renders a fresh
-    # instance for every tool call, so this handles both the initial open and
-    # any later re-open with new arguments.
+    # Apply the model's arguments in one observer. Handles both the initial
+    # open and in-place updates via update_demo_app(session = ..., ...).
     observe({
       args <- mcpUpdates()
       if (!is.null(args$n)) {

--- a/mcp/demo-app2/app.R
+++ b/mcp/demo-app2/app.R
@@ -38,6 +38,7 @@ shinyApp(
     )
   ),
   server = function(input, output, session) {
+    # Handles both initial open and in-place updates via update_cars_app().
     observe({
       args <- mcpUpdates()
       if (!is.null(args$xvar) && args$xvar %in% vars) {

--- a/mcp/demo-app3/app.R
+++ b/mcp/demo-app3/app.R
@@ -47,7 +47,9 @@ shinyApp(
     running <- reactiveVal(TRUE)
     heading <- reactiveVal("Live clock")
 
-    # Restore any arguments the model passed when opening the app.
+    # Restore args on open AND apply later in-place updates: the model can call
+    # update_clock_app(session = ..., label = ...) to change this running
+    # instance without re-opening it. Both arrive through mcpUpdates().
     observe({
       args <- mcpUpdates()
       if (!is.null(args$label) && nzchar(args$label)) {

--- a/mcp/design-mcp-update-running-app.md
+++ b/mcp/design-mcp-update-running-app.md
@@ -1,0 +1,279 @@
+# In-place update of a running Shiny MCP App (`update_<appId>_app`)
+
+**Date:** 2026-07-17
+**Issue:** [#4415](https://github.com/rstudio/shiny/issues/4415)
+**Follow-up to:** #4414 (`mcpConfigure()` / init-args-via-RestoreContext)
+**Target branch:** `origin/mcp`
+
+## Problem
+
+When a Shiny MCP App declares `arguments` in `mcpConfigure()`, the model's
+only lever on the running app is the `open_<appId>_app` tool. In a live host
+(claude.ai), asking the model to "change the label" of an already-open app
+causes it to **re-invoke `open_*`, rendering a fresh instance** rather than
+updating the running one. The model itself explains it has no way to send new
+arguments to a running instance — "the only way to modify the app is by
+calling the tool again with new parameters."
+
+The runtime-update channel built in #4414 (`mcpUpdates()`, fed by a host
+`ui/notifications/tool-input` to the live iframe) is therefore **effectively
+never triggered by the model**. In practice the feature behaves as
+init-args-only.
+
+**Fix:** give the model an explicit *update* verb — auto-register a companion
+`update_<appId>_app` tool — whose handler pushes new arguments into the
+running session's `mcpUpdates()` channel, with no re-render.
+
+## Goals
+
+- Model can update an already-open instance in place, targeting a specific
+  running session.
+- Zero author code beyond the existing `mcpConfigure(arguments = ...)` +
+  single `observe(mcpUpdates())`.
+- Reuse `mcpUpdates()` end-to-end so existing app code works unchanged.
+
+## Non-goals (handled separately)
+
+- Widget auto-restore doc corrections from #4414.
+- The `resourceUri`-args init-path spike from #4414.
+
+These are init-path concerns, tracked in another effort; not folded in here.
+
+## Decisions
+
+The five load-bearing decisions, as agreed during brainstorming:
+
+1. **Targeting = explicit session handle (required).** No broadcast /
+   most-recent guessing. `update_*` takes a **required** `session` argument;
+   the model targets exactly one running session per call. To update several,
+   the model loops over handles.
+2. **Server push via a per-session `reactiveVal` (server-side merge).** Each
+   registered MCP session holds a server-side `reactiveVal`. The `update_*`
+   handler sets it directly. `mcpUpdates()` is rewritten to **overlay** the
+   server-pushed args on top of the client-delivered init args (per-key,
+   latest wins), then apply the allow-list filter. No client round-trip.
+3. **Flat global session registry keyed by `session$token`.** Populated on
+   session start when `isMcpSession()` is `TRUE`; removed on
+   `session$onSessionEnded()`. One R process serves one `appId`, so a flat map
+   suffices. Unknown/stale token → `update_*` returns a **tool error** (not a
+   silent success).
+4. **Auto-registered `update_<appId>_app` tool**, published **only when
+   `arguments` are declared**. The handler sets the target session's
+   `reactiveVal` **inside that session's reactive domain**
+   (`withReactiveDomain(session, ...)`) and flushes it, so the app's
+   `observe(mcpUpdates())` invalidates in the correct session context.
+5. **Token delivered to the model via a reserved-key model-context
+   envelope + a connect-time auto-emit.** The framework stamps a reserved
+   `session` key into the model-visible structured content; the author's
+   payload nests under `data`. On connect, the framework auto-emits
+   `{ session: "<token>", state: "connected" }` plus a short text instruction
+   so the model learns the token with zero author code.
+
+## Architecture
+
+### Data flow
+
+```
+open_<appId>_app                                     (model -> host)
+  -> host renders iframe -> iframe connects
+  -> Shiny session created; isMcpSession() == TRUE
+  -> registry: token -> session                      (NEW)
+  -> framework auto-emits {session, state:"connected"} to model context (NEW)
+
+model reads token from its context
+  -> update_<appId>_app(session="<token>", <args>)   (model -> /mcp)
+  -> handler looks up token in registry              (NEW)
+     -> unknown/stale: tool error
+     -> found: withReactiveDomain(session, {
+          serverUpdates(filtered args)                (NEW reactiveVal set)
+          flush session
+        })
+  -> app's observe({ mcpUpdates() }) fires            (unchanged app code)
+```
+
+### Components
+
+#### 1. Session registry — `R/mcp-session.R` (or a small new file)
+
+A flat global map, mirroring `mcpConnections` (`R/mcp-tunnel.R`):
+
+```r
+mcpSessions <- NULL
+on_load({ mcpSessions <- Map$new() })
+
+mcpSessionRegister <- function(session) {
+  # Called on session start when isMcpSession(session).
+  # Stores token -> list(session = session, updates = reactiveVal(NULL)).
+  # Registers session$onSessionEnded() to remove the entry.
+}
+
+mcpSessionGet <- function(token) { ... }  # NULL if absent
+```
+
+- Keyed by `session$token`.
+- Value carries both the `ShinySession` and its server-push `reactiveVal`
+  (the `reactiveVal` is created within the session's domain at registration).
+- Cleanup on `session$onSessionEnded()`; reconnects register under a fresh
+  token.
+
+**Registration hook:** the point in session startup where `isMcpSession()` is
+knowable and the session is live (both tunnel and direct-connect sessions
+satisfy `isMcpSession()`). Investigate `ShinySession` construction /
+`server`-function invocation for the right hook; the registration must run
+with the session's reactive domain available so the `reactiveVal` is created
+in-session.
+
+#### 2. `mcpUpdates()` overlay — `R/mcp-session.R`
+
+Rewrite to merge two sources, latest-wins per key, then filter:
+
+```r
+mcpUpdates <- function(session = getDefaultReactiveDomain()) {
+  if (is.null(session)) stop("mcpUpdates() must be called from within a Shiny session")
+  clientArgs <- mcpParseClientData(session$clientData$mcp_tool_input)
+  serverArgs <- <this session's server-push reactiveVal>()   # reactive read
+  merged <- modifyList(clientArgs %||% list(), serverArgs %||% list())
+  mcpFilterArguments(merged)
+}
+```
+
+- Both reads are reactive, so the observer fires on init, re-open (client
+  channel), **and** server push (reactiveVal).
+- Overlay semantics: a server push updates only the keys it carries; other
+  init args persist. (Confirm this is the desired behavior vs. wholesale
+  replace — leaning overlay so partial updates like "just change the label"
+  don't drop `n`.)
+- The server-push `reactiveVal` is looked up from the registry entry for this
+  session. If the session isn't registered (non-MCP), `serverArgs` is `NULL`
+  and behavior is unchanged.
+
+#### 3. Auto-registered `update_<appId>_app` tool — `R/mcp-server.R`
+
+- **`tools/list` (`mcpToolsList()`):** when `.globals$mcp$arguments` is
+  non-empty, append a tool entry:
+  - `name`: `mcpUpdateToolName()` -> `update_<appId>_app`
+    (or `update_shiny_app` when no `appId`).
+  - `description`: *"Change parameters of the already-open app in place. Do
+    NOT re-open the app; use this to update the running instance."*
+  - `inputSchema`: `mcpArgumentsSchema(.globals$mcp$arguments)` **plus** a
+    required `session` string property.
+- **Reserved names (`mcpReservedToolNames()`):** add the update tool name so
+  `registerMcpTool()` cannot collide with it.
+- **Dispatch (`mcpToolCall()`):** add a branch for the update tool name:
+
+```r
+if (identical(name, mcpUpdateToolName())) {
+  args    <- body$params$arguments %||% list()
+  token   <- args$session
+  entry   <- mcpSessionGet(token)
+  if (is.null(entry)) {
+    return(mcpToolErrorResult(body$id, sprintf(
+      "No running app session with id '%s'. Open the app first, or use the id it reported.",
+      token %||% ""
+    )))
+  }
+  pushed <- mcpFilterArguments(args[setdiff(names(args), "session")])
+  withReactiveDomain(entry$session, {
+    entry$updates(pushed)
+    flushReact()  # or session-appropriate flush
+  })
+  return(mcpResult(body$id, list(content = list(list(
+    type = "text",
+    text = "Updated the running app in place."
+  )))))
+}
+```
+
+- Filter drops `session` and any non-declared keys before pushing.
+- The push runs in the target session's domain and flushes so the app's
+  observer fires promptly.
+
+#### 4. Token delivery — `R/mcp-session.R` + `srcts/src/mcp/index.ts`
+
+- **Envelope shape** sent from `mcpUpdateModelContext()`:
+  the framework always stamps a reserved `session` key into the model-visible
+  structured content; author `data` nests under `data`:
+
+  ```
+  { session: "<token>", data: { ...authorData } }   # + content[] from `text`
+  ```
+
+  Author calls can never clobber `session` (it's framework-owned).
+- **Connect-time auto-emit:** on connect, for MCP sessions with declared
+  `arguments`, the framework emits once:
+
+  ```
+  { session: "<token>", state: "connected" }        # structured
+  + text: "This app instance's id is <token>. To change THIS instance in
+           place, call update_<appId>_app with session = \"<token>\".
+           Do not re-open the app."
+  ```
+
+  The text instruction is required so the model knows to echo the id;
+  a bare structured id may not prompt the model to reuse it.
+- The token must land in **model-visible `structuredContent`** (not a
+  nonstandard top-level field a host might strip). See verification item
+  below.
+
+### Client (`srcts/src/mcp/index.ts`)
+
+- The connect-time auto-emit is triggered from R via
+  `session$sendCustomMessage(...)` and forwarded to `app.updateModelContext`
+  (reuse the existing `shiny.mcp.updateModelContext` handler, or a small
+  dedicated one). No new transport machinery.
+- `mcpUpdateModelContext()`'s envelope reshaping is done R-side before the
+  custom message is sent; the existing JS handler forwards it as-is.
+
+## Testing
+
+Unit tests (testthat 3):
+
+- **Registry lifecycle:** registering on MCP session start; removal on
+  `onSessionEnded()`; non-MCP sessions are not registered; reconnect gets a
+  fresh token.
+- **`mcpUpdates()` overlay:** client-only args; server-push-only args;
+  overlay precedence (server push updates named keys, leaves others); result
+  is allow-list filtered.
+- **`update_*` dispatch:** tool appears in `tools/list` only when `arguments`
+  declared; `inputSchema` includes required `session`; unknown/stale token
+  returns a tool error; valid token filters `session` + non-declared keys and
+  sets the session's `reactiveVal`; the app observer fires.
+- **Reserved names:** `registerMcpTool()` rejects the update tool name.
+- **Token envelope:** `mcpUpdateModelContext()` stamps `session`, nests author
+  `data`; author cannot overwrite `session`.
+
+Where a live `ShinySession` is awkward to construct in a unit test, use the
+existing MCP test harness/fakes (see current `tests/testthat/test-mcp*.R`).
+
+## Verification items / known limitations (document in `mcp/limitations.md`)
+
+- **Host-passthrough spike (host-dependent):** confirm a real host
+  (claude.ai) forwards our structured envelope (`session`/`state`) into the
+  model's readable context. If a host forwards only `content`/
+  `structuredContent`, the token already rides `structuredContent` — but
+  verify end-to-end that the model can read and echo it into
+  `update_*(session=...)`.
+- **Multi-instance caveat:** with several open instances, the model sees
+  several `session` tokens in one conversation and must associate each with
+  the right instance. There is no server-side guarantee it picks correctly;
+  the model targets/loops per handle. Documented, not solved.
+
+## Demo updates (update existing `mcp/` apps)
+
+- **`mcp/demo-app3/app.R` (clock):** the issue's motivating example. Its
+  `label` / `paused` args should now be updatable in place via
+  `update_clock_app(session=..., label=...)`. Verify the existing
+  `observe(mcpUpdates())` handles the server push with no code change; add a
+  brief comment noting update-in-place is now available.
+- **`mcp/demo-app/app.R` and `mcp/demo-app2/app.R`:** confirm their existing
+  `mcpUpdates()` observers work unchanged under server push; adjust comments
+  to mention the auto `update_*` tool.
+
+Per repo convention, mirror any MCP doc changes into the repo-root `mcp/`
+copies (design docs, limitations, demos).
+
+## Open question to confirm during implementation
+
+- `mcpUpdates()` overlay vs. wholesale replace on server push. Spec assumes
+  **overlay** (partial updates preserve untouched init args). Revisit if a
+  concrete app wants replace semantics.

--- a/mcp/design-mcpConfigure.md
+++ b/mcp/design-mcpConfigure.md
@@ -216,11 +216,23 @@ observe({
 default → the model's value) is unavoidable — flash-free restore is not
 reachable for MCP; see `limitations.md`.
 
-### Live re-steering of a running instance
+### Live re-steering of a running instance — `update_<appId>_app`
 
-Not currently possible: the model can only call tools, and hosts re-render
-rather than update in place. An explicit server-side update tool is proposed in
-rstudio/shiny#4415.
+Implemented in #4415. When `mcpConfigure(arguments = ...)` is declared, the
+framework auto-registers a companion `update_<appId>_app` tool (e.g.
+`update_clock_app` for `appId = "clock"`). The tool:
+
+1. Requires a `session` argument (the session token of the target instance).
+2. Accepts the same arguments declared in `mcpConfigure(arguments = ...)`.
+3. Pushes the new values server-side into the session's `mcpUpdates()`
+   reactiveVal (`mcpServerUpdatesFor(session)`), overlaying the original
+   client-delivered init args.
+4. The app's existing `observe({ args <- mcpUpdates(); ... })` fires with the
+   merged result — no code change needed in the app.
+
+On connect, `mcpAnnounceSession()` sends the session token to the model as both
+a text instruction and a `structuredContent { session, state }` payload, so the
+model knows which id to pass.
 
 ## Removal / migration
 

--- a/mcp/implementation-plan-update-running-app.md
+++ b/mcp/implementation-plan-update-running-app.md
@@ -1,0 +1,813 @@
+# In-place Update of a Running Shiny MCP App — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Auto-register an `update_<appId>_app` MCP tool that pushes new
+arguments into an already-running Shiny session's `mcpUpdates()` channel, so a
+model can update an open app in place instead of re-opening it.
+
+**Architecture:** A plain `tools/call update_<appId>_app` runs in the server R
+process. It takes a required `session` token, looks the session up in the
+existing `appsByToken` registry, verifies `isMcpSession()`, filters the args
+to the declared allow-list, and sets a per-session server-push `reactiveVal`
+inside that session's reactive domain. `mcpUpdates()` is rewritten to overlay
+that server-pushed value on top of the client-delivered init args. The app's
+existing single `observe(mcpUpdates())` fires with no code change. The model
+learns the token via a connect-time auto-emit through the existing
+`shiny.mcp.updateModelContext` bridge channel; `mcpUpdateModelContext()`'s
+payload gains a reserved `session` key.
+
+**Tech Stack:** R (shiny package internals), testthat 3e, ellmer (optional,
+`skip_if_not_installed`), existing MCP test harness in
+`tests/testthat/helper-mcp.R` and `test-mcp-session.R`.
+
+## Global Constraints
+
+- No new hard package dependencies. `ellmer` stays optional — tests that need
+  it call `skip_if_not_installed("ellmer")`; runtime code guards with
+  `rlang::check_installed()` where already established.
+- The feature is `lifecycle::badge("experimental")`, matching the rest of the
+  `mcp*` surface.
+- All new code is **R-side only**. No changes to `srcts/` — the bridge already
+  forwards `shiny.mcp.updateModelContext` messages to the host verbatim.
+- The `update_*` tool is published **only when `mcpConfigure(arguments = ...)`
+  is declared** (`length(.globals$mcp$arguments) > 0`). No args ⇒ no tool.
+- Targeting is by **explicit `session` token only** — no broadcast /
+  most-recent fallback. Unknown/stale token returns a tool **error**
+  (`isError = TRUE`), never a silent success.
+- `session$token` equals the client's `config.sessionId` (see
+  `R/shiny.R:1015`) and is the `appsByToken` key (see `R/server.R:176`).
+- Per repo convention (see memory + existing `mcp/` docs), any MCP doc changes
+  are mirrored into the repo-root `mcp/` copies.
+- Reference spec: `mcp/design-mcp-update-running-app.md`.
+
+**Run tests with:** `R -q -e 'devtools::test(filter = "<name>")'` where
+`<name>` matches `tests/testthat/test-<name>.R` (e.g. `mcp-server`,
+`mcp-session`). For a single test during development:
+`R -q -e 'pkgload::load_all(".", quiet = TRUE); testthat::test_file("tests/testthat/test-mcp-session.R")'`.
+
+---
+
+## File Structure
+
+- `R/mcp-config.R` — add `mcpUpdateToolName()` next to `mcpToolName()`.
+- `R/mcp-server.R` — add `mcpUpdateToolSchema()`, the `tools/list` entry, the
+  reserved-name entry, and the `update_*` dispatch branch + handler
+  (`mcpUpdateAppCall()`).
+- `R/mcp-session.R` — add the per-session server-push `reactiveVal` store
+  (`mcpSessionUpdates` map + `mcpServerUpdatesFor()`), rewrite `mcpUpdates()`
+  to overlay, reshape `mcpUpdateModelContext()`'s envelope, and add
+  `mcpAnnounceSession()`.
+- `R/server.R` — one guarded line in the websocket handler to trigger the
+  connect-time token announcement for MCP sessions.
+- `tests/testthat/test-mcp-server.R`, `test-mcp-session.R` — tests.
+- `mcp/demo-app3/app.R` (+ `demo-app`, `demo-app2`) — comments only; verify
+  zero-code-change works.
+- Docs: `R/mcp-session.R` roxygen, `mcp/limitations.md`,
+  `mcp/design-mcpConfigure.md`, `NEWS.md`.
+
+---
+
+## Task 1: `update_<appId>_app` tool name, schema, listing & reservation
+
+**Files:**
+- Modify: `R/mcp-config.R` (after `mcpToolName()`, ~line 133)
+- Modify: `R/mcp-server.R` (`mcpToolsList()` ~335, `mcpReservedToolNames()` ~358)
+- Test: `tests/testthat/test-mcp-server.R`
+
+**Interfaces:**
+- Produces: `mcpUpdateToolName()` → character; `mcpUpdateToolSchema()` → list
+  (JSON Schema with a required `session` string plus the declared args).
+- Consumes: `.globals$mcp$arguments`, `mcpArgumentsSchema()`,
+  `mcpAppId()`/`.globals$mcp$appId`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/testthat/test-mcp-server.R`:
+
+```r
+test_that("update_<appId>_app is listed only when arguments are declared", {
+  skip_if_not_installed("ellmer")
+
+  # No arguments: no update tool.
+  local_mcp_config(appId = "demo")
+  h <- mcpHttpHandler(function(req) NULL, function(ws) TRUE)
+  names_no_args <- vapply(
+    mcp_post(h, "tools/list")$result$tools, function(t) t$name, character(1)
+  )
+  expect_false("update_demo_app" %in% names_no_args)
+
+  # With arguments: update tool present, schema carries required `session`.
+  local_mcp_config(
+    appId = "demo",
+    arguments = list(note = ellmer::type_string("A note"))
+  )
+  tools <- mcp_post(h, "tools/list")$result$tools
+  nms <- vapply(tools, function(t) t$name, character(1))
+  expect_true("update_demo_app" %in% nms)
+
+  upd <- tools[[which(nms == "update_demo_app")]]
+  expect_equal(upd$inputSchema$properties$session$type, "string")
+  expect_equal(upd$inputSchema$properties$note$type, "string")
+  expect_true("session" %in% unlist(upd$inputSchema$required))
+  expect_match(upd$description, "in place", ignore.case = TRUE)
+})
+
+test_that("update tool name follows appId and reserves the name", {
+  skip_if_not_installed("ellmer")
+  local_mcp_config(arguments = list(x = ellmer::type_integer("x")))
+  expect_equal(mcpUpdateToolName(), "update_shiny_app")
+  expect_true("update_shiny_app" %in% mcpReservedToolNames())
+
+  local_mcp_config(appId = "clock", arguments = list(x = ellmer::type_integer("x")))
+  expect_equal(mcpUpdateToolName(), "update_clock_app")
+  expect_true("update_clock_app" %in% mcpReservedToolNames())
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `R -q -e 'devtools::test(filter = "mcp-server")'`
+Expected: FAIL — `mcpUpdateToolName` not found / `update_demo_app` absent.
+
+- [ ] **Step 3: Add `mcpUpdateToolName()`**
+
+In `R/mcp-config.R`, after `mcpToolName()` (~line 133):
+
+```r
+# update_shiny_app, or update_<appId>_app when an appId is configured. The
+# companion to mcpToolName(): the model calls this to change a running
+# instance in place instead of re-opening the app.
+mcpUpdateToolName <- function() {
+  id <- .globals$mcp$appId
+  if (is.null(id)) "update_shiny_app" else paste0("update_", id, "_app")
+}
+```
+
+- [ ] **Step 4: Add `mcpUpdateToolSchema()` and list/reserve the tool**
+
+In `R/mcp-server.R`, add near `mcpToolInfo()` (~line 199):
+
+```r
+# inputSchema for update_<appId>_app: the declared arguments allow-list plus a
+# required `session` string identifying the running instance to update.
+mcpUpdateToolInfo <- function() {
+  schema <- mcpArgumentsSchema(.globals$mcp$arguments)
+  schema$properties$session <- list(
+    type = "string",
+    description = paste(
+      "Id of the running app instance to update, as reported by the app when",
+      "it opened. Required."
+    )
+  )
+  schema$required <- as.list(unique(c(unlist(schema$required), "session")))
+  list(
+    name = mcpUpdateToolName(),
+    description = paste(
+      "Change parameters of the already-open app in place. Do NOT re-open the",
+      "app; use this to update the running instance identified by `session`."
+    ),
+    inputSchema = schema
+  )
+}
+
+# TRUE when a companion update_* tool should be published (author declared
+# arguments the model may push into a running session).
+mcpHasUpdateTool <- function() {
+  length(.globals$mcp$arguments) > 0
+}
+```
+
+In `mcpToolsList()` (~line 335), splice the update entry after the open tool.
+Change the `c(...)` to include it:
+
+```r
+mcpToolsList <- function() {
+  info <- mcpToolInfo()
+  update_entry <- if (mcpHasUpdateTool()) {
+    upd <- mcpUpdateToolInfo()
+    list(list(
+      name = upd$name,
+      description = upd$description,
+      inputSchema = upd$inputSchema
+    ))
+  } else {
+    list()
+  }
+  unname(c(
+    list(list(
+      name = info$name,
+      description = info$description,
+      inputSchema = info$inputSchema,
+      `_meta` = list(ui = list(resourceUri = mcpResourceUri()))
+    )),
+    update_entry,
+    mcpTunnelToolsList(),
+    lapply(mcpAuthorTools(), function(tool) {
+      dropNulls(list(
+        name = S7::prop(tool, "name"),
+        title = S7::prop(tool, "annotations")$title,
+        description = S7::prop(tool, "description"),
+        inputSchema = mcpToolInputSchema(tool)
+      ))
+    })
+  ))
+}
+```
+
+In `mcpReservedToolNames()` (~line 358):
+
+```r
+mcpReservedToolNames <- function() {
+  c(
+    mcpToolInfo()$name,
+    if (mcpHasUpdateTool()) mcpUpdateToolName(),
+    vapply(mcpTunnelToolsList(), function(t) t$name, character(1))
+  )
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `R -q -e 'devtools::test(filter = "mcp-server")'`
+Expected: PASS (all mcp-server tests green).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add R/mcp-config.R R/mcp-server.R tests/testthat/test-mcp-server.R
+git commit -m "feat(mcp): publish update_<appId>_app tool when arguments declared (#4415)"
+```
+
+---
+
+## Task 2: Server-push `reactiveVal` store + `mcpUpdates()` overlay
+
+**Files:**
+- Modify: `R/mcp-session.R` (`mcpUpdates()` ~line 120; add store near top)
+- Test: `tests/testthat/test-mcp-session.R`
+
+**Interfaces:**
+- Produces: `mcpServerUpdatesFor(session)` → the session's server-push
+  `reactiveVal` (idempotent get-or-create, keyed by `session$token`, cleaned up
+  on `session$onSessionEnded()`). `mcpUpdates(session)` now merges
+  client init args + server-pushed args, then allow-list filters.
+- Consumes: `mcpParseClientData()`, `mcpFilterArguments()`, `session$token`,
+  `session$clientData$mcp_tool_input`, `session$onSessionEnded()`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/testthat/test-mcp-session.R` (the harness `mcp_start_session`
+already registers the session in `appsByToken`):
+
+```r
+test_that("mcpUpdates overlays server-pushed args on client init args", {
+  skip_if_not_installed("ellmer")
+  withr::defer(.globals$mcp <- NULL)
+  mcpConfigure(arguments = list(
+    note = ellmer::type_string("a note"),
+    n    = ellmer::type_integer("count")
+  ))
+  observed <- list()
+  token <- NULL
+  sess <- mcp_start_session(
+    fluidPage(),
+    function(input, output, session) {
+      token <<- session$token
+      observe({
+        val <- mcpUpdates()
+        if (length(val) > 0) observed[[length(observed) + 1]] <<- val
+      })
+    }
+  )
+  # Client delivers the initial open args.
+  mcp_send_update(sess, list(
+    .clientdata_mcp_tool_input = '{"note":"hello","n":3}'
+  ))
+  pump_shiny(0.3)
+  expect_equal(observed[[length(observed)]]$note, "hello")
+
+  # Server pushes a partial update; `n` must persist, `note` changes. Set the
+  # reactiveVal inside the session's domain, as the update handler does.
+  session <- appsByToken$get(token)
+  rv <- mcpServerUpdatesFor(session)
+  withReactiveDomain(session, rv(list(note = "world")))
+  session$requestFlush()
+  pump_shiny(0.3)
+  latest <- observed[[length(observed)]]
+  expect_equal(latest$note, "world")
+  expect_equal(latest$n, 3)
+
+  mcpTunnelToolCall("_shiny_close", list(connectionId = sess$cid), 9, sess$handlers$ws)
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `R -q -e 'devtools::test(filter = "mcp-session")'`
+Expected: FAIL — `mcpServerUpdatesFor` not found.
+
+- [ ] **Step 3: Implement the store and rewrite `mcpUpdates()`**
+
+In `R/mcp-session.R`, add near the top (after the roxygen block, before
+`isMcpSession`):
+
+```r
+# Server-pushed MCP updates, keyed by session token. Shared between
+# mcpUpdates() (a reactive read) and the update_<appId>_app tool handler (a
+# server-side write): both fetch the *same* reactiveVal for a given session so
+# a push invalidates the app's mcpUpdates() observer. Created lazily; removed
+# when the session ends.
+mcpSessionUpdates <- NULL
+on_load({
+  mcpSessionUpdates <- Map$new()
+})
+
+mcpServerUpdatesFor <- function(session) {
+  token <- session$token
+  rv <- mcpSessionUpdates$get(token)
+  if (is.null(rv)) {
+    rv <- reactiveVal(NULL, label = "mcpServerUpdates")
+    mcpSessionUpdates$set(token, rv)
+    session$onSessionEnded(function() mcpSessionUpdates$remove(token))
+  }
+  rv
+}
+```
+
+Rewrite `mcpUpdates()` (~line 120):
+
+```r
+#' @rdname mcp-session
+#' @export
+mcpUpdates <- function(session = getDefaultReactiveDomain()) {
+  if (is.null(session)) {
+    stop("mcpUpdates() must be called from within a Shiny session")
+  }
+  clientArgs <- mcpParseClientData(session$clientData$mcp_tool_input)
+  # Server-side pushes from update_<appId>_app overlay the client-delivered
+  # init args, per key (latest wins). Reading the reactiveVal registers the
+  # dependency so a push re-fires this observer.
+  serverArgs <- mcpServerUpdatesFor(session)()
+  merged <- utils::modifyList(clientArgs %||% list(), serverArgs %||% list())
+  mcpFilterArguments(merged)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `R -q -e 'devtools::test(filter = "mcp-session")'`
+Expected: PASS. The existing `"mcpUpdates returns parsed tool arguments
+reactively"` test must also still pass (client-only path unchanged when no
+server push).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add R/mcp-session.R tests/testthat/test-mcp-session.R
+git commit -m "feat(mcp): mcpUpdates() overlays server-pushed args over init args (#4415)"
+```
+
+---
+
+## Task 3: `update_<appId>_app` dispatch handler
+
+**Files:**
+- Modify: `R/mcp-server.R` (`mcpToolCall()` ~line 434; add `mcpUpdateAppCall()`)
+- Test: `tests/testthat/test-mcp-session.R`
+
+**Interfaces:**
+- Consumes: `mcpUpdateToolName()`, `mcpHasUpdateTool()`, `appsByToken`,
+  `isMcpSession()`, `mcpFilterArguments()`, `mcpServerUpdatesFor()`,
+  `mcpToolErrorResult()`, `withReactiveDomain()`, `session$requestFlush()`.
+- Produces: `mcpUpdateAppCall(params, id)` → an MCP tool result (success or
+  `isError`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/testthat/test-mcp-session.R`:
+
+```r
+test_that("update_<appId>_app pushes args into the running session", {
+  skip_if_not_installed("ellmer")
+  withr::defer(.globals$mcp <- NULL)
+  mcpConfigure(appId = "demo", arguments = list(
+    note = ellmer::type_string("a note"),
+    n    = ellmer::type_integer("count")
+  ))
+  observed <- list()
+  token <- NULL
+  sess <- mcp_start_session(
+    fluidPage(),
+    function(input, output, session) {
+      token <<- session$token
+      observe({
+        val <- mcpUpdates()
+        if (length(val) > 0) observed[[length(observed) + 1]] <<- val
+      })
+    }
+  )
+  pump_shiny(0.2)
+
+  h <- mcpHttpHandler(function(req) NULL, sess$handlers$ws)
+  res <- mcp_post(h, "tools/call", params = list(
+    name = "update_demo_app",
+    # `session` and a non-declared key are filtered out before the push.
+    arguments = list(session = token, note = "pushed", bogus = "x")
+  ))
+  expect_false(isTRUE(res$result$isError))
+  pump_shiny(0.3)
+  expect_equal(observed[[length(observed)]]$note, "pushed")
+
+  mcpTunnelToolCall("_shiny_close", list(connectionId = sess$cid), 9, sess$handlers$ws)
+})
+
+test_that("update_<appId>_app errors on unknown or missing session token", {
+  skip_if_not_installed("ellmer")
+  local_mcp_config(appId = "demo", arguments = list(
+    note = ellmer::type_string("a note")
+  ))
+  h <- mcpHttpHandler(function(req) NULL, function(ws) TRUE)
+
+  missing <- mcp_post(h, "tools/call", params = list(
+    name = "update_demo_app", arguments = list(note = "x")
+  ))
+  expect_true(missing$result$isError)
+
+  unknown <- mcp_post(h, "tools/call", params = list(
+    name = "update_demo_app",
+    arguments = list(session = "no-such-token", note = "x")
+  ))
+  expect_true(unknown$result$isError)
+  expect_match(unknown$result$content[[1]]$text, "no-such-token", fixed = TRUE)
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `R -q -e 'devtools::test(filter = "mcp-session")'`
+Expected: FAIL — dispatch returns "Unknown tool: update_demo_app".
+
+- [ ] **Step 3: Implement the dispatch branch and handler**
+
+In `R/mcp-server.R`, add the branch to `mcpToolCall()` right after the
+open-tool check (after the `if (identical(name, info$name)) {...}` block,
+~line 444):
+
+```r
+  if (mcpHasUpdateTool() && identical(name, mcpUpdateToolName())) {
+    return(mcpUpdateAppCall(body$params, body$id))
+  }
+```
+
+Add the handler nearby (e.g. after `mcpToolCall()`):
+
+```r
+# Handle a model call to update_<appId>_app: push the (allow-list-filtered)
+# arguments into the running session named by `session`, inside that session's
+# reactive domain so its mcpUpdates() observer re-fires. No re-render.
+mcpUpdateAppCall <- function(params, id) {
+  args <- params$arguments %||% list()
+  token <- args$session
+  if (!is.character(token) || length(token) != 1 || !nzchar(token)) {
+    return(mcpToolErrorResult(
+      id,
+      "update requires a `session` id identifying the running app instance."
+    ))
+  }
+  session <- appsByToken$get(token)
+  if (is.null(session) || !isMcpSession(session)) {
+    return(mcpToolErrorResult(id, sprintf(
+      paste(
+        "No running app session with id '%s'. Open the app first, or use the",
+        "id the app reported for the instance you want to change."
+      ),
+      token
+    )))
+  }
+  pushed <- mcpFilterArguments(args[setdiff(names(args), "session")])
+  withReactiveDomain(session, {
+    mcpServerUpdatesFor(session)(pushed)
+  })
+  session$requestFlush()
+  mcpResult(id, list(content = list(list(
+    type = "text",
+    text = "Updated the running app in place."
+  ))))
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `R -q -e 'devtools::test(filter = "mcp-session")'`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add R/mcp-server.R tests/testthat/test-mcp-session.R
+git commit -m "feat(mcp): dispatch update_<appId>_app to push args into a live session (#4415)"
+```
+
+---
+
+## Task 4: `mcpUpdateModelContext()` reserved-key envelope
+
+**Files:**
+- Modify: `R/mcp-session.R` (`mcpUpdateModelContext()` ~line 148)
+- Test: `tests/testthat/test-mcp-session.R` (update the existing test)
+
+**Interfaces:**
+- Produces: model-context messages whose `structuredContent` always carries a
+  reserved `session` = `session$token`, with author `data` nested under `data`.
+- Consumes: `session$token`, `dropNulls()`.
+
+- [ ] **Step 1: Update the failing test**
+
+Edit the existing test `"mcpUpdateModelContext and mcpSendMessage send bridge
+messages"` in `tests/testthat/test-mcp-session.R` to assert the new shape.
+After the existing `expect_match(frames, "structuredContent", fixed = TRUE)`,
+add:
+
+```r
+  # The framework stamps the session token into structuredContent; author data
+  # nests under `data`.
+  expect_match(frames, "\"session\"", fixed = TRUE)
+  expect_match(frames, "\"data\"", fixed = TRUE)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `R -q -e 'devtools::test(filter = "mcp-session")'`
+Expected: FAIL — `"session"`/nested `"data"` not present in frames yet.
+
+- [ ] **Step 3: Reshape the payload**
+
+In `R/mcp-session.R`, `mcpUpdateModelContext()` (~line 158), replace the
+`params <- dropNulls(...)` construction:
+
+```r
+  structured <- dropNulls(list(
+    session = session$token,
+    data = data
+  ))
+  params <- dropNulls(list(
+    content = if (!is.null(text)) {
+      list(list(type = "text", text = text))
+    },
+    structuredContent = structured
+  ))
+  session$sendCustomMessage("shiny.mcp.updateModelContext", params)
+  invisible(TRUE)
+```
+
+> `session$token` is always available inside an MCP session (the function
+> already returns early via `isMcpSession()` for non-MCP sessions), so
+> `structured` always carries `session`; `data` is included only when the
+> author passed it.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `R -q -e 'devtools::test(filter = "mcp-session")'`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add R/mcp-session.R tests/testthat/test-mcp-session.R
+git commit -m "feat(mcp): stamp session token into mcpUpdateModelContext payload (#4415)"
+```
+
+---
+
+## Task 5: Connect-time token announcement
+
+**Files:**
+- Modify: `R/mcp-session.R` (add `mcpAnnounceSession()`)
+- Modify: `R/server.R` (guarded call in the websocket handler, ~line 176)
+- Test: `tests/testthat/test-mcp-session.R`
+
+**Interfaces:**
+- Produces: `mcpAnnounceSession(session)` — registers a one-shot
+  `session$onFlushed()` that sends a `shiny.mcp.updateModelContext` message
+  carrying `{ session: <token>, state: "connected" }` plus a text instruction
+  telling the model to call `update_<appId>_app` with that `session`.
+- Consumes: `session$onFlushed()`, `session$sendCustomMessage()`,
+  `mcpUpdateToolName()`, `session$token`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/testthat/test-mcp-session.R`:
+
+```r
+test_that("MCP sessions announce their token to the model on connect", {
+  skip_if_not_installed("ellmer")
+  withr::defer(.globals$mcp <- NULL)
+  mcpConfigure(appId = "clock", arguments = list(
+    label = ellmer::type_string("heading")
+  ))
+  token <- NULL
+  sess <- mcp_start_session(
+    fluidPage(),
+    function(input, output, session) {
+      token <<- session$token
+    }
+  )
+  frames <- paste(mcp_drain_frames(sess), collapse = "\n")
+  expect_match(frames, "shiny.mcp.updateModelContext", fixed = TRUE)
+  expect_match(frames, "update_clock_app", fixed = TRUE)
+  expect_match(frames, "connected", fixed = TRUE)
+  expect_match(frames, token, fixed = TRUE)
+
+  mcpTunnelToolCall("_shiny_close", list(connectionId = sess$cid), 9, sess$handlers$ws)
+})
+
+test_that("non-MCP and no-arguments sessions do not announce", {
+  # No mcpConfigure(arguments=...) => no announcement.
+  withr::defer(.globals$mcp <- NULL)
+  mcpConfigure(appId = "clock")  # enabled, but no arguments
+  sess <- mcp_start_session(fluidPage(), function(input, output, session) {})
+  frames <- paste(mcp_drain_frames(sess), collapse = "\n")
+  expect_no_match(frames, "shiny.mcp.updateModelContext", fixed = TRUE)
+  mcpTunnelToolCall("_shiny_close", list(connectionId = sess$cid), 9, sess$handlers$ws)
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `R -q -e 'devtools::test(filter = "mcp-session")'`
+Expected: FAIL — no `shiny.mcp.updateModelContext` frame on connect.
+
+- [ ] **Step 3: Implement `mcpAnnounceSession()`**
+
+In `R/mcp-session.R`, add (near `mcpUpdateModelContext()`):
+
+```r
+# Tell the model, once per MCP session, the id it must pass to
+# update_<appId>_app to change THIS running instance in place. Sent after the
+# first flush (the client bridge is initialized by then) via the same
+# updateModelContext bridge channel. The token instruction is text so the
+# model knows to echo the id; the structured {session, state} carries it
+# machine-readably. Only meaningful when an update_* tool exists (arguments
+# declared) and this is an MCP session.
+mcpAnnounceSession <- function(session) {
+  session$onFlushed(
+    function() {
+      token <- session$token
+      instruction <- sprintf(
+        paste(
+          "This app instance's id is \"%s\". To change THIS instance in",
+          "place, call %s with session = \"%s\". Do not re-open the app to",
+          "change it."
+        ),
+        token, mcpUpdateToolName(), token
+      )
+      session$sendCustomMessage("shiny.mcp.updateModelContext", list(
+        content = list(list(type = "text", text = instruction)),
+        structuredContent = list(session = token, state = "connected")
+      ))
+    },
+    once = TRUE
+  )
+}
+```
+
+- [ ] **Step 4: Trigger it for MCP sessions**
+
+In `R/server.R`, immediately after `appsByToken$set(shinysession$token,
+shinysession)` (line 176):
+
+```r
+    appsByToken$set(shinysession$token, shinysession)
+    if (mcpEnabled() && mcpHasUpdateTool() && isMcpSession(shinysession)) {
+      mcpAnnounceSession(shinysession)
+    }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `R -q -e 'devtools::test(filter = "mcp-session")'`
+Expected: PASS. Also run the full MCP suite to catch regressions:
+`R -q -e 'devtools::test(filter = "mcp-")'` — all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add R/mcp-session.R R/server.R tests/testthat/test-mcp-session.R
+git commit -m "feat(mcp): announce session token to the model on connect (#4415)"
+```
+
+---
+
+## Task 6: Docs, demo apps, NEWS, and mirror
+
+**Files:**
+- Modify: `R/mcp-session.R` (roxygen: document the update tool + announcement)
+- Modify: `mcp/demo-app3/app.R`, `mcp/demo-app/app.R`, `mcp/demo-app2/app.R`
+  (comments only; verify zero-code-change works)
+- Modify: `mcp/limitations.md`, `mcp/design-mcpConfigure.md`
+- Modify: `NEWS.md`
+
+**Interfaces:** none (documentation + demo comments).
+
+- [ ] **Step 1: Verify the demo apps update in place with no code change**
+
+Run demo-app3 (the clock — the issue's motivating example) and confirm the
+`update_clock_app` tool changes `label` in place. Manual check with the MCP
+host script:
+
+```bash
+# From repo root, with an MCP host / inspector pointed at the app's /mcp:
+R -q -e 'shiny::runApp("mcp/demo-app3", port = 8000)'
+# In the host: open_clock_app, then update_clock_app(session="<id>", label="Meeting clock")
+# Expected: the SAME clock instance's heading changes; no new instance renders.
+```
+
+Confirm the existing `observe({ args <- mcpUpdates(); ... })` in
+`mcp/demo-app3/app.R` handles the push unchanged. Add a short comment above
+that observer:
+
+```r
+    # Restore args on open AND apply later in-place updates: the model can call
+    # update_clock_app(session = ..., label = ...) to change this running
+    # instance without re-opening it. Both arrive through mcpUpdates().
+```
+
+Add the analogous one-line comment to the `mcpUpdates()` observers in
+`mcp/demo-app/app.R` and `mcp/demo-app2/app.R`.
+
+- [ ] **Step 2: Document in `?mcp-session` roxygen**
+
+In `R/mcp-session.R`, extend the `mcpUpdates()` bullet and the
+`mcpUpdateModelContext()` bullet to mention: (a) the auto-registered
+`update_<appId>_app` tool pushes server-side updates through the same
+`mcpUpdates()` channel; (b) the app announces its `session` id to the model on
+connect so the model can target the running instance. Regenerate docs:
+
+```bash
+R -q -e 'devtools::document()'
+```
+
+- [ ] **Step 3: Document the update tool + limitations**
+
+In `mcp/design-mcpConfigure.md`, add a section describing `update_<appId>_app`
+(auto-registered when `arguments` declared, required `session`, pushes through
+`mcpUpdates()`, connect-time token announcement).
+
+In `mcp/limitations.md`, add the two verification items from the spec:
+- **Host-passthrough spike:** confirm a real host (claude.ai) forwards the
+  `structuredContent` `{ session, state }` + instruction text into the model's
+  readable context so it can echo the id into `update_*(session=...)`.
+- **Multi-instance caveat:** with several open instances the model sees several
+  tokens and must pick the right one; the model targets/loops per handle.
+
+- [ ] **Step 4: Add a NEWS entry**
+
+In `NEWS.md`, under the current development version, add:
+
+```markdown
+* Shiny MCP Apps configured with `mcpConfigure(arguments = ...)` now
+  auto-register a companion `update_<appId>_app` tool. A model can call it to
+  update an already-open app instance in place (via `mcpUpdates()`) instead of
+  re-opening the app, targeting a specific instance by the `session` id the app
+  announces on connect. (#4415)
+```
+
+- [ ] **Step 5: Verify docs build and mirror is consistent**
+
+```bash
+R -q -e 'devtools::document()'
+R -q -e 'devtools::test(filter = "mcp-")'
+```
+
+Expected: docs regenerate cleanly; all MCP tests pass. Confirm the `mcp/`
+docs are the canonical copies (per repo convention).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add R/mcp-session.R man/ NEWS.md mcp/
+git commit -m "docs(mcp): document update_<appId>_app + update demos (#4415)"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Decision 1 (explicit handle, required) → Task 1 schema +
+  Task 3 handler. Decision 2 (server reactiveVal overlay) → Task 2. Decision 3
+  (registry keyed by token; unknown → error) → Task 3 (reuses `appsByToken`).
+  Decision 4 (auto tool, only when args, push in session domain) → Tasks 1 & 3.
+  Decision 5 (reserved-key envelope + connect emit) → Tasks 4 & 5. Limitations
+  + demos → Task 6.
+- **Registry note:** the spec's "flat global registry keyed by `session$token`"
+  is satisfied by the existing `appsByToken` (populated on session start,
+  removed on close) rather than a parallel map; the per-session server-push
+  `reactiveVal` is the only new per-session state (`mcpSessionUpdates`).
+- **Type consistency:** `mcpUpdateToolName()`, `mcpHasUpdateTool()`,
+  `mcpUpdateToolInfo()`, `mcpServerUpdatesFor()`, `mcpUpdateAppCall()`,
+  `mcpAnnounceSession()` are used with the same signatures across tasks.
+- **Test note (Task 2, Step 1):** the server push is exercised by setting the
+  reactiveVal inside `withReactiveDomain(session, ...)` followed by
+  `session$requestFlush()` — the same sequence `mcpUpdateAppCall()` uses in
+  Task 3.

--- a/mcp/limitations.md
+++ b/mcp/limitations.md
@@ -70,6 +70,33 @@ different channels purely by timing (session A → `mcpUpdates`, session B →
 **every** `ontoolinput` (opening and later) to the single `mcpUpdates()`
 channel.
 
+## 4. Host-passthrough spike: session token visibility
+
+**What needs verification:** the `mcpAnnounceSession()` call emits a
+`structuredContent { session, state }` envelope plus a text instruction ("This
+app instance's id is ...") via the `updateModelContext` bridge channel. For
+`update_<appId>_app` to work, the host must forward the `structuredContent` and
+the text into the model's readable context so the model can echo the session id
+into `update_*(session = ...)`.
+
+**Status:** tested with the MCP Inspector (stdio transport) — the text arrives
+in the model's context. Needs a real host (claude.ai / Claude Desktop) spike to
+confirm end-to-end passthrough when using the Apps extension's iframe
+transport.
+
+## 5. Multi-instance caveat
+
+When several instances of the same app are open simultaneously, the model
+receives one session-token announcement per instance. To update a specific
+instance, the model must select the correct token. The model
+targets/loops per handle — it has no built-in mechanism to disambiguate beyond
+matching the text context (e.g. heading labels) the app provides via
+`mcpUpdateModelContext()`.
+
+**Mitigation:** apps that expect multiple simultaneous instances should include
+distinguishing information (e.g. a label or purpose) in their
+`mcpUpdateModelContext()` text so the model can pair tokens to instances.
+
 ## Summary
 
 | Wanted | Reality |

--- a/mcp/limitations.md
+++ b/mcp/limitations.md
@@ -103,5 +103,5 @@ distinguishing information (e.g. a label or purpose) in their
 |---|---|
 | Flash-free widget auto-restore of init args | Not possible — args aren't available at render time |
 | Args via a per-call `resourceUri` | Host ignores it; reads the static URI |
-| Live in-place update of a running app | Host re-renders per tool call; needs an update tool (#4415) |
+| Live in-place update of a running app | Implemented via `update_<appId>_app`; host-passthrough spike (section 4) and multi-instance targeting (section 5) remain |
 | Deterministic init channel | Achieved by using one channel (`mcpUpdates()`) for all args |

--- a/mcp/limitations.md
+++ b/mcp/limitations.md
@@ -79,10 +79,12 @@ app instance's id is ...") via the `updateModelContext` bridge channel. For
 the text into the model's readable context so the model can echo the session id
 into `update_*(session = ...)`.
 
-**Status:** tested with the MCP Inspector (stdio transport) — the text arrives
-in the model's context. Needs a real host (claude.ai / Claude Desktop) spike to
-confirm end-to-end passthrough when using the Apps extension's iframe
-transport.
+**Status:** ✅ **Confirmed in Claude Desktop (2026-07-17).** The host forwards
+the announced session token into the model's context, and the model calls
+`update_<appId>_app` in place (rather than re-opening) to change the running
+instance. Also verified earlier with the MCP Inspector (stdio transport). Not
+yet spot-checked on claude.ai (web) — its iframe CSP handling differs, so the
+tunnel transport is expected to carry it, but confirm when convenient.
 
 ## 5. Multi-instance caveat
 
@@ -92,6 +94,12 @@ instance, the model must select the correct token. The model
 targets/loops per handle — it has no built-in mechanism to disambiguate beyond
 matching the text context (e.g. heading labels) the app provides via
 `mcpUpdateModelContext()`.
+
+**Status:** ✅ Exercised in Claude Desktop (2026-07-17): with two instances of
+the same app open, updating the *first* instance's label targeted the correct
+session token. This is not a server-side guarantee — the model chose correctly
+from context — so the caveat remains a theoretical risk, but it works in
+practice for the common case.
 
 **Mitigation:** apps that expect multiple simultaneous instances should include
 distinguishing information (e.g. a label or purpose) in their
@@ -103,5 +111,5 @@ distinguishing information (e.g. a label or purpose) in their
 |---|---|
 | Flash-free widget auto-restore of init args | Not possible — args aren't available at render time |
 | Args via a per-call `resourceUri` | Host ignores it; reads the static URI |
-| Live in-place update of a running app | Implemented via `update_<appId>_app`; host-passthrough spike (section 4) and multi-instance targeting (section 5) remain |
+| Live in-place update of a running app | Implemented via `update_<appId>_app`; host-passthrough (section 4) and multi-instance targeting (section 5) confirmed working in Claude Desktop 2026-07-17 |
 | Deterministic init channel | Achieved by using one channel (`mcpUpdates()`) for all args |

--- a/tests/testthat/test-mcp-server.R
+++ b/tests/testthat/test-mcp-server.R
@@ -314,6 +314,44 @@ test_that("resources/read uses the path-aware base: origin-only CSP, full direct
   )
 })
 
+test_that("update_<appId>_app is listed only when arguments are declared", {
+  skip_if_not_installed("ellmer")
+
+  # No arguments: no update tool.
+  local_mcp_config(appId = "demo")
+  h <- mcpHttpHandler(function(req) NULL, function(ws) TRUE)
+  names_no_args <- vapply(
+    mcp_post(h, "tools/list")$result$tools, function(t) t$name, character(1)
+  )
+  expect_false("update_demo_app" %in% names_no_args)
+
+  # With arguments: update tool present, schema carries required `session`.
+  local_mcp_config(
+    appId = "demo",
+    arguments = list(note = ellmer::type_string("A note"))
+  )
+  tools <- mcp_post(h, "tools/list")$result$tools
+  nms <- vapply(tools, function(t) t$name, character(1))
+  expect_true("update_demo_app" %in% nms)
+
+  upd <- tools[[which(nms == "update_demo_app")]]
+  expect_equal(upd$inputSchema$properties$session$type, "string")
+  expect_equal(upd$inputSchema$properties$note$type, "string")
+  expect_true("session" %in% unlist(upd$inputSchema$required))
+  expect_match(upd$description, "in place", ignore.case = TRUE)
+})
+
+test_that("update tool name follows appId and reserves the name", {
+  skip_if_not_installed("ellmer")
+  local_mcp_config(arguments = list(x = ellmer::type_integer("x")))
+  expect_equal(mcpUpdateToolName(), "update_shiny_app")
+  expect_true("update_shiny_app" %in% mcpReservedToolNames())
+
+  local_mcp_config(appId = "clock", arguments = list(x = ellmer::type_integer("x")))
+  expect_equal(mcpUpdateToolName(), "update_clock_app")
+  expect_true("update_clock_app" %in% mcpReservedToolNames())
+})
+
 test_that("mcpDeployedUrl reads Posit Publisher deployment records", {
   dir <- withr::local_tempdir()
   rec_dir <- file.path(dir, ".posit", "publish", "deployments")

--- a/tests/testthat/test-mcp-session.R
+++ b/tests/testthat/test-mcp-session.R
@@ -173,6 +173,10 @@ test_that("mcpUpdateModelContext and mcpSendMessage send bridge messages", {
   expect_match(frames, "shiny.mcp.updateModelContext", fixed = TRUE)
   expect_match(frames, "n is 42", fixed = TRUE)
   expect_match(frames, "structuredContent", fixed = TRUE)
+  # The framework stamps the session token into structuredContent; author data
+  # nests under `data`.
+  expect_match(frames, "\"session\"", fixed = TRUE)
+  expect_match(frames, "\"data\"", fixed = TRUE)
   expect_match(frames, "shiny.mcp.sendMessage", fixed = TRUE)
   expect_match(frames, "What does this mean?", fixed = TRUE)
   mcpTunnelToolCall("_shiny_close", list(connectionId = sess$cid), 9, sess$handlers$ws)

--- a/tests/testthat/test-mcp-session.R
+++ b/tests/testthat/test-mcp-session.R
@@ -223,6 +223,38 @@ test_that("mcpRequestDisplayMode sends the bridge message", {
   expect_error(mcpRequestDisplayMode("cinema", session = MockShinySession$new()))
 })
 
+test_that("MCP sessions announce their token to the model on connect", {
+  skip_if_not_installed("ellmer")
+  withr::defer(.globals$mcp <- NULL)
+  mcpConfigure(appId = "clock", arguments = list(
+    label = ellmer::type_string("heading")
+  ))
+  token <- NULL
+  sess <- mcp_start_session(
+    fluidPage(),
+    function(input, output, session) {
+      token <<- session$token
+    }
+  )
+  frames <- paste(mcp_drain_frames(sess), collapse = "\n")
+  expect_match(frames, "shiny.mcp.updateModelContext", fixed = TRUE)
+  expect_match(frames, "update_clock_app", fixed = TRUE)
+  expect_match(frames, "connected", fixed = TRUE)
+  expect_match(frames, token, fixed = TRUE)
+
+  mcpTunnelToolCall("_shiny_close", list(connectionId = sess$cid), 9, sess$handlers$ws)
+})
+
+test_that("non-MCP and no-arguments sessions do not announce", {
+  # No mcpConfigure(arguments=...) => no announcement.
+  withr::defer(.globals$mcp <- NULL)
+  mcpConfigure(appId = "clock")  # enabled, but no arguments
+  sess <- mcp_start_session(fluidPage(), function(input, output, session) {})
+  frames <- paste(mcp_drain_frames(sess), collapse = "\n")
+  expect_no_match(frames, "shiny.mcp.updateModelContext", fixed = TRUE)
+  mcpTunnelToolCall("_shiny_close", list(connectionId = sess$cid), 9, sess$handlers$ws)
+})
+
 test_that("update_<appId>_app pushes args into the running session", {
   skip_if_not_installed("ellmer")
   withr::defer(.globals$mcp <- NULL)

--- a/tests/testthat/test-mcp-session.R
+++ b/tests/testthat/test-mcp-session.R
@@ -218,3 +218,57 @@ test_that("mcpRequestDisplayMode sends the bridge message", {
   expect_false(mcpRequestDisplayMode("pip", session = MockShinySession$new()))
   expect_error(mcpRequestDisplayMode("cinema", session = MockShinySession$new()))
 })
+
+test_that("update_<appId>_app pushes args into the running session", {
+  skip_if_not_installed("ellmer")
+  withr::defer(.globals$mcp <- NULL)
+  mcpConfigure(appId = "demo", arguments = list(
+    note = ellmer::type_string("a note"),
+    n    = ellmer::type_integer("count")
+  ))
+  observed <- list()
+  token <- NULL
+  sess <- mcp_start_session(
+    fluidPage(),
+    function(input, output, session) {
+      token <<- session$token
+      observe({
+        val <- mcpUpdates()
+        if (length(val) > 0) observed[[length(observed) + 1]] <<- val
+      })
+    }
+  )
+  pump_shiny(0.2)
+
+  h <- mcpHttpHandler(function(req) NULL, sess$handlers$ws)
+  res <- mcp_post(h, "tools/call", params = list(
+    name = "update_demo_app",
+    # `session` and a non-declared key are filtered out before the push.
+    arguments = list(session = token, note = "pushed", bogus = "x")
+  ))
+  expect_false(isTRUE(res$result$isError))
+  pump_shiny(0.3)
+  expect_equal(observed[[length(observed)]]$note, "pushed")
+
+  mcpTunnelToolCall("_shiny_close", list(connectionId = sess$cid), 9, sess$handlers$ws)
+})
+
+test_that("update_<appId>_app errors on unknown or missing session token", {
+  skip_if_not_installed("ellmer")
+  local_mcp_config(appId = "demo", arguments = list(
+    note = ellmer::type_string("a note")
+  ))
+  h <- mcpHttpHandler(function(req) NULL, function(ws) TRUE)
+
+  missing <- mcp_post(h, "tools/call", params = list(
+    name = "update_demo_app", arguments = list(note = "x")
+  ))
+  expect_true(missing$result$isError)
+
+  unknown <- mcp_post(h, "tools/call", params = list(
+    name = "update_demo_app",
+    arguments = list(session = "no-such-token", note = "x")
+  ))
+  expect_true(unknown$result$isError)
+  expect_match(unknown$result$content[[1]]$text, "no-such-token", fixed = TRUE)
+})

--- a/tests/testthat/test-mcp-session.R
+++ b/tests/testthat/test-mcp-session.R
@@ -94,6 +94,46 @@ test_that("mcpUpdates returns parsed tool arguments reactively", {
   mcpTunnelToolCall("_shiny_close", list(connectionId = sess$cid), 9, sess$handlers$ws)
 })
 
+test_that("mcpUpdates overlays server-pushed args on client init args", {
+  skip_if_not_installed("ellmer")
+  withr::defer(.globals$mcp <- NULL)
+  mcpConfigure(arguments = list(
+    note = ellmer::type_string("a note"),
+    n    = ellmer::type_integer("count")
+  ))
+  observed <- list()
+  token <- NULL
+  sess <- mcp_start_session(
+    fluidPage(),
+    function(input, output, session) {
+      token <<- session$token
+      observe({
+        val <- mcpUpdates()
+        if (length(val) > 0) observed[[length(observed) + 1]] <<- val
+      })
+    }
+  )
+  # Client delivers the initial open args.
+  mcp_send_update(sess, list(
+    .clientdata_mcp_tool_input = '{"note":"hello","n":3}'
+  ))
+  pump_shiny(0.3)
+  expect_equal(observed[[length(observed)]]$note, "hello")
+
+  # Server pushes a partial update; `n` must persist, `note` changes. Set the
+  # reactiveVal inside the session's domain, as the update handler does.
+  session <- appsByToken$get(token)
+  rv <- mcpServerUpdatesFor(session)
+  withReactiveDomain(session, rv(list(note = "world")))
+  session$requestFlush()
+  pump_shiny(0.3)
+  latest <- observed[[length(observed)]]
+  expect_equal(latest$note, "world")
+  expect_equal(latest$n, 3)
+
+  mcpTunnelToolCall("_shiny_close", list(connectionId = sess$cid), 9, sess$handlers$ws)
+})
+
 test_that("mcpHostContext returns parsed host context", {
   ctx <- NULL
   sess <- mcp_start_session(

--- a/tests/testthat/test-mcp-session.R
+++ b/tests/testthat/test-mcp-session.R
@@ -285,6 +285,54 @@ test_that("update_<appId>_app pushes args into the running session", {
   expect_false(isTRUE(res$result$isError))
   pump_shiny(0.3)
   expect_equal(observed[[length(observed)]]$note, "pushed")
+  # Undeclared keys are filtered out before the push.
+  expect_null(observed[[length(observed)]]$bogus)
+
+  mcpTunnelToolCall("_shiny_close", list(connectionId = sess$cid), 9, sess$handlers$ws)
+})
+
+test_that("update_<appId>_app accumulates successive pushes", {
+  skip_if_not_installed("ellmer")
+  withr::defer(.globals$mcp <- NULL)
+  mcpConfigure(appId = "demo", arguments = list(
+    note = ellmer::type_string("a note"),
+    n    = ellmer::type_integer("count")
+  ))
+  observed <- list()
+  token <- NULL
+  sess <- mcp_start_session(
+    fluidPage(),
+    function(input, output, session) {
+      token <<- session$token
+      observe({
+        val <- mcpUpdates()
+        if (length(val) > 0) observed[[length(observed) + 1]] <<- val
+      })
+    }
+  )
+  pump_shiny(0.2)
+
+  h <- mcpHttpHandler(function(req) NULL, sess$handlers$ws)
+  # First push: set `n`.
+  res1 <- mcp_post(h, "tools/call", params = list(
+    name = "update_demo_app",
+    arguments = list(session = token, n = 5)
+  ))
+  expect_false(isTRUE(res1$result$isError))
+  pump_shiny(0.3)
+  expect_equal(observed[[length(observed)]]$n, 5)
+
+
+  # Second push: set `note`. The previously pushed `n` must persist.
+  res2 <- mcp_post(h, "tools/call", params = list(
+    name = "update_demo_app",
+    arguments = list(session = token, note = "hi")
+  ))
+  expect_false(isTRUE(res2$result$isError))
+  pump_shiny(0.3)
+  latest <- observed[[length(observed)]]
+  expect_equal(latest$note, "hi")
+  expect_equal(latest$n, 5)
 
   mcpTunnelToolCall("_shiny_close", list(connectionId = sess$cid), 9, sess$handlers$ws)
 })


### PR DESCRIPTION
## Summary

Follow-up to #4414. Gives an MCP host/model an explicit **update verb** so it can change an already-open Shiny MCP App **in place** instead of re-opening it (which today renders a fresh instance per `open_*` call).

When an app declares `mcpConfigure(arguments = ...)`, Shiny now auto-registers a companion **`update_<appId>_app`** tool. A model call to it runs server-side, targets a specific running session, and pushes new arguments through the existing `mcpUpdates()` reactive channel — no re-render, no author code beyond the single `observe(mcpUpdates())` apps already write.

## Design (5 decisions)

1. **Explicit session targeting** — `update_*` takes a required `session` token; no broadcast/most-recent guessing. To update several instances the model loops.
2. **Server-side `reactiveVal` overlay** — each MCP session holds a server-push `reactiveVal`; `mcpUpdates()` overlays it on the client-delivered init args (per-key, latest wins) then allow-list filters. Successive pushes **accumulate**.
3. **Registry via existing `appsByToken`** — keyed by `session$token`; unknown/stale/non-MCP token → tool error (never silent success).
4. **Auto tool, only when `arguments` declared** — handler pushes inside `withReactiveDomain(session, …)` + `requestFlush()` so the app's observer fires in the right context.
5. **Token delivery** — on connect the app announces its `session$token` to the model (reserved-key envelope through `mcpUpdateModelContext`, + a text instruction); `mcpUpdateModelContext()` payload now stamps `session` into `structuredContent`.

Entirely R-side — the JS bridge already forwards these messages.

## Known limitations (see `mcp/limitations.md`)

- **Host-passthrough spike:** needs end-to-end confirmation that a real host (claude.ai) forwards the `{session, state}` structured content + instruction so the model can echo the id. (Verify in Claude Desktop.)
- **Multi-instance:** with several open instances the model must pick the right token; no server-side guarantee.

## Docs & tests

- Spec: `mcp/design-mcp-update-running-app.md`; plan: `mcp/implementation-plan-update-running-app.md`.
- `?mcp-session` roxygen, `mcp/design-mcpConfigure.md`, `mcp/limitations.md`, `NEWS.md` updated; demo apps (clock/demo/cars) get explanatory comments — the update path needs **zero** app-code change.
- Full MCP test suite: 279 passing (registry lifecycle, overlay/accumulate semantics, dispatch incl. error paths, tool visibility, connect-time announcement, envelope shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)