### PR TITLE
docs: Stop implying that closing a session destroys its reactives

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # shiny (development version)
 
+* The `?session` docs no longer imply that closing a session destroys its reactive values and expressions. The `destroy(namespace)` entry lists the reactive state that teardown cleans up and then said the root session "is torn down via `close()`" -- i.e. the behavior #4421 removed. The corrective paragraph added in #4421 only landed on the neighboring `onDestroy()` entry, so the two contradicted each other. (#4422)
+
 * Fixed #4420: closing a session no longer destroys the reactive values and expressions created in it, so async work that outlives the connection does not error. Since 1.14.0, refreshing the page while an `ExtendedTask` (or any promise or `later()` callback) was in flight could raise ``Can't access reactive `<NAME>`; its module session has been destroyed`` once it settled. Reactives are now left readable at their last value on close and reclaimed by garbage collection, while an explicit `session$destroy(namespace)` on a live session still tears them down. (#4421)
 
 * The `session$destroy()` parameter is now documented as `namespace` to match the implemented argument name. (#4419)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # shiny (development version)
 
-* The `?session` docs no longer imply that closing a session destroys its reactive values and expressions. The `destroy(namespace)` entry lists the reactive state that teardown cleans up and then said the root session "is torn down via `close()`" -- i.e. the behavior #4421 removed. The corrective paragraph added in #4421 only landed on the neighboring `onDestroy()` entry, so the two contradicted each other. (#4422)
+* The `?session` docs no longer imply that closing a session destroys its reactive values and expressions. The `destroy(namespace)` entry lists the reactive state that teardown cleans up and then said the root session "is torn down via `close()`" -- i.e. the behavior #4421 removed. The corrective paragraph added in #4421 only landed on the neighboring `onDestroy()` entry, so the two contradicted each other. (#4423)
 
 * Fixed #4420: closing a session no longer destroys the reactive values and expressions created in it, so async work that outlives the connection does not error. Since 1.14.0, refreshing the page while an `ExtendedTask` (or any promise or `later()` callback) was in flight could raise ``Can't access reactive `<NAME>`; its module session has been destroyed`` once it settled. Reactives are now left readable at their last value on close and reclaimed by garbage collection, while an explicit `session$destroy(namespace)` on a live session still tears them down. (#4421)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,6 @@
 # shiny (development version)
 
-* The `?session` docs no longer imply that closing a session destroys its reactive values and expressions. The `destroy(namespace)` entry lists the reactive state that teardown cleans up and then said the root session "is torn down via `close()`" -- i.e. the behavior #4421 removed. The corrective paragraph added in #4421 only landed on the neighboring `onDestroy()` entry, so the two contradicted each other. (#4423)
-
-* Fixed #4420: closing a session no longer destroys the reactive values and expressions created in it, so async work that outlives the connection does not error. Since 1.14.0, refreshing the page while an `ExtendedTask` (or any promise or `later()` callback) was in flight could raise ``Can't access reactive `<NAME>`; its module session has been destroyed`` once it settled. Reactives are now left readable at their last value on close and reclaimed by garbage collection, while an explicit `session$destroy(namespace)` on a live session still tears them down. (#4421)
+* Fixed #4420: closing a session no longer destroys the reactive values and expressions created in it, so async work that outlives the connection does not error. Since 1.14.0, refreshing the page while an `ExtendedTask` (or any promise or `later()` callback) was in flight could raise ``Can't access reactive `<NAME>`; its module session has been destroyed`` once it settled. Reactives are now left readable at their last value on close and reclaimed by garbage collection, while an explicit `session$destroy(namespace)` on a live session still tears them down. (#4421, #4423)
 
 * The `session$destroy()` parameter is now documented as `namespace` to match the implemented argument name. (#4419)
 

--- a/R/mock-session.R
+++ b/R/mock-session.R
@@ -316,9 +316,14 @@ MockShinySession <- R6Class(
     onEnded = function(sessionEndedCallback) {
       private$endedCBs$register(sessionEndedCallback)
     },
-    #' @description Registers a callback to be invoked when the session scope
-    #'   is destroyed. Returns a function that can be called to unregister the
-    #'   callback.
+    #' @description Registers a callback to be invoked when the session scope is
+    #'   destroyed via `destroy()`, and when the session itself closes. Returns a
+    #'   function that can be called to unregister the callback.
+    #'
+    #'   Note that closing a session is not the same as destroying a scope. An
+    #'   explicit `destroy()` tears down the scope's reactive values and
+    #'   expressions, so reading one afterwards is an error. On close, they are
+    #'   left readable at their last value, matching `ShinySession`.
     #' @param callback The callback to invoke on destroy.
     onDestroy = function(callback) {
       private$getOrCreateDestroyCallbacks(NULL)$register(callback)
@@ -333,7 +338,7 @@ MockShinySession <- R6Class(
     destroy = function(namespace = NULL) {
       if (length(namespace) == 0) {
         stop(
-          "`$destroy()` cannot be called on the root session without a `namespace`. Pass a module `namespace` to tear down that scope (e.g. `session$destroy(\"my_module\")`), or call `close()` to tear down the whole session.",
+          "`$destroy()` cannot be called on the root session without a `namespace`. Pass a module `namespace` to tear down that scope (e.g. `session$destroy(\"my_module\")`), or call `close()` to end the whole session (which is not a destroy: reactive values and expressions stay readable).",
           call. = FALSE
         )
       }
@@ -781,10 +786,11 @@ MockShinySession <- R6Class(
     # @param allowRoot Whether tearing down the root scope is permitted.
     invokeDestroyCallbacks = function(namespace = NULL, allowRoot = FALSE) {
       isRoot <- length(namespace) == 0
-      # The root scope can only be torn down via `close()` (allowRoot = TRUE).
+      # Root-scope destroy callbacks are only dispatched from `close()`
+      # (allowRoot = TRUE), where the reactives themselves are left intact.
       if (isRoot && !allowRoot) {
         stop(
-          "`$destroy()` cannot be called on the root session without a `namespace`. Pass a module `namespace` to tear down that scope (e.g. `session$destroy(\"my_module\")`), or call `close()` to tear down the whole session.",
+          "`$destroy()` cannot be called on the root session without a `namespace`. Pass a module `namespace` to tear down that scope (e.g. `session$destroy(\"my_module\")`), or call `close()` to end the whole session (which is not a destroy: reactive values and expressions stay readable).",
           call. = FALSE
         )
       }

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -162,9 +162,10 @@ workerId <- local({
 #' }
 #' \item{destroy(namespace = NULL)}{
 #'   Destroys a module session scope (and any descendant scopes) by invoking
-#'   all registered `onDestroy()` callbacks. This includes cleaning up all
-#'   reactive values, observers, and reactive expressions created within
-#'   that scope (and any descendant scopes).
+#'   all registered `onDestroy()` callbacks. An explicit `destroy()` cleans up
+#'   all reactive values, observers, and reactive expressions created within
+#'   that scope (and any descendant scopes). A session *close* is gentler with
+#'   reactives -- see `onDestroy()` above.
 #'
 #'   Called with no `namespace` on a module session proxy (e.g. the `session`
 #'   inside [moduleServer()]), it destroys that module's own scope. Called
@@ -178,7 +179,9 @@ workerId <- local({
 #'   ```
 #'
 #'   On the root session a `namespace` is required; `session$destroy()` with no
-#'   `namespace` is an error (the root session is torn down via `close()`).
+#'   `namespace` is an error. The root session ends via `close()`, which is not
+#'   a destroy: observers are torn down, but reactive values and expressions
+#'   are left readable at their last value.
 #' }
 #' \item{onEnded(callback)}{
 #'   Synonym for `onSessionEnded`.
@@ -351,9 +354,9 @@ workerId <- local({
 #'
 #' @section Module data ownership:
 #' The key rule: **data that must outlive a module should live outside it.**
-#' A reactive value created inside a module is destroyed with the module.
-#' A reactive value created in the caller's scope and passed in survives
-#' destruction.
+#' A reactive value created inside a module is destroyed when that module's
+#' scope is destroyed with `session$destroy()`. A reactive value created in the
+#' caller's scope and passed in survives destruction.
 #'
 #' Returning a reactive value from a module works when the module lives for
 #' the entire session. However, if you plan to call `session$destroy()`, the
@@ -853,10 +856,11 @@ ShinySession <- R6Class(
     },
     invokeDestroyCallbacks = function(namespace = NULL, allowRoot = FALSE) {
       isRoot <- length(namespace) == 0
-      # The root scope can only be torn down via `close()` (allowRoot = TRUE).
+      # Root-scope destroy callbacks are only dispatched from `close()`
+      # (allowRoot = TRUE), where the reactives themselves are left intact.
       if (isRoot && !allowRoot) {
         stop(
-          "`$destroy()` cannot be called on the root ShinySession without a `namespace`. Pass a module `namespace` to tear down that scope (e.g. `session$destroy(\"my_module\")`), or call `close()` to tear down the whole session.",
+          "`$destroy()` cannot be called on the root ShinySession without a `namespace`. Pass a module `namespace` to tear down that scope (e.g. `session$destroy(\"my_module\")`), or call `close()` to end the whole session (which is not a destroy: reactive values and expressions stay readable).",
           call. = FALSE
         )
       }
@@ -1342,10 +1346,12 @@ ShinySession <- R6Class(
       tears that scope down. The root scope is the absence of a namespace --
       `NULL` (the default) or `character(0)` -- and cannot be destroyed this
       way: calling `destroy()` with no `namespace` on the root session is an
-      error, since the root session is torn down via `close()`."
+      error. The root session ends via `close()`, which is not a destroy --
+      observers are torn down, but reactive values and expressions are left
+      readable at their last value."
       if (length(namespace) == 0) {
         stop(
-          "`$destroy()` cannot be called on the root ShinySession without a `namespace`. Pass a module `namespace` to tear down that scope (e.g. `session$destroy(\"my_module\")`), or call `close()` to tear down the whole session.",
+          "`$destroy()` cannot be called on the root ShinySession without a `namespace`. Pass a module `namespace` to tear down that scope (e.g. `session$destroy(\"my_module\")`), or call `close()` to end the whole session (which is not a destroy: reactive values and expressions stay readable).",
           call. = FALSE
         )
       }

--- a/man/MockShinySession.Rd
+++ b/man/MockShinySession.Rd
@@ -196,9 +196,14 @@ user. Always \code{NULL} for a \code{MockShinySesion}.}
 \if{html}{\out{<a id="method-MockShinySession-onDestroy"></a>}}
 \if{latex}{\out{\hypertarget{method-MockShinySession-onDestroy}{}}}
 \subsection{\code{MockShinySession$onDestroy()}}{
-  Registers a callback to be invoked when the session scope
-is destroyed. Returns a function that can be called to unregister the
-callback.
+  Registers a callback to be invoked when the session scope is
+destroyed via \code{destroy()}, and when the session itself closes. Returns a
+function that can be called to unregister the callback.
+
+Note that closing a session is not the same as destroying a scope. An
+explicit \code{destroy()} tears down the scope's reactive values and
+expressions, so reading one afterwards is an error. On close, they are
+left readable at their last value, matching \code{ShinySession}.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{MockShinySession$onDestroy(callback)}

--- a/man/session.Rd
+++ b/man/session.Rd
@@ -70,9 +70,10 @@ that settles after the user refreshes the page) does not error.
 }
 \item{destroy(namespace = NULL)}{
 Destroys a module session scope (and any descendant scopes) by invoking
-all registered \code{onDestroy()} callbacks. This includes cleaning up all
-reactive values, observers, and reactive expressions created within
-that scope (and any descendant scopes).
+all registered \code{onDestroy()} callbacks. An explicit \code{destroy()} cleans up
+all reactive values, observers, and reactive expressions created within
+that scope (and any descendant scopes). A session \emph{close} is gentler with
+reactives -- see \code{onDestroy()} above.
 
 Called with no \code{namespace} on a module session proxy (e.g. the \code{session}
 inside \code{\link[=moduleServer]{moduleServer()}}), it destroys that module's own scope. Called
@@ -85,7 +86,9 @@ session$destroy("editor")
 }\if{html}{\out{</div>}}
 
 On the root session a \code{namespace} is required; \code{session$destroy()} with no
-\code{namespace} is an error (the root session is torn down via \code{close()}).
+\code{namespace} is an error. The root session ends via \code{close()}, which is not
+a destroy: observers are torn down, but reactive values and expressions
+are left readable at their last value.
 }
 \item{onEnded(callback)}{
 Synonym for \code{onSessionEnded}.
@@ -267,9 +270,9 @@ trigger teardown from somewhere that doesn't have the parent session or
 \section{Module data ownership}{
 
 The key rule: \strong{data that must outlive a module should live outside it.}
-A reactive value created inside a module is destroyed with the module.
-A reactive value created in the caller's scope and passed in survives
-destruction.
+A reactive value created inside a module is destroyed when that module's
+scope is destroyed with \code{session$destroy()}. A reactive value created in the
+caller's scope and passed in survives destruction.
 
 Returning a reactive value from a module works when the module lives for
 the entire session. However, if you plan to call \code{session$destroy()}, the


### PR DESCRIPTION
Docs follow-up to #4421. No behavior change.

## Problem

#4421 made a whole-session close leave reactive values and expressions readable, and documented it — but only on the `onDestroy(callback)` entry of `?session`. The `destroy(namespace = NULL)` entry directly below it was left as-is, and still reads the old way. Its first sentence lists what teardown cleans up:

> Destroys a module session scope (and any descendant scopes) by invoking all registered `onDestroy()` callbacks. This includes cleaning up all **reactive values, observers, and reactive expressions** created within that scope (and any descendant scopes).

and its last sentence says:

> On the root session a `namespace` is required; `session$destroy()` with no `namespace` is an error (**the root session is torn down via `close()`**).

Read in sequence within the one `\item`: destroy tears down reactive values and expressions → the root scope is torn down via `close()` → closing the session tears down its reactive values and expressions. That is precisely the inference #4421 set out to remove, and the corrective paragraph sits in the *previous* entry where a reader of this one won't see it.

Worse inside `ShinySession`: the `onDestroy` R6 docstring got the new paragraph in #4421 while the `destroy` docstring immediately below kept "since the root session is torn down via `close()`", so the two adjacent docstrings now contradict each other.

## Changes

- **`destroy(namespace)`, `?session` + the `ShinySession$destroy` R6 docstring** — scope the teardown list to an explicit `destroy()`, and say what `close()` actually does: observers are torn down, reactive values and expressions are left readable at their last value.

- **The root-destroy error message** (4 copies: `R/shiny.R` × 2, `R/mock-session.R` × 2) — it offered `close()` as the way "to tear down the whole session". This fires exactly when someone is reaching for whole-session teardown, so it is the one place a confused user actually reads; it should not present `close()` as the destroy-everything equivalent. Now: "or call `close()` to end the whole session (which is not a destroy: reactive values and expressions stay readable)."

- **"Module data ownership" section of `?session`** — "A reactive value created inside a module is destroyed with the module" had no anchor to an explicit `destroy()` call, and sits two paragraphs above the sentence that supplies the scope. "With the module" invites the session-close reading, so it is now anchored to `session$destroy()`.

- **`MockShinySession$onDestroy`** — never got #4421's clarification, even though `MockShinySession$close()` calls `invokeDestroyCallbacks(allowRoot = TRUE)` and so fires root destroy callbacks. Its docstring framed close as "when the session scope is destroyed" — the exact conflation #4421 broke — while its `ShinySession` counterpart was fixed. Added, matching that wording.

- Two internal comments that used the same "the root scope can only be torn down via `close()`" framing now say that root destroy callbacks are only *dispatched* from `close()`, where the reactives themselves are left intact.

## Verification

- `roxygen2::roxygenise()` run to regenerate `man/session.Rd` and `man/MockShinySession.Rd`. `NAMESPACE` was reverted: the roxygen2 available here is 8.0.0 against the 8.1.0 this package expects, and it rewrote the whole `importFrom` block — pure version churn, unrelated to this change. Worth a `devtools::document()` on CI to confirm.
- Full `testthat::test_local()` suite passes. The two `session$onDestroy: attempt to apply non-function` warnings in `test-reactivity.r` are pre-existing — confirmed by stashing this branch's changes and re-running.
- Grepped `R/` and `tests/` for the old wording; no remaining occurrences, and no test asserts the changed error string.

The same audit against py-shiny turned up the identical structural problem in its ported `Session.destroy()` docstring, fixed there in posit-dev/py-shiny#2428.