### PR TITLE
fix: soft teardown of reactives when a session closes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -122,7 +122,7 @@ Suggests:
     testthat (>= 3.2.1),
     yaml
 Config/Needs/check: shinyjs
-Config/roxygen2/version: 8.0.0
+Config/roxygen2/version: 8.1.0
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -342,92 +342,104 @@ import(httpuv)
 import(methods)
 import(mime)
 import(xtable)
-importFrom(fastmap,fastmap)
-importFrom(fastmap,is.key_missing)
-importFrom(fastmap,key_missing)
-importFrom(grDevices,dev.cur)
-importFrom(grDevices,dev.set)
-importFrom(htmltools,HTML)
-importFrom(htmltools,a)
-importFrom(htmltools,br)
-importFrom(htmltools,code)
-importFrom(htmltools,div)
-importFrom(htmltools,em)
-importFrom(htmltools,h1)
-importFrom(htmltools,h2)
-importFrom(htmltools,h3)
-importFrom(htmltools,h4)
-importFrom(htmltools,h5)
-importFrom(htmltools,h6)
-importFrom(htmltools,hr)
-importFrom(htmltools,htmlTemplate)
-importFrom(htmltools,img)
-importFrom(htmltools,includeCSS)
-importFrom(htmltools,includeHTML)
-importFrom(htmltools,includeMarkdown)
-importFrom(htmltools,includeScript)
-importFrom(htmltools,includeText)
-importFrom(htmltools,is.singleton)
-importFrom(htmltools,p)
-importFrom(htmltools,pre)
-importFrom(htmltools,singleton)
-importFrom(htmltools,span)
-importFrom(htmltools,strong)
-importFrom(htmltools,suppressDependencies)
-importFrom(htmltools,tag)
-importFrom(htmltools,tagAppendAttributes)
-importFrom(htmltools,tagAppendChild)
-importFrom(htmltools,tagAppendChildren)
-importFrom(htmltools,tagGetAttribute)
-importFrom(htmltools,tagHasAttribute)
-importFrom(htmltools,tagList)
-importFrom(htmltools,tagSetChildren)
-importFrom(htmltools,tags)
-importFrom(htmltools,validateCssUnit)
-importFrom(htmltools,withTags)
-importFrom(lifecycle,deprecated)
-importFrom(lifecycle,is_present)
-importFrom(promises,"%...!%")
-importFrom(promises,"%...>%")
-importFrom(promises,as.promise)
-importFrom(promises,hybrid_then)
-importFrom(promises,is.promise)
-importFrom(promises,is.promising)
-importFrom(promises,new_promise_domain)
-importFrom(promises,promise_reject)
-importFrom(promises,promise_resolve)
-importFrom(promises,with_promise_domain)
-importFrom(rlang,"%||%")
-importFrom(rlang,"fn_body<-")
-importFrom(rlang,"fn_fmls<-")
-importFrom(rlang,as_function)
-importFrom(rlang,as_quosure)
-importFrom(rlang,check_dots_empty)
-importFrom(rlang,check_dots_unnamed)
-importFrom(rlang,enexpr)
-importFrom(rlang,enquo)
-importFrom(rlang,enquo0)
-importFrom(rlang,enquos)
-importFrom(rlang,enquos0)
-importFrom(rlang,eval_tidy)
-importFrom(rlang,expr)
-importFrom(rlang,fn_body)
-importFrom(rlang,get_env)
-importFrom(rlang,get_expr)
-importFrom(rlang,inject)
-importFrom(rlang,is_false)
-importFrom(rlang,is_missing)
-importFrom(rlang,is_na)
-importFrom(rlang,is_quosure)
-importFrom(rlang,list2)
-importFrom(rlang,maybe_missing)
-importFrom(rlang,missing_arg)
-importFrom(rlang,new_function)
-importFrom(rlang,new_quosure)
-importFrom(rlang,pairlist2)
-importFrom(rlang,quo)
-importFrom(rlang,quo_get_expr)
-importFrom(rlang,quo_is_missing)
-importFrom(rlang,quo_set_env)
-importFrom(rlang,quo_set_expr)
-importFrom(rlang,zap_srcref)
+importFrom(fastmap,
+  fastmap,
+  is.key_missing,
+  key_missing
+)
+importFrom(grDevices,
+  dev.cur,
+  dev.set
+)
+importFrom(htmltools,
+  HTML,
+  a,
+  br,
+  code,
+  div,
+  em,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  hr,
+  htmlTemplate,
+  img,
+  includeCSS,
+  includeHTML,
+  includeMarkdown,
+  includeScript,
+  includeText,
+  is.singleton,
+  p,
+  pre,
+  singleton,
+  span,
+  strong,
+  suppressDependencies,
+  tag,
+  tagAppendAttributes,
+  tagAppendChild,
+  tagAppendChildren,
+  tagGetAttribute,
+  tagHasAttribute,
+  tagList,
+  tagSetChildren,
+  tags,
+  validateCssUnit,
+  withTags
+)
+importFrom(lifecycle,
+  deprecated,
+  is_present
+)
+importFrom(promises,
+  "%...!%",
+  "%...>%",
+  as.promise,
+  hybrid_then,
+  is.promise,
+  is.promising,
+  new_promise_domain,
+  promise_reject,
+  promise_resolve,
+  with_promise_domain
+)
+importFrom(rlang,
+  "%||%",
+  "fn_body<-",
+  "fn_fmls<-",
+  as_function,
+  as_quosure,
+  check_dots_empty,
+  check_dots_unnamed,
+  enexpr,
+  enquo,
+  enquo0,
+  enquos,
+  enquos0,
+  eval_tidy,
+  expr,
+  fn_body,
+  get_env,
+  get_expr,
+  inject,
+  is_false,
+  is_missing,
+  is_na,
+  is_quosure,
+  list2,
+  maybe_missing,
+  missing_arg,
+  new_function,
+  new_quosure,
+  pairlist2,
+  quo,
+  quo_get_expr,
+  quo_is_missing,
+  quo_set_env,
+  quo_set_expr,
+  zap_srcref
+)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # shiny (development version)
 
