### PR TITLE
chore: Test against rstudio/bslib#1342

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -121,6 +121,8 @@ Suggests:
     showtext,
     testthat (>= 3.2.1),
     yaml
+Remotes:
+    rstudio/bslib#1342
 Config/Needs/check: shinyjs
 Config/roxygen2/version: 8.1.0
 Config/testthat/edition: 3


### PR DESCRIPTION
## Summary

Companion to **rstudio/bslib#1342**, which makes a navset with an `id` reuse it as the `data-tabsetid` instead of minting a random integer. `shiny::tabsetPanel()`, `navbarPage()`, `navlistPanel()` and `tabPanel()` all render through `bslib:::buildTabset()`, so that change flows into shiny's markup.

This PR only adds a `Remotes:` entry pointing at the bslib branch, so CI exercises shiny against it.

## No shiny-side changes are needed

- Full test suite against the bslib branch: **3130 passing, 0 failing**.
- `tests/testthat/_snaps/tabPanel.md` is **unchanged**. It contains 30 `data-tabsetid` values, but none of the snapshotted tabsets pass an `id`, so they all stay on the random-integer path.

## Merge order

1. Merge rstudio/bslib#1342
2. Revert the `Remotes:` entry here (or drop it entirely)
3. Merge this

## Note on the bslib side

R doesn't validate input id characters the way py-shiny does, so bslib only reuses an id when it's safe to embed in a CSS selector (`^[A-Za-z0-9_-]+$`) — otherwise `tabsetPanel(id = "my.tabs")` would emit `href="#tab-my.tabs-1"`, which a browser reads as `#tab-my` + `.tabs-1`. Unsafe ids fall back to the previous random integer. Details in the bslib PR.

Originally from posit-dev/py-shiny#2410, which makes the same change in Shiny for Python.