-* Fixed #4420: closing a session no longer destroys the reactive values and expressions created in it, so async work that outlives the connection does not error. Since 1.14.0, refreshing the page while an `ExtendedTask` (or any promise or `later()` callback) was in flight could raise ``Can't access reactive `Theme Counter`; its module session has been destroyed`` once it settled. Reactives are now left readable at their last value on close and reclaimed by garbage collection, while an explicit `session$destroy(namespace)` on a live session still tears them down. (#4421)
+* Fixed #4420: closing a session no longer destroys the reactive values and expressions created in it, so async work that outlives the connection does not error. Since 1.14.0, refreshing the page while an `ExtendedTask` (or any promise or `later()` callback) was in flight could raise ``Can't access reactive `<NAME>`; its module session has been destroyed`` once it settled. Reactives are now left readable at their last value on close and reclaimed by garbage collection, while an explicit `session$destroy(namespace)` on a live session still tears them down. (#4421)
 
 * The `session$destroy()` parameter is now documented as `namespace` to match the implemented argument name. (#4419)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # shiny (development version)
 
+* Fixed #4420: closing a session no longer destroys the reactive values and expressions created in it, so async work that outlives the connection does not error. Since 1.14.0, refreshing the page while an `ExtendedTask` (or any promise or `later()` callback) was in flight could raise ``Can't access reactive `Theme Counter`; its module session has been destroyed`` once it settled. Reactives are now left readable at their last value on close and reclaimed by garbage collection, while an explicit `session$destroy(namespace)` on a live session still tears them down. (#4421)
+
 * The `session$destroy()` parameter is now documented as `namespace` to match the implemented argument name. (#4419)
 
 * `{watcher}` is now a required dependency and is always used for autoreload file watching, so it no longer needs to be installed separately. The legacy polling-based file watcher has been removed. (#4403)

--- a/R/mock-session.R
+++ b/R/mock-session.R
@@ -347,6 +347,9 @@ MockShinySession <- R6Class(
     isClosed = function(){ private$was_closed },
     #' @description Closes the session
     close = function(){
+      # Mark closed first, mirroring `ShinySession$wsClosed()`: teardown needs
+      # to be able to tell a whole-session close from an explicit `destroy()`.
+      private$was_closed <- TRUE
       for (output in private$output) {
         output$suspend()
       }
@@ -354,7 +357,6 @@ MockShinySession <- R6Class(
         private$endedCBs$invoke(onError = printError, ..stacktraceon = TRUE)
       })
       private$invokeDestroyCallbacks(allowRoot = TRUE)
-      private$was_closed <- TRUE
     },
 
     #' @description Set input names to be excluded from bookmarking.

--- a/R/reactives.R
+++ b/R/reactives.R
@@ -65,16 +65,35 @@ Dependents <- R6Class(
   )
 )
 
+# Is this domain being torn down because its client went away, as opposed to an
+# explicit `session$destroy(namespace)` on a still-running session?
+isClosedDomain <- function(domain) {
+  !is.null(domain) &&
+    is.function(domain$isClosed) &&
+    isTRUE(domain$isClosed())
+}
+
 # Helper to create an onDestroy wrapper closure that only captures the weakref,
 # avoiding accidental strong references to `self`/`private` from the enclosing
 # initialize() environment.
-make_weak_destroy_wrapper <- function(wr) {
+make_weak_destroy_wrapper <- function(wr, domain = NULL) {
   # force() is critical: without it, `wr` is a promise that retains a reference
   # to the calling environment (e.g., initialize()), which holds `self` strongly.
   # Forcing the promise replaces it with the evaluated value, breaking the
   # reference chain and allowing the weakref key to be GC'd.
   force(wr)
+  force(domain)
   function() {
+    # A whole-session close is not a destroy. Every consumer in the session is
+    # already gone (observers are destroyed via onEnded, outputs are suspended,
+    # and flushes are skipped once closed), so the reactive is left intact and
+    # reclaimed by ordinary garbage collection. Tearing it down here would
+    # instead poison async work that outlives the socket -- an ExtendedTask
+    # settling after a page refresh, a later() callback, an httr2 continuation
+    # -- with an unavoidable, racy `shiny.destroyed.error`.
+    if (isClosedDomain(domain)) {
+      return()
+    }
     obj <- rlang::wref_key(wr)
     if (!is.null(obj)) {
       obj$destroy()
@@ -126,7 +145,7 @@ ReactiveVal <- R6Class(
 
       if (!is.null(domain) && is.function(domain$onDestroy)) {
         wr <- rlang::new_weakref(key = self)
-        private$.destroyHandle <- domain$onDestroy(make_weak_destroy_wrapper(wr))
+        private$.destroyHandle <- domain$onDestroy(make_weak_destroy_wrapper(wr, domain))
       }
     },
     get = function() {
@@ -443,7 +462,7 @@ ReactiveValues <- R6Class(
       domain <- getDefaultReactiveDomain()
       if (!is.null(domain) && is.function(domain$onDestroy)) {
         wr <- rlang::new_weakref(key = self)
-        .destroyHandle <<- domain$onDestroy(make_weak_destroy_wrapper(wr))
+        .destroyHandle <<- domain$onDestroy(make_weak_destroy_wrapper(wr, domain))
       }
     },
 
@@ -1063,7 +1082,7 @@ Observable <- R6Class(
 
       if (!is.null(.domain) && is.function(.domain$onDestroy)) {
         wr <- rlang::new_weakref(key = self)
-        .destroyHandle <<- .domain$onDestroy(make_weak_destroy_wrapper(wr))
+        .destroyHandle <<- .domain$onDestroy(make_weak_destroy_wrapper(wr, .domain))
       }
     },
     getValue = function() {
@@ -1538,7 +1557,7 @@ Observer <- R6Class(
             .autoDestroyHandle <<- onReactiveDomainEnded(.domain, .onDomainEnded)
             if (is.function(.domain$onDestroy)) {
               wr <- rlang::new_weakref(key = self)
-              .autoDestroyOnDestroyHandle <<- .domain$onDestroy(make_weak_destroy_wrapper(wr))
+              .autoDestroyOnDestroyHandle <<- .domain$onDestroy(make_weak_destroy_wrapper(wr, .domain))
             }
           }
         }

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -152,6 +152,13 @@ workerId <- local({
 #'   after `session$onEnded()` callbacks. Note, `session$destroy()` is not
 #'   allowed for root sessions. For module session proxies, callbacks are
 #'   invoked when `session$destroy()` is called.
+#'
+#'   Closing a session is not the same as destroying a scope. `destroy()`
+#'   tears down the scope's reactive values and expressions, so reading one
+#'   afterwards is an error. When a session closes, they are instead left
+#'   readable at their last value and reclaimed by garbage collection, so
+#'   async work that outlives the connection (for example an [ExtendedTask]
+#'   that settles after the user refreshes the page) does not error.
 #' }
 #' \item{destroy(namespace = NULL)}{
 #'   Destroys a module session scope (and any descendant scopes) by invoking
@@ -1316,10 +1323,16 @@ ShinySession <- R6Class(
     },
     onDestroy = function(callback) {
       "Registers a callback to be invoked when the session scope is destroyed
-      via `destroy()`. Returns a function that can be called to
-      unregister the callback. For module sessions, use this to register
-      cleanup logic that runs when the module's UI is removed and
-      `session$destroy()` is called."
+      via `destroy()`, and when the session itself closes. Returns a function
+      that can be called to unregister the callback. For module sessions, use
+      this to register cleanup logic that runs when the module's UI is removed
+      and `session$destroy()` is called.
+
+      Note that closing a session is not the same as destroying a scope. An
+      explicit `destroy()` tears down the scope's reactive values and
+      expressions, so reading one afterwards is an error. On close, they are
+      left readable at their last value and reclaimed by garbage collection,
+      so async work that outlives the connection does not error."
       private$getOrCreateDestroyCallbacks(NULL)$register(callback)
     },
     destroy = function(namespace = NULL) {

--- a/man/session.Rd
+++ b/man/session.Rd
@@ -60,6 +60,13 @@ For the root session, callbacks are invoked when the session closes,
 after \code{session$onEnded()} callbacks. Note, \code{session$destroy()} is not
 allowed for root sessions. For module session proxies, callbacks are
 invoked when \code{session$destroy()} is called.
+
+Closing a session is not the same as destroying a scope. \code{destroy()}
+tears down the scope's reactive values and expressions, so reading one
+afterwards is an error. When a session closes, they are instead left
+readable at their last value and reclaimed by garbage collection, so
+async work that outlives the connection (for example an \link{ExtendedTask}
+that settles after the user refreshes the page) does not error.
 }
 \item{destroy(namespace = NULL)}{
 Destroys a module session scope (and any descendant scopes) by invoking

--- a/tests/testthat/test-destroy.R
+++ b/tests/testthat/test-destroy.R
@@ -977,3 +977,219 @@ test_that("createMockDomain destroy is idempotent", {
   domain$destroy()
   expect_equal(count, 1L)
 })
+
+# ---- Soft teardown on whole-session close ---------------------------------
+#
+# Closing a session is not the same as destroying a module scope. When the
+# client goes away, every consumer in the session is already gone and the whole
+# object graph is about to be garbage collected, so reactives are left intact:
+# async work that outlives the socket (an ExtendedTask settling after a page
+# refresh, a `later()` callback, an httr2 continuation) must not be poisoned by
+# a `shiny.destroyed.error`. An explicit `session$destroy(ns)` on a live session
+# still tears down for real.
+
+test_that("session close leaves a reactiveVal readable at its last value", {
+  session <- MockShinySession$new()
+  withReactiveDomain(session, {
+    rv <- reactiveVal(10, label = "survives_close")
+  })
+  isolate(rv(42))
+
+  session$close()
+
+  isolate(expect_equal(rv(), 42))
+})
+
+test_that("session close leaves a reactiveVal writable", {
+  session <- MockShinySession$new()
+  withReactiveDomain(session, {
+    rv <- reactiveVal(10, label = "survives_close")
+  })
+
+  session$close()
+
+  expect_no_error(isolate(rv(99)))
+  isolate(expect_equal(rv(), 99))
+})
+
+test_that("session close leaves reactiveValues usable", {
+  session <- MockShinySession$new()
+  withReactiveDomain(session, {
+    rvs <- reactiveValues(x = 1)
+  })
+
+  session$close()
+
+  isolate(expect_equal(rvs$x, 1))
+  expect_no_error(isolate(rvs$x <- 2))
+  isolate(expect_equal(rvs$x, 2))
+})
+
+test_that("session close leaves a reactive expression usable", {
+  session <- MockShinySession$new()
+  withReactiveDomain(session, {
+    rv <- reactiveVal(10)
+    r <- reactive(rv() * 2)
+  })
+  isolate(expect_equal(r(), 20))
+
+  session$close()
+
+  isolate(expect_equal(r(), 20))
+})
+
+# A real ShinySession, driven by a websocket stub. MockShinySession is not
+# usable for the theme tests below: its `getCurrentTheme()` is a warn-noop, so
+# it never touches the session-scoped `Theme Counter` reactiveVal that the
+# original bug was reported against.
+createTestShinySession <- function() {
+  ShinySession$new(list(
+    request = list(),
+    send = function(json) invisible(NULL),
+    close = function() invisible(NULL),
+    onMessage = function(f) invisible(NULL),
+    onClose = function(f) invisible(NULL)
+  ))
+}
+
+# Settle pending promises and reactive flushes.
+pumpEvents <- function(times = 10) {
+  for (i in seq_len(times)) {
+    later::run_now()
+    flushReact()
+  }
+}
+
+test_that("session close leaves session$getCurrentTheme() readable", {
+  # The regression that motivated this: shinychat's streaming ExtendedTask
+  # resolves after a page refresh and reads the theme, which reads the
+  # session-scoped `Theme Counter` reactiveVal.
+  session <- createTestShinySession()
+  isolate(expect_no_error(session$getCurrentTheme()))
+
+  session$wsClosed()
+
+  expect_true(session$isClosed())
+  expect_no_error(isolate(session$getCurrentTheme()))
+})
+
+test_that("session close leaves the `Theme Counter` reactiveVal at its last value", {
+  session <- createTestShinySession()
+  themeCounter <- session$.__enclos_env__$private$currentThemeDependency
+  # Bump it the way `session$setCurrentTheme()` does, so the assertion after
+  # close distinguishes "kept its value" from "reset to its initial value".
+  isolate(themeCounter(themeCounter() + 1))
+  isolate(expect_equal(themeCounter(), 1))
+
+  session$wsClosed()
+
+  isolate(expect_equal(themeCounter(), 1))
+  expect_no_error(isolate(themeCounter(2)))
+  isolate(expect_equal(themeCounter(), 2))
+})
+
+test_that("an ExtendedTask settling after session close completes normally", {
+  # End-to-end shape of the reported bug: the task is still in flight when the
+  # user refreshes, and its promise settles against a closed session.
+  session <- createTestShinySession()
+  resolve <- NULL
+  withReactiveDomain(session, {
+    task <- ExtendedTask$new(function() {
+      promises::promise(function(res, rej) resolve <<- res)
+    })
+  })
+  withReactiveDomain(session, task$invoke())
+  pumpEvents()
+  expect_equal(isolate(task$status()), "running")
+
+  session$wsClosed()
+  resolve(42)
+
+  expect_no_error(pumpEvents())
+  expect_equal(isolate(task$status()), "success")
+  expect_equal(isolate(task$result()), 42)
+})
+
+test_that("an ExtendedTask settling after close can read the session theme", {
+  # The full reported chain: shinychat's stream task resolves post-refresh and
+  # calls chat_append() -> with_current_theme() -> bslib::bs_current_theme()
+  # -> session$getCurrentTheme() -> the `Theme Counter` reactiveVal.
+  session <- createTestShinySession()
+  resolve <- NULL
+  themeReadError <- NULL
+  withReactiveDomain(session, {
+    task <- ExtendedTask$new(function() {
+      promises::then(
+        promises::promise(function(res, rej) resolve <<- res),
+        function(value) {
+          themeReadError <<- tryCatch(
+            {
+              isolate(session$getCurrentTheme())
+              NA_character_
+            },
+            error = function(e) conditionMessage(e)
+          )
+          value
+        }
+      )
+    })
+  })
+  withReactiveDomain(session, task$invoke())
+  pumpEvents()
+
+  session$wsClosed()
+  resolve("streamed")
+  pumpEvents()
+
+  expect_true(is.na(themeReadError))
+  expect_equal(isolate(task$status()), "success")
+  expect_equal(isolate(task$result()), "streamed")
+})
+
+test_that("session close does not re-run observers", {
+  # Soft teardown must not resurrect the session: writes after close stay inert
+  # because observers were already destroyed when the domain ended.
+  session <- MockShinySession$new()
+  ran <- 0L
+  withReactiveDomain(session, {
+    rv <- reactiveVal(0)
+    observe({
+      rv()
+      ran <<- ran + 1L
+    })
+  })
+  flushReact()
+  expect_equal(ran, 1L)
+
+  session$close()
+  isolate(rv(1))
+  flushReact()
+
+  expect_equal(ran, 1L)
+})
+
+test_that("explicit destroy of a module scope still hard-destroys its reactives", {
+  # Contrast with close: an explicit `destroy()` on a live session means a
+  # later access is a genuine bug, so it must keep erroring.
+  session <- MockShinySession$new()
+  scope <- session$makeScope("mod1")
+  withReactiveDomain(scope, {
+    rv <- reactiveVal(10, label = "in_module")
+  })
+
+  session$destroy("mod1")
+
+  expect_error(isolate(rv()), class = "shiny.destroyed.error")
+})
+
+test_that("module reactives survive a root session close", {
+  session <- MockShinySession$new()
+  scope <- session$makeScope("mod1")
+  withReactiveDomain(scope, {
+    rv <- reactiveVal(10, label = "in_module")
+  })
+
+  session$close()
+
+  isolate(expect_equal(rv(), 10))
+})


### PR DESCRIPTION
Fixes #4420. Found by @gadenbuie (Garrick Aden-Buie) while using shinychat.

## Problem

Since #4372 / #4395, closing a session tears down every reactive created in the session's domain: `ShinySession$wsClosed()` calls `invokeDestroyCallbacks(allowRoot = TRUE)`, which fires the weak destroy wrapper that each `reactiveVal()` / `reactiveValues()` / `reactive()` registers at construction.

So any async continuation that outlives the websocket close errors on its first reactive access. Refreshing the page during in-flight async work is routine, which turned a previously benign race into a user-visible error:

```
Can't access reactive `Theme Counter`; its module session has been destroyed
```

`Theme Counter` is just the first reactive shinychat happens to touch (`chat_append()` -> `with_current_theme()` -> `bslib::bs_current_theme()` -> `session$getCurrentTheme()`). User-created reactives failed identically, and `ExtendedTask` then failed *again* setting its own state, leaving the task in neither `"success"` nor `"error"`.

Affects shiny 1.14.0 and later, including current `main` -- the `session$destroy()` work shipped in 1.14.0.

## Fix

A close is not a destroy, so the two are now distinguished:

- **On close**, reactive values and expressions are left intact, readable at their last value, and reclaimed by ordinary garbage collection. `onDestroy()` callbacks still fire, so module cleanup and `invalidateLater` timer cancellation are unaffected.
- **On explicit `session$destroy(namespace)`** against a live session, teardown is unchanged and a later access still raises `shiny.destroyed.error` -- there, a stale access is a genuine bug worth surfacing.

`make_weak_destroy_wrapper()` takes the domain and no-ops when that domain is closed. No new state, so `get()` returning the last value and `set()` staying legal-but-inert both fall out naturally.

`MockShinySession$close()` now marks the session closed *before* running teardown, matching `ShinySession$wsClosed()`.

## Why not keep erroring on post-close access

- **Shiny's own code depends on it.** `ExtendedTask` sets `rv_status` / `rv_error` when its promise settles, which routinely lands after a refresh. Under the old rule `ExtendedTask` itself was in violation.
- **App authors cannot comply.** The access is usually inside shinychat/bslib/`ExtendedTask`, not user code, and `if (!session$isClosed())` is TOCTOU.
- **The write was already inert.** Observers are destroyed when the domain ends, the session is dropped from `appsNeedingFlush`, and `flushOutput()` early-returns when closed. Verified experimentally: an observer depending on a post-close write does not re-run.
- **Erroring made teardown worse**, not better -- the first error aborted the promise chain and left `ExtendedTask` in a bogus state.

## Tests

12 new tests in `test-destroy.R`, all of which fail without the source change and pass with it:

- reactiveVal / reactiveValues / reactive expressions readable and writable after close, and module reactives surviving a root close
- an observer does **not** re-run on a post-close write (soft teardown must not resurrect the session)
- explicit module `destroy()` still raises `shiny.destroyed.error`

The theme tests drive a **real `ShinySession`** via a websocket stub rather than `MockShinySession`, whose `getCurrentTheme()` is a `makeWarnNoops` stub that never touches the `Theme Counter` reactiveVal:

- `session$getCurrentTheme()` readable after a real `wsClosed()`
- the `Theme Counter` reactiveVal holds its last value across close (bumped first, so the assertion distinguishes "kept its value" from "reset")
- a real `ExtendedTask` that settles after close reaches `"success"` with its result
- an `ExtendedTask` whose continuation reads the session theme after close, i.e. the full reported chain in one test

Verified by reverting only `R/reactives.R` and `R/mock-session.R`: all 12 fail with the exact errors from the report.

Also confirmed end-to-end in a browser -- click, refresh mid-task, previously two errors, now clean.

